### PR TITLE
fix: use real response in seed relay test

### DIFF
--- a/convex/couplingJobAndReveal.realtest.ts
+++ b/convex/couplingJobAndReveal.realtest.ts
@@ -149,18 +149,15 @@ describe('coupling job + license reveal', () => {
         seeds: (body.assetPaths ?? []).map((assetPath) => ({ assetPath, seedHex })),
       });
       const bytes = new TextEncoder().encode(payload);
-      return {
-        ok: true,
-        body: new ReadableStream<Uint8Array>({
+      return new Response(
+        new ReadableStream<Uint8Array>({
           start(controller) {
             controller.enqueue(bytes);
             controller.close();
           },
         }),
-        text: async () => {
-          throw new Error('seed relay responses must use the bounded stream reader');
-        },
-      } as Response;
+        { status: 200 }
+      );
     }) as typeof fetch;
   }
 

--- a/convex/couplingJobAndReveal.realtest.ts
+++ b/convex/couplingJobAndReveal.realtest.ts
@@ -149,7 +149,7 @@ describe('coupling job + license reveal', () => {
         seeds: (body.assetPaths ?? []).map((assetPath) => ({ assetPath, seedHex })),
       });
       const bytes = new TextEncoder().encode(payload);
-      return new Response(
+      const response = new Response(
         new ReadableStream<Uint8Array>({
           start(controller) {
             controller.enqueue(bytes);
@@ -158,6 +158,10 @@ describe('coupling job + license reveal', () => {
         }),
         { status: 200 }
       );
+      response.text = async () => {
+        throw new Error('seed relay responses must use the bounded stream reader');
+      };
+      return response;
     }) as typeof fetch;
   }
 


### PR DESCRIPTION
## Summary

- Replace the seed relay realtest's partial `Response` cast with a native `Response` instance around the same bounded stream payload.
- Keep the fixture behavior intact while satisfying the Convex deploy typecheck path that Zeabur runs for API and bot builds.

## Root Cause

Zeabur Araiguma API and bot builds failed during `bun x convex deploy` because Convex typechecking rejected a test fixture that force-cast a partial object to `Response`:

```text
convex/couplingJobAndReveal.realtest.ts:152:14 - error TS2352
```

The normal fixture only needed `ok`, `body`, and `text`, but the deploy typecheck validates the full `Response` type. Constructing a real `Response` preserves the stream behavior and removes the invalid cast.

## Verification

- `bun x vitest run --config convex/vitest.config.ts convex/couplingJobAndReveal.realtest.ts`
- `bun x convex deploy --dry-run --typecheck enable --codegen disable --yes`
- `bun audit`
- `bun run lint`
- `bun run typecheck`
- `bun run test:external-integrations`
- `bun run test:ci`
- `bun run test:convex`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated streaming response handling in test coverage to better match real network responses and improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->