### PR TITLE
fix(web): stop reusing pending invite ids

### DIFF
--- a/apps/web/src/routes/_authenticated/dashboard/collaboration.lazy.tsx
+++ b/apps/web/src/routes/_authenticated/dashboard/collaboration.lazy.tsx
@@ -237,7 +237,6 @@ function MyCollaboratorsSection({
   const [generatedInvite, setGeneratedInvite] = useState<{ url: string; expiresAt: number } | null>(
     null
   );
-  const [copiedInviteId, setCopiedInviteId] = useState<string | null>(null);
 
   const providersQuery = useQuery(
     dashboardPanelQueryOptions<CollabProviderSummary[]>({
@@ -319,44 +318,19 @@ function MyCollaboratorsSection({
 
   const handleProviderChange = (key: string) => {
     setSelectedProvider(key);
-    const existing = invites.find((i) => i.providerKey === key);
-    if (existing) {
-      setGeneratedInvite({
-        url: `${window.location.origin}/collab-invite?id=${encodeURIComponent(existing.id)}`,
-        expiresAt: existing.expiresAt,
-      });
-    } else {
-      setGeneratedInvite(null);
-    }
+    setGeneratedInvite(null);
   };
 
   const openInvitePanel = () => {
     const providerKey = selectedProvider || providers[0]?.key || '';
     setSelectedProvider(providerKey);
     setInvitePanelOpen(true);
-
-    const existingInvite = invites.find((i) => i.providerKey === providerKey);
-    if (existingInvite) {
-      setGeneratedInvite({
-        url: `${window.location.origin}/collab-invite?id=${encodeURIComponent(existingInvite.id)}`,
-        expiresAt: existingInvite.expiresAt,
-      });
-    } else {
-      setGeneratedInvite(null);
-    }
+    setGeneratedInvite(null);
   };
 
   const closeInvitePanel = () => {
     setInvitePanelOpen(false);
   };
-
-  const handleCopyInviteLink = (url: string, inviteId: string) => {
-    void copyToClipboard(url);
-    setCopiedInviteId(inviteId);
-    setTimeout(() => setCopiedInviteId(null), 1500);
-  };
-
-  const currentInviteId = invites.find((i) => i.providerKey === selectedProvider)?.id;
 
   if (hasAuthError) {
     return (
@@ -531,26 +505,6 @@ function MyCollaboratorsSection({
                     >
                       Copy Invite Link
                     </button>
-                    {currentInviteId ? (
-                      <button
-                        type="button"
-                        className={`collab-remove-btn${revokeInviteMutation.isPending ? ' btn-loading' : ''}`}
-                        style={{ marginLeft: 0, width: '100%', justifyContent: 'center' }}
-                        disabled={revokeInviteMutation.isPending}
-                        onClick={() =>
-                          currentInviteId && revokeInviteMutation.mutate(currentInviteId)
-                        }
-                      >
-                        {revokeInviteMutation.isPending ? (
-                          <>
-                            <span className="btn-loading-spinner" aria-hidden="true" />
-                            Revoking...
-                          </>
-                        ) : (
-                          'Revoke Invite'
-                        )}
-                      </button>
-                    ) : null}
                   </div>
                 </div>
               ) : (
@@ -595,18 +549,6 @@ function MyCollaboratorsSection({
                       {formatRelativeDate(invite.expiresAt)}
                     </span>
                   </div>
-                  <button
-                    type="button"
-                    className={`collab-copy-btn${copiedInviteId === invite.id ? ' copied' : ''}`}
-                    onClick={() =>
-                      handleCopyInviteLink(
-                        `${window.location.origin}/collab-invite?id=${encodeURIComponent(invite.id)}`,
-                        invite.id
-                      )
-                    }
-                  >
-                    {copiedInviteId === invite.id ? 'Copied!' : 'Copy link'}
-                  </button>
                   <button
                     type="button"
                     className={`collab-remove-btn${revokeInviteMutation.isPending && revokeInviteMutation.variables === invite.id ? ' btn-loading' : ''}`}

--- a/apps/web/src/styles/dashboard/partials/01-page-through-skeleton.css
+++ b/apps/web/src/styles/dashboard/partials/01-page-through-skeleton.css
@@ -1214,56 +1214,6 @@ img.collab-avatar {
   margin-top: 2px;
 }
 
-/* Copy button in invite rows, same shape as collab-remove-btn but neutral hover */
-.collab-copy-btn {
-  margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 5px;
-  font-size: 12px;
-  font-weight: 700;
-  background: transparent;
-  border: 1px solid var(--border-color);
-  color: var(--text-secondary);
-  border-radius: 10px;
-  padding: 6px 14px;
-  min-height: 32px;
-  cursor: pointer;
-  transition: all 0.2s;
-  font-family: var(--font-display), sans-serif;
-  flex-shrink: 0;
-}
-
-.collab-copy-btn:hover {
-  background: #0ea5e9;
-  border-color: #0ea5e9;
-  color: #ffffff;
-}
-
-.collab-copy-btn.copied {
-  background: #22c55e;
-  border-color: #22c55e;
-  color: #ffffff;
-}
-
-.dark .collab-copy-btn {
-  border-color: rgba(255, 255, 255, 0.18);
-  color: rgba(255, 255, 255, 0.7);
-}
-
-.dark .collab-copy-btn:hover {
-  background: #0ea5e9;
-  border-color: #0ea5e9;
-  color: #ffffff;
-}
-
-.dark .collab-copy-btn.copied {
-  background: #22c55e;
-  border-color: #22c55e;
-  color: #ffffff;
-}
-
 /*  Animations */
 
 @keyframes fadeInUp {

--- a/apps/web/test/unit/dashboard-collaboration-route.test.tsx
+++ b/apps/web/test/unit/dashboard-collaboration-route.test.tsx
@@ -60,6 +60,12 @@ function createWrapper() {
   };
 }
 
+function createPortalRoot() {
+  const portalRoot = document.createElement('div');
+  portalRoot.id = 'portal-root';
+  document.body.appendChild(portalRoot);
+}
+
 describe('dashboard collaboration route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -84,6 +90,7 @@ describe('dashboard collaboration route', () => {
   afterEach(() => {
     vi.useRealTimers();
     cleanup();
+    document.body.innerHTML = '';
   });
 
   it('cancels store removal when the hold is released early', async () => {
@@ -126,5 +133,40 @@ describe('dashboard collaboration route', () => {
       'user-123',
       'conn-1'
     );
+  });
+
+  it('does not synthesize share links from pending invite ids', async () => {
+    vi.mocked(dashboardApi.listCollabProviders).mockResolvedValue([
+      { key: 'jinxxy', label: 'Jinxxy' },
+    ]);
+    vi.mocked(dashboardApi.listCollabInvites).mockResolvedValue([
+      {
+        id: 'invite-id-only',
+        providerKey: 'jinxxy',
+        ownerDisplayName: 'Creator Store',
+        expiresAt: Date.now() + 86_400_000,
+        createdAt: Date.now(),
+      },
+    ]);
+
+    const Component = CollaborationRoute.options.component;
+    if (!Component) {
+      throw new Error('Collaboration route component is not defined');
+    }
+
+    createPortalRoot();
+
+    render(<Component />, { wrapper: createWrapper() });
+
+    await waitFor(() => expect(screen.getByText('Pending Invites')).toBeInTheDocument());
+
+    expect(screen.queryByRole('button', { name: /^copy link$/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /invite a creator/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /generate invite link/i })).toBeInTheDocument()
+    );
+    expect(screen.queryByText(/\/collab-invite\?id=invite-id-only/)).not.toBeInTheDocument();
   });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -292,7 +292,7 @@
     "shell-quote": "1.8.4",
     "srvx": ">=0.11.13",
     "tar": "7.5.16",
-    "undici": ">=6.23.0",
+    "undici": "7.28.0",
     "uuid": ">=14.0.0",
     "vite": ">=8.0.16",
     "ws": ">=8.20.1",
@@ -2348,7 +2348,7 @@
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
-    "undici": ["undici@7.24.5", "", {}, "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q=="],
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "protobufjs": "7.6.4",
     "defu": ">=6.1.6",
     "esbuild": "0.28.1",
-    "undici": ">=6.23.0",
+    "undici": "7.28.0",
     "vite": ">=8.0.16",
     "follow-redirects": ">=1.15.12",
     "@smithy/config-resolver": ">=4.4.0",


### PR DESCRIPTION
## Summary

- Stop rebuilding collaboration share URLs from pending invite ids in the dashboard.
- Require a fresh generated invite link when opening the invite panel or switching providers.
- Remove the pending-row copy-link control and stale styles.
- Add a collaboration route regression that verifies pending invite ids are not exposed as synthesized share links.
- Pin `undici` to `7.28.0` so the audit gate resolves to the patched version consistently.

## Verification

- `bun audit`
- `bun run lint`
- `bun run typecheck`
- `bun run test:external-integrations`
- `bun run test:ci`
- `bun run test test/unit/dashboard-collaboration-route.test.tsx` from `apps/web`