### PR TITLE
fix(convex): use runtime-safe hkdf decryption

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -54,6 +54,7 @@ import type * as lib_couplingRuntimePackageConfig from "../lib/couplingRuntimePa
 import type * as lib_couplingServiceRuntimeArtifacts from "../lib/couplingServiceRuntimeArtifacts.js";
 import type * as lib_credentialKeys from "../lib/credentialKeys.js";
 import type * as lib_externalAccountIdentity from "../lib/externalAccountIdentity.js";
+import type * as lib_hkdfAesGcm from "../lib/hkdfAesGcm.js";
 import type * as lib_httpRateLimit from "../lib/httpRateLimit.js";
 import type * as lib_licenseSubjectLink from "../lib/licenseSubjectLink.js";
 import type * as lib_logger from "../lib/logger.js";
@@ -184,6 +185,7 @@ declare const fullApi: ApiFromModules<{
   "lib/couplingServiceRuntimeArtifacts": typeof lib_couplingServiceRuntimeArtifacts;
   "lib/credentialKeys": typeof lib_credentialKeys;
   "lib/externalAccountIdentity": typeof lib_externalAccountIdentity;
+  "lib/hkdfAesGcm": typeof lib_hkdfAesGcm;
   "lib/httpRateLimit": typeof lib_httpRateLimit;
   "lib/licenseSubjectLink": typeof lib_licenseSubjectLink;
   "lib/logger": typeof lib_logger;

--- a/convex/lib/hkdfAesGcm.realtest.ts
+++ b/convex/lib/hkdfAesGcm.realtest.ts
@@ -10,4 +10,36 @@ describe('decryptHkdfAesGcm', () => {
 
     await expect(decryptHkdfAesGcm(ciphertext, secret, purpose)).resolves.toBe('provider-token');
   });
+
+  it('rejects ciphertext encrypted with a different secret', async () => {
+    const purpose = 'gumroad-oauth-access-token';
+    const ciphertext = await encrypt('provider-token', 'test-encryption-secret-32-bytes!!', purpose);
+
+    await expect(decryptHkdfAesGcm(ciphertext, 'different-secret-32-bytes-here', purpose)).rejects.toThrow();
+  });
+
+  it('rejects ciphertext encrypted for a different purpose', async () => {
+    const secret = 'test-encryption-secret-32-bytes!!';
+    const ciphertext = await encrypt('provider-token', secret, 'gumroad-oauth-access-token');
+
+    await expect(decryptHkdfAesGcm(ciphertext, secret, 'vrchat-creator-session')).rejects.toThrow();
+  });
+
+  it('rejects truncated encrypted values before decrypting', async () => {
+    await expect(
+      decryptHkdfAesGcm('YWJj', 'test-encryption-secret-32-bytes!!', 'gumroad-oauth-access-token')
+    ).rejects.toThrow('Encrypted value is malformed.');
+  });
+
+  it('rejects oversized encrypted values before decoding', async () => {
+    const oversizedCiphertext = 'A'.repeat(100 * 1024 + 1);
+
+    await expect(
+      decryptHkdfAesGcm(
+        oversizedCiphertext,
+        'test-encryption-secret-32-bytes!!',
+        'gumroad-oauth-access-token'
+      )
+    ).rejects.toThrow('Encrypted value exceeds maximum supported size.');
+  });
 });

--- a/convex/lib/hkdfAesGcm.realtest.ts
+++ b/convex/lib/hkdfAesGcm.realtest.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { encrypt } from '../../apps/api/src/lib/encrypt';
+import { decryptHkdfAesGcm } from './hkdfAesGcm';
+
+describe('decryptHkdfAesGcm', () => {
+  it('decrypts ciphertext from the API native HKDF encryptor', async () => {
+    const secret = 'test-encryption-secret-32-bytes!!';
+    const purpose = 'gumroad-oauth-access-token';
+    const ciphertext = await encrypt('provider-token', secret, purpose);
+
+    await expect(decryptHkdfAesGcm(ciphertext, secret, purpose)).resolves.toBe('provider-token');
+  });
+});

