### PR TITLE
fix(convex): prefer explicit YUCP certificate root key

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1181,7 +1181,12 @@ http.route({
       const raw = err instanceof Error ? err.message : '';
       // Sanitize Convex-wrapped errors, never expose stack traces or internal paths.
       // Map known failure modes to appropriate HTTP status codes.
-      if (raw.includes('not configured') || raw.includes('not set')) {
+      if (
+        raw.includes('not configured') ||
+        raw.includes('not set') ||
+        raw.includes('configured YUCP trust root') ||
+        raw.includes('active trust bundle')
+      ) {
         return errorResponse('Certificate service is not available', 503);
       }
       if (raw.includes('Rate limit')) {

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1181,11 +1181,12 @@ http.route({
       const raw = err instanceof Error ? err.message : '';
       // Sanitize Convex-wrapped errors, never expose stack traces or internal paths.
       // Map known failure modes to appropriate HTTP status codes.
+      const normalizedError = raw.toLowerCase();
       if (
-        raw.includes('not configured') ||
-        raw.includes('not set') ||
-        raw.includes('configured YUCP trust root') ||
-        raw.includes('active trust bundle')
+        normalizedError.includes('not configured') ||
+        normalizedError.includes('not set') ||
+        normalizedError.includes('configured yucp trust root') ||
+        normalizedError.includes('active trust bundle')
       ) {
         return errorResponse('Certificate service is not available', 503);
       }

--- a/convex/httpCertificates.contract.test.ts
+++ b/convex/httpCertificates.contract.test.ts
@@ -21,4 +21,14 @@ describe('/v1/certificates issuance contract', () => {
     expect(httpSource).toContain("return errorResponse('Certificate issuance failed', 500)");
     expect(httpSource).not.toContain('return errorResponse(raw || String(err), 500)');
   });
+
+  it('normalizes trust configuration errors before mapping them to 503', () => {
+    expect(httpSource).toContain('const normalizedError = raw.toLowerCase();');
+    expect(httpSource).toContain("normalizedError.includes('not configured')");
+    expect(httpSource).toContain("normalizedError.includes('not set')");
+    expect(httpSource).toContain("normalizedError.includes('configured yucp trust root')");
+    expect(httpSource).toContain("normalizedError.includes('active trust bundle')");
+    expect(httpSource).toContain("return errorResponse('Certificate service is not available', 503)");
+    expect(httpSource).not.toContain("raw.includes('configured YUCP trust root')");
+  });
 });

--- a/convex/yucpCertificates.contract.test.ts
+++ b/convex/yucpCertificates.contract.test.ts
@@ -6,6 +6,7 @@ const source = readFileSync(resolve(__dirname, './yucpCertificates.ts'), 'utf8')
 
 describe('yucpCertificates env compatibility contract', () => {
   it('supports both legacy and current root key id env names', () => {
-    expect(source).toContain('process.env.YUCP_KEY_ID ?? process.env.YUCP_ROOT_KEY_ID ?? null');
+    expect(source).toContain('process.env.YUCP_ROOT_KEY_ID ?? process.env.YUCP_KEY_ID ?? null');
+    expect(source).not.toContain('process.env.YUCP_KEY_ID ?? process.env.YUCP_ROOT_KEY_ID ?? null');
   });
 });

--- a/convex/yucpCertificates.ts
+++ b/convex/yucpCertificates.ts
@@ -329,7 +329,7 @@ export const issueCertificate = internalAction({
     if (!rootPrivateKey) throw new Error('YUCP_ROOT_PRIVATE_KEY not configured');
     const signingRoot = await resolvePinnedYucpSigningRoot(
       rootPrivateKey,
-      process.env.YUCP_KEY_ID ?? process.env.YUCP_ROOT_KEY_ID ?? null
+      process.env.YUCP_ROOT_KEY_ID ?? process.env.YUCP_KEY_ID ?? null
     );
 
     // Rate limit: same-key renewals (same machine) are always free.


### PR DESCRIPTION
## What

- Prefer `YUCP_ROOT_KEY_ID` over the legacy `YUCP_KEY_ID` when resolving the certificate signing root.
- Preserve the legacy `YUCP_KEY_ID` fallback for compatibility.
- Sanitize missing trust-root and trust-bundle certificate issuance failures into the existing 503 service-unavailable response.
- Normalize certificate issuance setup errors before matching known trust-root/trust-bundle failures.
- Add contract coverage for env precedence and the sanitized trust-configuration error patterns.

## Why

Zeabur deployment failed during `bun x convex deploy`, and the certificate signing root should be driven by the current root-key environment variable. The HTTP route should also avoid leaking internal Convex/action setup details when certificate trust configuration is missing, even if upstream error text changes casing.

## Verification

- `bun test convex/yucpCertificates.contract.test.ts`
- `bun test convex/httpCertificates.contract.test.ts`
- `bun audit`
- `bun run lint`
- `bun run typecheck`
- `bun run test:external-integrations`
- `bun run test:ci`
- `bun run test:convex`
- `bun x convex deploy --dry-run --typecheck enable -y`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate issuance error handling by normalizing trust-configuration error text and mapping misconfiguration cases to a “service unavailable” response.
  * Updated signing key selection precedence so the more specific root key setting is used when both related environment variables are present.
* **Tests**
  * Added/updated contract coverage to confirm error normalization and correct fallback order for environment-based key selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->