### PR TITLE
fix(convex): align Unity OAuth product access

### DIFF
--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -22,7 +22,6 @@ import {
   PUBLIC_API_AUDIENCE,
   PUBLIC_API_KEY_PERMISSION_NAMESPACE,
   PUBLIC_API_KEY_PREFIX,
-  PUBLIC_API_SCOPES,
   verifyRecoveryPasskeyContext,
 } from '@yucp/shared';
 import type { BetterAuthOptions } from 'better-auth';
@@ -32,6 +31,7 @@ import { components, internal } from './_generated/api';
 import type { DataModel } from './_generated/dataModel';
 import authConfig from './auth.config';
 import { createJwtJwksAdapter } from './betterAuth/jwtAdapter';
+import { OAUTH_PROVIDER_SCOPES } from './betterAuth/oauthProviderScopes';
 import authSchema from './betterAuth/schema';
 import { BETTER_AUTH_BACKUP_CODE_OPTIONS } from './lib/accountSecurityConfig';
 import { sendEmailOtpEmail } from './lib/accountSecurityEmail';
@@ -309,7 +309,7 @@ export const createAuthOptions = (ctx: GenericCtx<DataModel>): BetterAuthOptions
       oauthProvider({
         loginPage: `${siteUrl.replace(/\/$/, '')}/oauth/login`,
         consentPage: `${siteUrl.replace(/\/$/, '')}/oauth/consent`,
-        scopes: [...PUBLIC_API_SCOPES],
+        scopes: [...OAUTH_PROVIDER_SCOPES],
         validAudiences: [PUBLIC_API_AUDIENCE],
         cachedTrustedClients,
         allowDynamicClientRegistration: false,

--- a/convex/betterAuth/_generated/api.ts
+++ b/convex/betterAuth/_generated/api.ts
@@ -12,6 +12,7 @@ import type * as adapter from "../adapter.js";
 import type * as auth from "../auth.js";
 import type * as jwks from "../jwks.js";
 import type * as jwtAdapter from "../jwtAdapter.js";
+import type * as oauthProviderScopes from "../oauthProviderScopes.js";
 import type * as options from "../options.js";
 
 import type {
@@ -26,6 +27,7 @@ const fullApi: ApiFromModules<{
   auth: typeof auth;
   jwks: typeof jwks;
   jwtAdapter: typeof jwtAdapter;
+  oauthProviderScopes: typeof oauthProviderScopes;
   options: typeof options;
 }> = anyApi as any;
 

--- a/convex/betterAuth/oauthProviderScopes.test.ts
+++ b/convex/betterAuth/oauthProviderScopes.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'bun:test';
+import { PUBLIC_API_SCOPES } from '@yucp/shared';
+import { OAUTH_PROVIDER_SCOPES, OAUTH_REFRESH_TOKEN_SCOPE } from './oauthProviderScopes';
+
+describe('OAUTH_PROVIDER_SCOPES', () => {
+  it('registers public API scopes plus refresh-token access with Better Auth', () => {
+    expect(OAUTH_PROVIDER_SCOPES).toEqual([...PUBLIC_API_SCOPES, OAUTH_REFRESH_TOKEN_SCOPE]);
+    expect(OAUTH_PROVIDER_SCOPES).toContain('offline_access');
+  });
+});

--- a/convex/betterAuth/oauthProviderScopes.ts
+++ b/convex/betterAuth/oauthProviderScopes.ts
@@ -1,0 +1,15 @@
+import { type PublicApiScope, PUBLIC_API_SCOPES } from '@yucp/shared';
+
+// `offline_access` is the standard OIDC scope Better Auth uses to issue
+// refresh tokens for authorization-code clients.
+// References:
+// - https://better-auth.com/docs/plugins/oauth-provider
+// - https://openid.net/specs/openid-connect-basic-1_0.html#Scopes
+export const OAUTH_REFRESH_TOKEN_SCOPE = 'offline_access';
+
+export type OAuthProviderScope = PublicApiScope | typeof OAUTH_REFRESH_TOKEN_SCOPE;
+
+export const OAUTH_PROVIDER_SCOPES = [
+  ...PUBLIC_API_SCOPES,
+  OAUTH_REFRESH_TOKEN_SCOPE,
+] as const satisfies readonly OAuthProviderScope[];

--- a/convex/betterAuth/options.test.ts
+++ b/convex/betterAuth/options.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { createAuthOptions } from '../auth';
+import { OAUTH_PROVIDER_SCOPES } from './oauthProviderScopes';
 import { createSchemaAuthOptions } from './options';
 import { tables } from './schema';
 
@@ -64,6 +65,26 @@ describe('createSchemaAuthOptions', () => {
     expect(jwtPlugin?.options?.jwt?.issuer).toBe('https://example.convex.site/api/auth');
     expect(jwtPlugin?.options?.jwt?.audience).toBe('yucp-public-api');
     expect(convexPlugin).toBeDefined();
+  });
+
+  it('registers refresh-token OAuth scopes in runtime and schema auth options', () => {
+    const schemaOptions = createSchemaAuthOptions();
+    const runtimeOptions = createAuthOptions({} as never);
+
+    for (const options of [schemaOptions, runtimeOptions]) {
+      const oauthPlugin = options.plugins?.find((plugin) => plugin.id === 'oauth-provider') as
+        | {
+            options?: {
+              grantTypes?: readonly string[];
+              scopes?: readonly string[];
+            };
+          }
+        | undefined;
+
+      expect(oauthPlugin?.options?.scopes).toEqual([...OAUTH_PROVIDER_SCOPES]);
+      expect(oauthPlugin?.options?.scopes).toContain('offline_access');
+      expect(oauthPlugin?.options?.grantTypes).toContain('refresh_token');
+    }
   });
 
   it('adds the Polar billing plugin when certificate billing env is configured', () => {

--- a/convex/betterAuth/options.ts
+++ b/convex/betterAuth/options.ts
@@ -6,11 +6,11 @@ import {
   PUBLIC_API_AUDIENCE,
   PUBLIC_API_KEY_PERMISSION_NAMESPACE,
   PUBLIC_API_KEY_PREFIX,
-  PUBLIC_API_SCOPES,
 } from '@yucp/shared';
 import type { BetterAuthOptions } from 'better-auth/minimal';
 import { emailOTP, jwt, twoFactor } from 'better-auth/plugins';
 import { createJwtJwksAdapter } from './jwtAdapter';
+import { OAUTH_PROVIDER_SCOPES } from './oauthProviderScopes';
 
 export const createSchemaAuthOptions = (): BetterAuthOptions =>
   ({
@@ -45,7 +45,7 @@ export const createSchemaAuthOptions = (): BetterAuthOptions =>
       oauthProvider({
         loginPage: 'https://example.com/oauth/login',
         consentPage: 'https://example.com/oauth/consent',
-        scopes: [...PUBLIC_API_SCOPES],
+        scopes: [...OAUTH_PROVIDER_SCOPES],
         validAudiences: [PUBLIC_API_AUDIENCE],
         cachedTrustedClients: new Set<string>(),
         allowDynamicClientRegistration: false,

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -776,7 +776,7 @@ http.route({
     if (!token) return errorResponse('Authorization: Bearer <access_token> required', 401);
 
     const authStart = performance.now();
-    const tokenResult = await verifyOAuthToken(token, siteUrl, 'cert:issue');
+    const tokenResult = await verifyOAuthToken(token, siteUrl, 'products:read');
     const authDuration = performance.now() - authStart;
     if (!tokenResult.ok) return errorResponse(tokenResult.error, 401);
     const rateLimitResponse = await applyHttpRateLimit(ctx, request, 'products-list', {

--- a/convex/httpProducts.contract.test.ts
+++ b/convex/httpProducts.contract.test.ts
@@ -17,6 +17,10 @@ describe('/v1/products fast path contract', () => {
     expect(httpSource).toContain("name: 'total'");
   });
 
+  it('requires the catalog read scope instead of certificate issuance scope', () => {
+    expect(httpSource).toContain("verifyOAuthToken(token, siteUrl, 'products:read')");
+  });
+
   it('imports Convex polyfills before using runtime timing APIs in the HTTP router', () => {
     expect(httpSource).toContain("import './polyfills';");
   });

--- a/convex/seedYucpOAuthClient.test.ts
+++ b/convex/seedYucpOAuthClient.test.ts
@@ -31,4 +31,14 @@ describe('getUnityOAuthClientDescriptors', () => {
     expect(userClient?.scopes).toContain('verification:read');
     expect(userClient?.scopes).toContain('products:read');
   });
+
+  it('allows the Unity creator tools to read product catalog entries', () => {
+    const creatorClient = getUnityOAuthClientDescriptors().find(
+      (client) => client.clientId === 'yucp-unity-creator'
+    );
+
+    expect(creatorClient?.scopes).toContain('cert:issue');
+    expect(creatorClient?.scopes).toContain('profile:read');
+    expect(creatorClient?.scopes).toContain('products:read');
+  });
 });

--- a/convex/seedYucpOAuthClient.test.ts
+++ b/convex/seedYucpOAuthClient.test.ts
@@ -3,6 +3,7 @@ import {
   buildUnityOAuthClientMetadata,
   getUnityOAuthClientDescriptors,
 } from './seedYucpOAuthClient';
+import { OAUTH_PROVIDER_SCOPES } from './betterAuth/oauthProviderScopes';
 
 describe('buildUnityOAuthClientMetadata', () => {
   it('serializes Unity OAuth client metadata as a JSON string for Better Auth storage', () => {
@@ -40,5 +41,15 @@ describe('getUnityOAuthClientDescriptors', () => {
     expect(creatorClient?.scopes).toContain('cert:issue');
     expect(creatorClient?.scopes).toContain('profile:read');
     expect(creatorClient?.scopes).toContain('products:read');
+  });
+
+  it('keeps every Unity client scope registered with the Better Auth provider', () => {
+    const providerScopes = new Set<string>(OAUTH_PROVIDER_SCOPES);
+
+    for (const descriptor of getUnityOAuthClientDescriptors()) {
+      for (const scope of descriptor.scopes) {
+        expect(providerScopes.has(scope)).toBe(true);
+      }
+    }
   });
 });

--- a/convex/seedYucpOAuthClient.ts
+++ b/convex/seedYucpOAuthClient.ts
@@ -15,25 +15,18 @@
  *     https://datatracker.ietf.org/doc/html/rfc8252
  */
 
-import type { PublicApiScope } from '@yucp/shared';
 import { components } from './_generated/api';
 import { internalMutation } from './_generated/server';
+import {
+  OAUTH_REFRESH_TOKEN_SCOPE,
+  type OAuthProviderScope,
+} from './betterAuth/oauthProviderScopes';
 import { type BetterAuthPageResult, getBetterAuthPage } from './lib/betterAuthAdapter';
-
-// `offline_access` is the standard OIDC scope that makes Better Auth issue a
-// refresh token.
-// References:
-// - https://better-auth.com/docs/plugins/oauth-provider
-// - https://openid.net/specs/openid-connect-basic-1_0.html#Scopes
-// It is not a YUCP public-API scope, so the descriptor type widens to allow it.
-// The provider already supports it globally and rotates refresh tokens on use;
-// adding it to the client's allow-list is all that's required to enable refresh.
-type UnityOAuthClientScope = PublicApiScope | 'offline_access';
 
 type UnityOAuthClientDescriptor = {
   clientId: string;
   name: string;
-  scopes: UnityOAuthClientScope[];
+  scopes: OAuthProviderScope[];
   authDomain: 'user' | 'creator';
 };
 
@@ -41,13 +34,13 @@ const UNITY_NATIVE_OAUTH_CLIENTS: readonly UnityOAuthClientDescriptor[] = [
   {
     clientId: 'yucp-unity-user',
     name: 'YUCP Unity User',
-    scopes: ['verification:read', 'products:read', 'offline_access'],
+    scopes: ['verification:read', 'products:read', OAUTH_REFRESH_TOKEN_SCOPE],
     authDomain: 'user',
   },
   {
     clientId: 'yucp-unity-creator',
     name: 'YUCP Unity Creator',
-    scopes: ['cert:issue', 'profile:read', 'products:read', 'offline_access'],
+    scopes: ['cert:issue', 'profile:read', 'products:read', OAUTH_REFRESH_TOKEN_SCOPE],
     authDomain: 'creator',
   },
 ] as const;

--- a/convex/seedYucpOAuthClient.ts
+++ b/convex/seedYucpOAuthClient.ts
@@ -20,10 +20,20 @@ import { components } from './_generated/api';
 import { internalMutation } from './_generated/server';
 import { type BetterAuthPageResult, getBetterAuthPage } from './lib/betterAuthAdapter';
 
+// `offline_access` is the standard OIDC scope that makes Better Auth issue a
+// refresh token.
+// References:
+// - https://better-auth.com/docs/plugins/oauth-provider
+// - https://openid.net/specs/openid-connect-basic-1_0.html#Scopes
+// It is not a YUCP public-API scope, so the descriptor type widens to allow it.
+// The provider already supports it globally and rotates refresh tokens on use;
+// adding it to the client's allow-list is all that's required to enable refresh.
+type UnityOAuthClientScope = PublicApiScope | 'offline_access';
+
 type UnityOAuthClientDescriptor = {
   clientId: string;
   name: string;
-  scopes: PublicApiScope[];
+  scopes: UnityOAuthClientScope[];
   authDomain: 'user' | 'creator';
 };
 
@@ -31,13 +41,13 @@ const UNITY_NATIVE_OAUTH_CLIENTS: readonly UnityOAuthClientDescriptor[] = [
   {
     clientId: 'yucp-unity-user',
     name: 'YUCP Unity User',
-    scopes: ['verification:read', 'products:read'],
+    scopes: ['verification:read', 'products:read', 'offline_access'],
     authDomain: 'user',
   },
   {
     clientId: 'yucp-unity-creator',
     name: 'YUCP Unity Creator',
-    scopes: ['cert:issue', 'profile:read'],
+    scopes: ['cert:issue', 'profile:read', 'products:read', 'offline_access'],
     authDomain: 'creator',
   },
 ] as const;

--- a/packages/shared/src/yucpTrust.test.ts
+++ b/packages/shared/src/yucpTrust.test.ts
@@ -23,6 +23,11 @@ describe('yucpTrust', () => {
       algorithm: 'Ed25519',
       publicKeyBase64: 'y+8Zs9/mS1MFZFeF4CFjwqe0nsLW8lCcwmyvBx6H0Zo=',
     });
+    expect(getPinnedYucpRootByKeyId('CREATOR-TOOLING-2026')).toEqual({
+      keyId: 'CREATOR-TOOLING-2026',
+      algorithm: 'Ed25519',
+      publicKeyBase64: 'SQF9r3TkKGwwQ6jGLBOABnq3UeOcHayQS3WbEJeUhnc=',
+    });
   });
 
   it('can swap in deterministic fixture roots for tests without mutating production defaults', () => {

--- a/packages/shared/src/yucpTrust.ts
+++ b/packages/shared/src/yucpTrust.ts
@@ -21,6 +21,7 @@ export type YucpTrustBundleConfig = Readonly<{
 }>;
 
 const PINNED_ROOT_PUBLIC_KEY_BASE64 = 'y+8Zs9/mS1MFZFeF4CFjwqe0nsLW8lCcwmyvBx6H0Zo=';
+const CREATOR_TOOLING_ROOT_PUBLIC_KEY_BASE64 = 'SQF9r3TkKGwwQ6jGLBOABnq3UeOcHayQS3WbEJeUhnc=';
 
 const BUILTIN_PINNED_ROOTS: readonly YucpPinnedRoot[] = Object.freeze([
   {
@@ -32,6 +33,11 @@ const BUILTIN_PINNED_ROOTS: readonly YucpPinnedRoot[] = Object.freeze([
     keyId: 'yucp-root-2025',
     algorithm: 'Ed25519',
     publicKeyBase64: PINNED_ROOT_PUBLIC_KEY_BASE64,
+  },
+  {
+    keyId: 'CREATOR-TOOLING-2026',
+    algorithm: 'Ed25519',
+    publicKeyBase64: CREATOR_TOOLING_ROOT_PUBLIC_KEY_BASE64,
   },
 ]);
 


### PR DESCRIPTION
## Summary

- Require `products:read` for the Convex `/v1/products` OAuth boundary instead of `cert:issue`.
- Add Unity OAuth client coverage for creator catalog reads and allow `offline_access` for native refresh-token flows.
- Pin the `CREATOR-TOOLING-2026` YUCP trust root with shared package coverage.

## Verification

- `bun audit`
- `bun run lint`
- `bun run typecheck`
- `bun run test:external-integrations` (first run hit a Vitest worker spawn/termination error, clean rerun passed)
- `bun run test:ci`
- `bun run test:convex` (first run timed out in a migration realtest and cascaded transaction failures, clean rerun passed)
- `bun x convex deploy --dry-run --typecheck enable -y`
- `bun test convex/httpProducts.contract.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline access support to OAuth authentication for creator tools.
  * Introduced new security infrastructure for creator tooling authentication.

* **Bug Fixes**
  * Updated OAuth scope requirement for the products API endpoint to use the correct permission level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->