--- a/convex/lib/hkdfAesGcm.ts
+++ b/convex/lib/hkdfAesGcm.ts
@@ -1,12 +1,20 @@
+const MAX_CIPHERTEXT_B64_LENGTH = 100 * 1024;
+
+function toExactArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
 async function hmacSha256(keyBytes: Uint8Array, message: Uint8Array): Promise<Uint8Array> {
   const key = await crypto.subtle.importKey(
     'raw',
-    keyBytes.buffer as ArrayBuffer,
+    toExactArrayBuffer(keyBytes),
     { name: 'HMAC', hash: 'SHA-256' },
     false,
     ['sign']
   );
-  return new Uint8Array(await crypto.subtle.sign('HMAC', key, message.buffer as ArrayBuffer));
+  return new Uint8Array(await crypto.subtle.sign('HMAC', key, toExactArrayBuffer(message)));
 }
 
 async function deriveHkdfAesGcmKey(secret: string, purpose: string): Promise<CryptoKey> {
@@ -19,7 +27,7 @@ async function deriveHkdfAesGcmKey(secret: string, purpose: string): Promise<Cry
   const okm = await hmacSha256(prk, expandInput);
   return await crypto.subtle.importKey(
     'raw',
-    okm.buffer as ArrayBuffer,
+    toExactArrayBuffer(okm),
     { name: 'AES-GCM', length: 256 },
     false,
     ['decrypt']
@@ -31,8 +39,14 @@ export async function decryptHkdfAesGcm(
   secret: string,
   purpose: string
 ): Promise<string> {
+  if (ciphertextB64.length > MAX_CIPHERTEXT_B64_LENGTH) {
+    throw new Error('Encrypted value exceeds maximum supported size.');
+  }
   const key = await deriveHkdfAesGcmKey(secret, purpose);
   const combined = Uint8Array.from(atob(ciphertextB64), (char) => char.charCodeAt(0));
+  if (combined.byteLength <= 12) {
+    throw new Error('Encrypted value is malformed.');
+  }
   const iv = combined.slice(0, 12);
   const data = combined.slice(12);
   const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data);

--- a/convex/lib/hkdfAesGcm.ts
+++ b/convex/lib/hkdfAesGcm.ts
@@ -1,0 +1,40 @@
+async function hmacSha256(keyBytes: Uint8Array, message: Uint8Array): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    keyBytes.buffer as ArrayBuffer,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  return new Uint8Array(await crypto.subtle.sign('HMAC', key, message.buffer as ArrayBuffer));
+}
+
+async function deriveHkdfAesGcmKey(secret: string, purpose: string): Promise<CryptoKey> {
+  const encoder = new TextEncoder();
+  const prk = await hmacSha256(new Uint8Array(32), encoder.encode(secret));
+  const info = encoder.encode(purpose);
+  const expandInput = new Uint8Array(info.byteLength + 1);
+  expandInput.set(info);
+  expandInput[info.byteLength] = 0x01;
+  const okm = await hmacSha256(prk, expandInput);
+  return await crypto.subtle.importKey(
+    'raw',
+    okm.buffer as ArrayBuffer,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['decrypt']
+  );
+}
+
+export async function decryptHkdfAesGcm(
+  ciphertextB64: string,
+  secret: string,
+  purpose: string
+): Promise<string> {
+  const key = await deriveHkdfAesGcmKey(secret, purpose);
+  const combined = Uint8Array.from(atob(ciphertextB64), (char) => char.charCodeAt(0));
+  const iv = combined.slice(0, 12);
+  const data = combined.slice(12);
+  const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data);
+  return new TextDecoder().decode(decrypted);
+}

--- a/convex/providers/shared.ts
+++ b/convex/providers/shared.ts
@@ -3,6 +3,7 @@ import { symmetricDecrypt } from 'better-auth/crypto';
 import { internal } from '../_generated/api';
 import type { ActionCtx } from '../_generated/server';
 import { AUTH_MODE_CREDENTIAL_KEY } from '../lib/credentialKeys';
