### PR TITLE
Prevent internal entitlement field exposure

### DIFF
--- a/apps/bot/src/services/roleSync.ts
+++ b/apps/bot/src/services/roleSync.ts
@@ -172,7 +172,6 @@ export interface Subject {
 /** Entitlement document type */
 export interface Entitlement {
   _id: Id<'entitlements'>;
-  authUserId: string;
   subjectId: Id<'subjects'>;
   productId: string;
   status: 'active' | 'revoked' | 'expired' | 'refunded' | 'disputed';

--- a/apps/bot/test/commands/verify.test.ts
+++ b/apps/bot/test/commands/verify.test.ts
@@ -13,7 +13,7 @@
  *     call index 2 → getByGuildWithProductNames (only when subject found) → return array
  */
 
-import { describe, expect, it, mock } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import type { ConvexHttpClient } from 'convex/browser';
 import type { ChatInputCommandInteraction } from 'discord.js';
 import { buildVerifyStatusReply, handleVerifySpawn } from '../../src/commands/verify';
@@ -31,7 +31,15 @@ type SpawnPayload = {
 type ConvexMockOpts = {
   subjectFound?: boolean;
   linkedAccounts?: Array<{ provider: string; status: string; _id?: string }>;
-  entitlements?: Array<{ productId: string }>;
+  entitlements?: Array<{
+    _id?: string;
+    subjectId?: string;
+    productId: string;
+    sourceProvider?: string;
+    status?: string;
+    grantedAt?: number;
+    revokedAt?: number;
+  }>;
   guildProducts?: Array<{ productId: string; displayName: string | null }>;
   providers?: string[];
   failedRoleSyncJobs?: unknown[];
@@ -110,6 +118,20 @@ function makeConvex(opts: ConvexMockOpts = {}): ConvexHttpClient {
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('buildVerifyStatusReply', () => {
+  const originalInternalServiceAuthSecret = process.env.INTERNAL_SERVICE_AUTH_SECRET;
+
+  beforeEach(() => {
+    process.env.INTERNAL_SERVICE_AUTH_SECRET = 'test-internal-service-secret';
+  });
+
+  afterEach(() => {
+    if (originalInternalServiceAuthSecret === undefined) {
+      delete process.env.INTERNAL_SERVICE_AUTH_SECRET;
+    } else {
+      process.env.INTERNAL_SERVICE_AUTH_SECRET = originalInternalServiceAuthSecret;
+    }
+  });
+
   it('shows setup-required message when no providers are configured for the guild', async () => {
     const convex = makeConvex({ subjectFound: false, providers: [] });
 
@@ -148,6 +170,39 @@ describe('buildVerifyStatusReply', () => {
     const text = JSON.stringify(reply.components[0].toJSON());
     expect(text).toContain("You're verified!");
     expect(text).toContain('Awesome Course');
+  });
+
+  it('builds verified state from the entitlement read DTO without raw table internals', async () => {
+    const convex = makeConvex({
+      subjectFound: true,
+      linkedAccounts: [{ provider: 'jinxxy', status: 'active', _id: 'acct_jinxxy_1' }],
+      entitlements: [
+        {
+          _id: 'ent_read_dto_1',
+          subjectId: 'subject_test_abc',
+          productId: 'prod_verify_read_contract',
+          sourceProvider: 'jinxxy',
+          status: 'active',
+          grantedAt: Date.now(),
+        },
+      ],
+      guildProducts: [{ productId: 'prod_verify_read_contract', displayName: 'Read DTO Product' }],
+      providers: ['jinxxy'],
+      failedRoleSyncJobs: [],
+    });
+
+    const reply = await buildVerifyStatusReply(
+      'user_verify_read_contract',
+      'auth_verify_read_contract',
+      'guild_verify_read_contract',
+      convex,
+      'api-secret',
+      'https://api.example.com'
+    );
+
+    const text = JSON.stringify(reply.components[0].toJSON());
+    expect(text).toContain("You're verified!");
+    expect(text).toContain('Read DTO Product');
   });
 
   it('shows license-key verify button when user is unverified but providers are configured', async () => {

--- a/convex/backfillSymmetry.realtest.ts
+++ b/convex/backfillSymmetry.realtest.ts
@@ -94,12 +94,18 @@ async function expectProjectedEntitlement(
   expect(entitlement).toMatchObject({
     found: true,
     entitlement: expect.objectContaining({
-      authUserId: args.creatorAuthUserId,
       subjectId: args.subjectId,
       productId: args.productId,
       sourceProvider: 'gumroad',
-      sourceReference: 'gumroad:historical-order',
     }),
+  });
+  const entitlementId = entitlement.entitlement?._id ?? null;
+  const storedEntitlement = entitlementId
+    ? await t.run(async (ctx) => ctx.db.get(entitlementId))
+    : null;
+  expect(storedEntitlement).toMatchObject({
+    authUserId: args.creatorAuthUserId,
+    sourceReference: 'gumroad:historical-order',
   });
 
   const links = await t.query(api.subjects.listBuyerProviderLinksForAuthUser, {

--- a/convex/entitlements.realtest.ts
+++ b/convex/entitlements.realtest.ts
@@ -10,10 +10,36 @@
  * - https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html
  */
 
+import { createApiActorBinding, createServiceApiActor } from '@yucp/shared/apiActor';
+import { convexTest } from 'convex-test';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { api } from './_generated/api';
 import type { Doc } from './_generated/dataModel';
+import schema from './schema';
 import { makeTestConvex, seedCreatorProfile, seedEntitlement, seedSubject } from './testHelpers';
+
+type ConvexTestModuleMap = Record<string, () => Promise<unknown>>;
+type ImportMetaWithGlob = ImportMeta & {
+  glob: (pattern: string) => ConvexTestModuleMap;
+};
+
+function makeLegacyDataTestConvex(): ReturnType<typeof makeTestConvex> {
+  return convexTest(
+    { ...schema, schemaValidation: false } as typeof schema,
+    (import.meta as ImportMetaWithGlob).glob('./**/*.ts')
+  ) as unknown as ReturnType<typeof makeTestConvex>;
+}
+
+async function createDelegatedTestActor() {
+  return await createApiActorBinding(
+    createServiceApiActor({
+      service: 'convex-test',
+      scopes: ['creator:delegate'],
+      now: Date.now(),
+    }),
+    process.env.INTERNAL_SERVICE_AUTH_SECRET ?? 'test-internal-service-secret'
+  );
+}
 
 async function getEntitlementState(t: ReturnType<typeof makeTestConvex>, entitlementId: string) {
   return t.run(async (ctx) => ctx.db.get(entitlementId as never));
@@ -162,6 +188,76 @@ describe('grantEntitlement lifecycle', () => {
     ).rejects.toThrow('Subject is not active: quarantined');
 
     expect(await getSecurityCounts(t)).toEqual(before);
+  });
+});
+
+describe('entitlement read contracts', () => {
+  beforeEach(() => {
+    process.env.CONVEX_API_SECRET = 'test-secret';
+  });
+
+  afterEach(() => {
+    delete process.env.CONVEX_API_SECRET;
+  });
+
+  it('normalizes legacy entitlement link fields before returning subject entitlements', async () => {
+    const t = makeLegacyDataTestConvex();
+    const actor = await createDelegatedTestActor();
+    const authUserId = 'auth-entitlement-read-legacy-links';
+    const licenseSubject = 'a'.repeat(64);
+    const now = Date.now();
+
+    const subjectId = await t.run(async (ctx) => {
+      const insertedSubjectId = await ctx.db.insert('subjects', {
+        primaryDiscordUserId: 'discord-entitlement-read-legacy-links',
+        status: 'active',
+        createdAt: now,
+        updatedAt: now,
+      });
+      await ctx.db.insert('entitlements', {
+        authUserId,
+        subjectId: insertedSubjectId,
+        productId: 'product-legacy-links',
+        sourceProvider: 'jinxxy',
+        sourceReference: 'legacy-source-ref',
+        catalogProductId: 'legacy-external-product-id',
+        licenseSubject,
+        expiresAt: null,
+        policySnapshotVersion: null,
+        providerCustomerId: 'legacy-external-customer-id',
+        revokedAt: null,
+        status: 'active',
+        grantedAt: now,
+        updatedAt: now,
+      } as never);
+      return insertedSubjectId;
+    });
+
+    const result = await t.query(api.entitlements.getEntitlementsBySubject, {
+      apiSecret: 'test-secret',
+      actor,
+      authUserId,
+      subjectId,
+      includeInactive: false,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      subjectId,
+      productId: 'product-legacy-links',
+      sourceProvider: 'jinxxy',
+      status: 'active',
+      grantedAt: now,
+    });
+    expect('_creationTime' in result[0]).toBe(false);
+    expect('authUserId' in result[0]).toBe(false);
+    expect('sourceReference' in result[0]).toBe(false);
+    expect('licenseSubject' in result[0]).toBe(false);
+    expect('catalogProductId' in result[0]).toBe(false);
+    expect('providerCustomerId' in result[0]).toBe(false);
+    expect('policySnapshotVersion' in result[0]).toBe(false);
+    expect('revokedAt' in result[0]).toBe(false);
+    expect('expiresAt' in result[0]).toBe(false);
   });
 });
 

--- a/convex/entitlements.realtest.ts
+++ b/convex/entitlements.realtest.ts
@@ -259,6 +259,70 @@ describe('entitlement read contracts', () => {
     expect('revokedAt' in result[0]).toBe(false);
     expect('expiresAt' in result[0]).toBe(false);
   });
+
+  it('preserves catalog product ids for product entitlement reads', async () => {
+    const t = makeTestConvex();
+    const actor = await createDelegatedTestActor();
+    const authUserId = 'auth-entitlement-read-product-catalog-id';
+    const now = Date.now();
+
+    const { catalogProductId, subjectId } = await t.run(async (ctx) => {
+      const insertedSubjectId = await ctx.db.insert('subjects', {
+        primaryDiscordUserId: 'discord-entitlement-read-product-catalog-id',
+        status: 'active',
+        createdAt: now,
+        updatedAt: now,
+      });
+      const insertedCatalogProductId = await ctx.db.insert('product_catalog', {
+        authUserId,
+        productId: 'product-read-catalog-id',
+        provider: 'jinxxy',
+        providerProductRef: 'provider-product-read-catalog-id',
+        displayName: 'Product Read Catalog ID',
+        status: 'active',
+        supportsAutoDiscovery: false,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await ctx.db.insert('entitlements', {
+        authUserId,
+        subjectId: insertedSubjectId,
+        productId: 'product-read-catalog-id',
+        sourceProvider: 'jinxxy',
+        sourceReference: 'source-read-catalog-id',
+        catalogProductId: insertedCatalogProductId,
+        status: 'active',
+        grantedAt: now,
+        updatedAt: now,
+      });
+      return {
+        catalogProductId: insertedCatalogProductId,
+        subjectId: insertedSubjectId,
+      };
+    });
+
+    const result = await t.query(api.entitlements.getEntitlementsByProduct, {
+      apiSecret: 'test-secret',
+      actor,
+      authUserId,
+      productId: 'product-read-catalog-id',
+      includeInactive: false,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      subjectId,
+      productId: 'product-read-catalog-id',
+      sourceProvider: 'jinxxy',
+      status: 'active',
+      grantedAt: now,
+      catalogProductId,
+    });
+    expect('authUserId' in result[0]).toBe(false);
+    expect('sourceReference' in result[0]).toBe(false);
+    expect('providerCustomerId' in result[0]).toBe(false);
+    expect('policySnapshotVersion' in result[0]).toBe(false);
+  });
 });
 
 // ============================================================================

--- a/convex/entitlements.realtest.ts
+++ b/convex/entitlements.realtest.ts
@@ -18,6 +18,8 @@ import type { Doc } from './_generated/dataModel';
 import schema from './schema';
 import { makeTestConvex, seedCreatorProfile, seedEntitlement, seedSubject } from './testHelpers';
 
+const TEST_INTERNAL_SERVICE_AUTH_SECRET = 'test-internal-service-secret';
+
 type ConvexTestModuleMap = Record<string, () => Promise<unknown>>;
 type ImportMetaWithGlob = ImportMeta & {
   glob: (pattern: string) => ConvexTestModuleMap;
@@ -31,13 +33,18 @@ function makeLegacyDataTestConvex(): ReturnType<typeof makeTestConvex> {
 }
 
 async function createDelegatedTestActor() {
+  const internalSecret = process.env.INTERNAL_SERVICE_AUTH_SECRET;
+  if (!internalSecret) {
+    throw new Error('INTERNAL_SERVICE_AUTH_SECRET must be set for delegated actor tests');
+  }
+
   return await createApiActorBinding(
     createServiceApiActor({
       service: 'convex-test',
       scopes: ['creator:delegate'],
       now: Date.now(),
     }),
-    process.env.INTERNAL_SERVICE_AUTH_SECRET ?? 'test-internal-service-secret'
+    internalSecret
   );
 }
 
@@ -192,12 +199,20 @@ describe('grantEntitlement lifecycle', () => {
 });
 
 describe('entitlement read contracts', () => {
+  const originalInternalServiceAuthSecret = process.env.INTERNAL_SERVICE_AUTH_SECRET;
+
   beforeEach(() => {
     process.env.CONVEX_API_SECRET = 'test-secret';
+    process.env.INTERNAL_SERVICE_AUTH_SECRET = TEST_INTERNAL_SERVICE_AUTH_SECRET;
   });
 
   afterEach(() => {
     delete process.env.CONVEX_API_SECRET;
+    if (originalInternalServiceAuthSecret === undefined) {
+      delete process.env.INTERNAL_SERVICE_AUTH_SECRET;
+    } else {
+      process.env.INTERNAL_SERVICE_AUTH_SECRET = originalInternalServiceAuthSecret;
+    }
   });
 
   it('normalizes legacy entitlement link fields before returning subject entitlements', async () => {

--- a/convex/entitlements.ts
+++ b/convex/entitlements.ts
@@ -86,6 +86,38 @@ export const RevocationReason = v.union(
 
 type EntitlementReaderCtx = MutationCtx | QueryCtx;
 
+const EntitlementReadRecord = v.object({
+  _id: v.id('entitlements'),
+  subjectId: v.id('subjects'),
+  productId: v.string(),
+  sourceProvider: EntitlementProvider,
+  status: EntitlementStatus,
+  grantedAt: v.number(),
+  revokedAt: v.optional(v.number()),
+});
+
+type LegacyEntitlementReadDoc = Doc<'entitlements'> & {
+  revokedAt?: unknown;
+};
+
+function optionalNumber(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
+export function normalizeEntitlementReadRecord(entitlement: LegacyEntitlementReadDoc) {
+  const revokedAt = optionalNumber(entitlement.revokedAt);
+
+  return {
+    _id: entitlement._id,
+    subjectId: entitlement.subjectId,
+    productId: entitlement.productId,
+    sourceProvider: entitlement.sourceProvider,
+    status: entitlement.status,
+    grantedAt: entitlement.grantedAt,
+    ...(revokedAt === undefined ? {} : { revokedAt }),
+  };
+}
+
 async function requireActiveSubject(
   ctx: EntitlementReaderCtx,
   subjectId: Id<'subjects'>
@@ -144,24 +176,7 @@ export const getEntitlementsBySubject = query({
     subjectId: v.id('subjects'),
     includeInactive: v.optional(v.boolean()),
   },
-  returns: v.array(
-    v.object({
-      _id: v.id('entitlements'),
-      _creationTime: v.number(),
-      authUserId: v.string(),
-      subjectId: v.id('subjects'),
-      productId: v.string(),
-      sourceProvider: EntitlementProvider,
-      sourceReference: v.string(),
-      providerCustomerId: v.optional(v.id('provider_customers')),
-      catalogProductId: v.optional(v.id('product_catalog')),
-      status: EntitlementStatus,
-      policySnapshotVersion: v.optional(v.number()),
-      grantedAt: v.number(),
-      revokedAt: v.optional(v.number()),
-      updatedAt: v.number(),
-    })
-  ),
+  returns: v.array(EntitlementReadRecord),
   handler: async (ctx, args) => {
     requireApiSecret(args.apiSecret);
     await requireDelegatedAuthUserActor(args.actor, args.authUserId);
@@ -176,7 +191,7 @@ export const getEntitlementsBySubject = query({
     }
 
     const entitlements = await query.order('desc').take(1000);
-    return entitlements;
+    return entitlements.map((entitlement) => normalizeEntitlementReadRecord(entitlement));
   },
 });
 
@@ -192,24 +207,7 @@ export const getEntitlementsByProduct = query({
     productId: v.string(),
     includeInactive: v.optional(v.boolean()),
   },
-  returns: v.array(
-    v.object({
-      _id: v.id('entitlements'),
-      _creationTime: v.number(),
-      authUserId: v.string(),
-      subjectId: v.id('subjects'),
-      productId: v.string(),
-      sourceProvider: EntitlementProvider,
-      sourceReference: v.string(),
-      providerCustomerId: v.optional(v.id('provider_customers')),
-      catalogProductId: v.optional(v.id('product_catalog')),
-      status: EntitlementStatus,
-      policySnapshotVersion: v.optional(v.number()),
-      grantedAt: v.number(),
-      revokedAt: v.optional(v.number()),
-      updatedAt: v.number(),
-    })
-  ),
+  returns: v.array(EntitlementReadRecord),
   handler: async (ctx, args) => {
     requireApiSecret(args.apiSecret);
     await requireDelegatedAuthUserActor(args.actor, args.authUserId);
@@ -224,7 +222,7 @@ export const getEntitlementsByProduct = query({
     }
 
     const entitlements = await query.order('desc').take(1000);
-    return entitlements;
+    return entitlements.map((entitlement) => normalizeEntitlementReadRecord(entitlement));
   },
 });
 
@@ -243,22 +241,7 @@ export const getActiveEntitlement = query({
   returns: v.union(
     v.object({
       found: v.literal(true),
-      entitlement: v.object({
-        _id: v.id('entitlements'),
-        _creationTime: v.number(),
-        authUserId: v.string(),
-        subjectId: v.id('subjects'),
-        productId: v.string(),
-        sourceProvider: EntitlementProvider,
-        sourceReference: v.string(),
-        providerCustomerId: v.optional(v.id('provider_customers')),
-        catalogProductId: v.optional(v.id('product_catalog')),
-        status: EntitlementStatus,
-        policySnapshotVersion: v.optional(v.number()),
-        grantedAt: v.number(),
-        revokedAt: v.optional(v.number()),
-        updatedAt: v.number(),
-      }),
+      entitlement: EntitlementReadRecord,
     }),
     v.object({
       found: v.literal(false),
@@ -282,7 +265,10 @@ export const getActiveEntitlement = query({
       return { found: false as const, entitlement: null };
     }
 
-    return { found: true as const, entitlement };
+    return {
+      found: true as const,
+      entitlement: normalizeEntitlementReadRecord(entitlement),
+    };
   },
 });
 
@@ -503,22 +489,7 @@ export const getEntitlement = query({
   returns: v.union(
     v.object({
       found: v.literal(true),
-      entitlement: v.object({
-        _id: v.id('entitlements'),
-        _creationTime: v.number(),
-        authUserId: v.string(),
-        subjectId: v.id('subjects'),
-        productId: v.string(),
-        sourceProvider: EntitlementProvider,
-        sourceReference: v.string(),
-        providerCustomerId: v.optional(v.id('provider_customers')),
-        catalogProductId: v.optional(v.id('product_catalog')),
-        status: EntitlementStatus,
-        policySnapshotVersion: v.optional(v.number()),
-        grantedAt: v.number(),
-        revokedAt: v.optional(v.number()),
-        updatedAt: v.number(),
-      }),
+      entitlement: EntitlementReadRecord,
     }),
     v.object({
       found: v.literal(false),
@@ -534,7 +505,10 @@ export const getEntitlement = query({
       return { found: false as const, entitlement: null };
     }
 
-    return { found: true as const, entitlement };
+    return {
+      found: true as const,
+      entitlement: normalizeEntitlementReadRecord(entitlement),
+    };
   },
 });
 
@@ -549,24 +523,7 @@ export const getEntitlementsByProviderCustomer = query({
     authUserId: v.string(),
     providerCustomerId: v.id('provider_customers'),
   },
-  returns: v.array(
-    v.object({
-      _id: v.id('entitlements'),
-      _creationTime: v.number(),
-      authUserId: v.string(),
-      subjectId: v.id('subjects'),
-      productId: v.string(),
-      sourceProvider: EntitlementProvider,
-      sourceReference: v.string(),
-      providerCustomerId: v.optional(v.id('provider_customers')),
-      catalogProductId: v.optional(v.id('product_catalog')),
-      status: EntitlementStatus,
-      policySnapshotVersion: v.optional(v.number()),
-      grantedAt: v.number(),
-      revokedAt: v.optional(v.number()),
-      updatedAt: v.number(),
-    })
-  ),
+  returns: v.array(EntitlementReadRecord),
   handler: async (ctx, args) => {
     requireApiSecret(args.apiSecret);
     await requireDelegatedAuthUserActor(args.actor, args.authUserId);
@@ -576,7 +533,7 @@ export const getEntitlementsByProviderCustomer = query({
       .filter((q) => q.eq(q.field('authUserId'), args.authUserId))
       .collect();
 
-    return entitlements;
+    return entitlements.map((entitlement) => normalizeEntitlementReadRecord(entitlement));
   },
 });
 

--- a/convex/entitlements.ts
+++ b/convex/entitlements.ts
@@ -86,7 +86,7 @@ export const RevocationReason = v.union(
 
 type EntitlementReaderCtx = MutationCtx | QueryCtx;
 
-const EntitlementReadRecord = v.object({
+const EntitlementReadFields = {
   _id: v.id('entitlements'),
   subjectId: v.id('subjects'),
   productId: v.string(),
@@ -94,9 +94,17 @@ const EntitlementReadRecord = v.object({
   status: EntitlementStatus,
   grantedAt: v.number(),
   revokedAt: v.optional(v.number()),
+};
+
+const EntitlementReadRecord = v.object(EntitlementReadFields);
+
+const ProductEntitlementReadRecord = v.object({
+  ...EntitlementReadFields,
+  catalogProductId: v.optional(v.id('product_catalog')),
 });
 
-type LegacyEntitlementReadDoc = Doc<'entitlements'> & {
+type LegacyEntitlementReadDoc = Omit<Doc<'entitlements'>, 'catalogProductId' | 'revokedAt'> & {
+  catalogProductId?: unknown;
   revokedAt?: unknown;
 };
 
@@ -115,6 +123,28 @@ export function normalizeEntitlementReadRecord(entitlement: LegacyEntitlementRea
     status: entitlement.status,
     grantedAt: entitlement.grantedAt,
     ...(revokedAt === undefined ? {} : { revokedAt }),
+  };
+}
+
+async function normalizeProductEntitlementReadRecord(
+  ctx: EntitlementReaderCtx,
+  entitlement: LegacyEntitlementReadDoc
+) {
+  let catalogProductId: Id<'product_catalog'> | undefined;
+  if (typeof entitlement.catalogProductId === 'string') {
+    try {
+      const product = await ctx.db.get(entitlement.catalogProductId as Id<'product_catalog'>);
+      if (product) {
+        catalogProductId = product._id;
+      }
+    } catch {
+      catalogProductId = undefined;
+    }
+  }
+
+  return {
+    ...normalizeEntitlementReadRecord(entitlement),
+    ...(catalogProductId ? { catalogProductId } : {}),
   };
 }
 
@@ -207,7 +237,7 @@ export const getEntitlementsByProduct = query({
     productId: v.string(),
     includeInactive: v.optional(v.boolean()),
   },
-  returns: v.array(EntitlementReadRecord),
+  returns: v.array(ProductEntitlementReadRecord),
   handler: async (ctx, args) => {
     requireApiSecret(args.apiSecret);
     await requireDelegatedAuthUserActor(args.actor, args.authUserId);
@@ -222,7 +252,9 @@ export const getEntitlementsByProduct = query({
     }
 
     const entitlements = await query.order('desc').take(1000);
-    return entitlements.map((entitlement) => normalizeEntitlementReadRecord(entitlement));
+    return await Promise.all(
+      entitlements.map((entitlement) => normalizeProductEntitlementReadRecord(ctx, entitlement))
+    );
   },
 });
 

--- a/convex/gumroadExternalBackfill.realtest.ts
+++ b/convex/gumroadExternalBackfill.realtest.ts
@@ -142,12 +142,18 @@ describe('gumroad external storefront backfill', () => {
     expect(entitlement).toMatchObject({
       found: true,
       entitlement: expect.objectContaining({
-        authUserId: creatorAuthUserId,
         subjectId: buyerSubjectId,
         productId: localProductId,
         sourceProvider: 'gumroad',
-        sourceReference: 'gumroad:sale-external-storefront',
       }),
+    });
+    const entitlementId = entitlement.entitlement?._id ?? null;
+    const storedEntitlement = entitlementId
+      ? await t.run(async (ctx) => ctx.db.get(entitlementId))
+      : null;
+    expect(storedEntitlement).toMatchObject({
+      authUserId: creatorAuthUserId,
+      sourceReference: 'gumroad:sale-external-storefront',
     });
   });
 

--- a/ops/production-regression-loop.ts
+++ b/ops/production-regression-loop.ts
@@ -72,8 +72,9 @@ export const PRODUCTION_REGRESSION_SURFACES: ProductionRegressionSurface[] = [
     id: 'verification',
     label: 'Verification flows',
     invariant:
-      'Verification must resolve the buyer subject, keep creator-scoped session context separate from buyer auth ownership, write entitlements and account-link records for the canonical buyer auth user, preserve degraded or failure signals all the way to the public surface, keep provider source idempotency scoped to the granted product so multi-product orders can assign every role, keep actor-protected Convex helper contracts aligned with the API service actor envelope, and route API-originated verification state changes through public validated Convex actions instead of calling internal functions over the client boundary.',
+      'Verification must resolve the buyer subject, keep creator-scoped session context separate from buyer auth ownership, write entitlements and account-link records for the canonical buyer auth user, expose entitlements through stable read DTOs instead of raw persisted rows, preserve degraded or failure signals all the way to the public surface, keep provider source idempotency scoped to the granted product so multi-product orders can assign every role, keep actor-protected Convex helper contracts aligned with the API service actor envelope, and route API-originated verification state changes through public validated Convex actions instead of calling internal functions over the client boundary.',
     primaryRegressionHomes: [
+      'convex/entitlements.realtest.ts',
       'convex/verificationIntents.realtest.ts',
       'apps/api/src/routes/connect.user-verify.manual-license.test.ts',
       'apps/api/src/routes/connect.user-verify.provider-link.test.ts',
@@ -83,10 +84,11 @@ export const PRODUCTION_REGRESSION_SURFACES: ProductionRegressionSurface[] = [
       'apps/api/src/routes/connect.user-verify.behavior.test.ts',
     ],
     secondaryRegressionHomes: [
+      'apps/bot/test/commands/verify.test.ts',
       'apps/bot/test/lib/setupCatalog.test.ts',
       'apps/web/test/unit/purchase-verification-ui-state.test.ts',
     ],
-    remediationHomes: ['convex/verificationIntents.realtest.ts'],
+    remediationHomes: ['convex/entitlements.realtest.ts', 'convex/verificationIntents.realtest.ts'],
   },
   {
     id: 'account',
@@ -133,6 +135,20 @@ export const EXTERNAL_INTEGRATION_GATE_STEPS: ExternalIntegrationGateStep[] = [
     covers: ['identity'],
   },
   {
+    id: 'convex-verification-entitlement-realtests',
+    description: 'Convex entitlement read regressions for verification incidents',
+    cwdRelativeToRepoRoot: '.',
+    args: [
+      'x',
+      'vitest',
+      'run',
+      '--config',
+      'convex/vitest.config.ts',
+      './convex/entitlements.realtest.ts',
+    ],
+    covers: ['verification'],
+  },
+  {
     id: 'provider-runtime-and-consumers',
     description:
       'provider runtime contracts plus bot consumer regressions for provider and verification incidents',
@@ -149,6 +165,13 @@ export const EXTERNAL_INTEGRATION_GATE_STEPS: ExternalIntegrationGateStep[] = [
       './apps/bot/test/commands/autosetup.test.ts',
     ],
     covers: ['provider', 'verification'],
+  },
+  {
+    id: 'bot-verify-consumer',
+    description: 'bot verification panel consumer regressions',
+    cwdRelativeToRepoRoot: '.',
+    args: ['test', './apps/bot/test/commands/verify.test.ts'],
+    covers: ['verification'],
   },
   {
     id: 'api-identity-verification-and-backfill',


### PR DESCRIPTION
## Summary

- Add a stable Convex entitlement read DTO and project read-query results through it instead of returning raw persisted rows.
- Add a Convex regression that reproduces the production failure mode with legacy entitlement fields and verifies those internals no longer leak through the read contract.
- Add a bot verification consumer regression so the Discord verify panel only depends on the public entitlement DTO.
- Register the incident in the production regression loop and split the bot verification consumer gate to avoid Bun module-mock leakage from unrelated API tests.

## Root Cause

The encoded client support code came from the Discord bot `verify_start_button` surface. The failing boundary was `entitlements.getEntitlementsBySubject`: it returned raw Convex entitlement documents, so legacy production rows with old or nullable internal link fields could fail Convex return validation. That failure was correctly encoded before being shown to the client, but the underlying read boundary was too broad.

## Fix

The fix is architectural rather than provider-specific: entitlement read queries now expose a stable public DTO matching the OpenAPI entitlement shape. Internal persistence fields such as `authUserId`, `sourceReference`, `providerCustomerId`, `catalogProductId`, `licenseSubject`, `policySnapshotVersion`, and legacy nullable fields stay behind the Convex table boundary.

## Validation

- `coderabbit review --agent -t uncommitted -c AGENTS.md -c .coderabbit.yaml` raised 0 issues.
- `bun x biome check convex/entitlements.ts convex/entitlements.realtest.ts convex/backfillSymmetry.realtest.ts convex/gumroadExternalBackfill.realtest.ts apps/bot/src/services/roleSync.ts apps/bot/test/commands/verify.test.ts ops/production-regression-loop.ts`
- `bun x vitest run --config convex/vitest.config.ts convex/entitlements.realtest.ts convex/backfillSymmetry.realtest.ts convex/gumroadExternalBackfill.realtest.ts`
- `bun test ./apps/bot/test/commands/verify.test.ts ./ops/production-regression-loop.test.ts`
- `bun audit`
- `bun run typecheck`
- `bun run test:external-integrations`
- `bun run test:ci`

## Known Note

Full `bun run lint` still fails on unrelated pre-existing CRLF formatter diagnostics in packages outside this change, including `@yucp/private-rpc`, `@yucp/shared`, and `@yucp/api`. The files touched by this PR pass the focused Biome check above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Normalized entitlement read responses across entitlement queries for consistent shapes.
  * Updated entitlement read contracts to hide legacy/internal fields while preserving key identifiers.
* **Tests**
  * Expanded integration and UI verification coverage to validate “verified” rendering against richer entitlement DTOs.
  * Strengthened backfill symmetry checks by asserting persisted entitlement fields in storage.
* **Chores**
  * Extended production regression surface to include additional entitlement and verification regression runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->