+import { decryptHkdfAesGcm } from '../lib/hkdfAesGcm';
 
 type StoredProviderConnection = {
   credentials: Record<string, string>;
@@ -38,45 +39,13 @@ function getCredentialEncryptionSecret(): string {
   return secret;
 }
 
-async function deriveCredentialKey(secret: string, purpose: string): Promise<CryptoKey> {
-  const encoder = new TextEncoder();
-  const keyMaterial = await crypto.subtle.importKey('raw', encoder.encode(secret), 'HKDF', false, [
-    'deriveKey',
-  ]);
-  return await crypto.subtle.deriveKey(
-    {
-      name: 'HKDF',
-      hash: 'SHA-256',
-      salt: new Uint8Array(0),
-      info: encoder.encode(purpose),
-    },
-    keyMaterial,
-    { name: 'AES-GCM', length: 256 },
-    false,
-    ['decrypt']
-  );
-}
-
-async function decryptHkdfCredential(
-  ciphertextB64: string,
-  secret: string,
-  purpose: string
-): Promise<string> {
-  const key = await deriveCredentialKey(secret, purpose);
-  const combined = Uint8Array.from(atob(ciphertextB64), (char) => char.charCodeAt(0));
-  const iv = combined.slice(0, 12);
-  const data = combined.slice(12);
-  const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data);
-  return new TextDecoder().decode(decrypted);
-}
-
 export async function decryptStoredCredential(
   encryptedCredential: string,
   purpose: string
 ): Promise<string | null> {
   const secret = getCredentialEncryptionSecret();
   try {
-    return await decryptHkdfCredential(encryptedCredential, secret, purpose);
+    return await decryptHkdfAesGcm(encryptedCredential, secret, purpose);
   } catch {
     const legacySecret = process.env.BETTER_AUTH_SECRET?.trim();
     if (!legacySecret) {

--- a/convex/webhookDeliveryWorker.ts
+++ b/convex/webhookDeliveryWorker.ts
@@ -14,6 +14,7 @@
 import { v } from 'convex/values';
 import { internal } from './_generated/api';
 import { internalAction } from './_generated/server';
+import { decryptHkdfAesGcm } from './lib/hkdfAesGcm';
 
 // ---------------------------------------------------------------------------
 // Crypto helpers
@@ -24,22 +25,7 @@ async function decryptSecret(
   secret: string,
   purpose: string
 ): Promise<string> {
-  const encoder = new TextEncoder();
-  const keyMaterial = await crypto.subtle.importKey('raw', encoder.encode(secret), 'HKDF', false, [
-    'deriveKey',
-  ]);
-  const key = await crypto.subtle.deriveKey(
-    { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(0), info: encoder.encode(purpose) },
-    keyMaterial,
-    { name: 'AES-GCM', length: 256 },
-    false,
-    ['decrypt']
-  );
-  const combined = Uint8Array.from(atob(ciphertextB64), (c) => c.charCodeAt(0));
-  const iv = combined.slice(0, 12);
-  const data = combined.slice(12);
-  const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data);
-  return new TextDecoder().decode(decrypted);
+  return await decryptHkdfAesGcm(ciphertextB64, secret, purpose);
 }
 
 async function computeHmacSha256(payload: string, secret: string): Promise<string> {


### PR DESCRIPTION
## Summary

- Add a shared Convex HMAC-HKDF AES-GCM decrypt helper for ciphertext produced by the API encryptor.
- Route provider credential and webhook signing secret decryption through the helper so Convex does not call unsupported native WebCrypto HKDF.
- Add a realtest that encrypts through the API native-HKDF path and decrypts through the Convex helper.

## Verification

- `bun x vitest run --config convex/vitest.config.ts convex/lib/hkdfAesGcm.realtest.ts`
- `bun audit`
- `bun run lint`
- `bun run typecheck`
- `bun run test:external-integrations`
- `bun run test:ci`
- `bun run test:convex` passed on rerun after an initial migration test timeout cascade
- `bun x convex deploy --dry-run --typecheck enable -y`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized HKDF-AES-GCM decryption into a shared utility and updated both stored-credential and webhook signing-secret decryption to use it, removing duplicate inlined implementations.

* **Tests**
  * Added real/integration coverage for the decryption utility, including successful round-trip compatibility and rejection cases for wrong secret/purpose, malformed/truncated ciphertext, and ciphertext exceeding the maximum supported size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->