### PR TITLE
feat: add coupling trace attribution

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1013,10 +1013,6 @@ async function routeRequest(request: Request): Promise<Response> {
     if (request.method === 'POST') return forensicsRoutes.lookup(request);
     return Response.json({ error: 'Method not allowed' }, { status: 405 });
   }
-  if (pathname === '/api/forensics/reveal-license' && forensicsRoutes) {
-    if (request.method === 'POST') return forensicsRoutes.revealLicense(request);
-    return Response.json({ error: 'Method not allowed' }, { status: 405 });
-  }
   if (pathname === '/api/packages' && packageRoutes) {
     if (request.method === 'GET') return packageRoutes.listPackages(request);
     return Response.json({ error: 'Method not allowed' }, { status: 405 });

--- a/apps/api/src/lib/couplingForensicsService.test.ts
+++ b/apps/api/src/lib/couplingForensicsService.test.ts
@@ -224,6 +224,7 @@ describe('runCouplingAttribution', () => {
 
     for (const baseUrl of [
       'http://[fe80::1]',
+      'http://[fe90::1]',
       'http://[::ffff:169.254.169.254]',
       'http://[fd00:ec2::254]',
     ]) {
@@ -266,6 +267,84 @@ describe('runCouplingAttribution', () => {
         config
       )
     ).rejects.toThrow('Coupling service returned invalid JSON');
+  });
+
+  it('rejects non-array attribution results as a controlled upstream protocol error', async () => {
+    const fetchMock = mock(async () => {
+      return new Response(JSON.stringify({ results: {} }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      runCouplingAttribution(
+        [
+          {
+            assetPath: 'Assets/Character/body.png',
+            assetType: 'png',
+            filePath: assetFixturePath,
+          },
+        ],
+        candidates,
+        config
+      )
+    ).rejects.toThrow('Coupling service returned invalid results');
+  });
+
+  it('rejects oversized attribution response bodies before parsing JSON', async () => {
+    const fetchMock = mock(async () => {
+      return new Response(JSON.stringify({ requestId: 'x'.repeat(64), results: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      runCouplingAttribution(
+        [
+          {
+            assetPath: 'Assets/Character/body.png',
+            assetType: 'png',
+            filePath: assetFixturePath,
+          },
+        ],
+        candidates,
+        { ...config, responseMaxBytes: 16 }
+      )
+    ).rejects.toThrow('Coupling service response is too large');
+  });
+
+  it('maps attribution network failures without exposing raw transport details', async () => {
+    const fetchMock = mock(async () => {
+      throw new Error('dial tcp coupling.internal:443: network down');
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    let caught: unknown;
+    try {
+      await runCouplingAttribution(
+        [
+          {
+            assetPath: 'Assets/Character/body.png',
+            assetType: 'png',
+            filePath: assetFixturePath,
+          },
+        ],
+        candidates,
+        config
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    const message = caught instanceof Error ? caught.message : String(caught);
+    expect(message).toBe('Coupling service is unreachable');
+    expect(message).not.toContain('coupling.internal');
+    expect(message).not.toContain('network down');
   });
 
   it('does not include uploaded asset paths when rejecting invalid matched license subjects', async () => {
@@ -484,6 +563,45 @@ describe('runCouplingAttribution', () => {
     ).rejects.toThrow('Coupling attribution timed out');
   });
 
+  it('prefers the attribution-specific timeout over the generic request timeout', async () => {
+    const fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+      const signal = init?.signal;
+      return await new Promise<Response>((resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(new Error('fetch aborted')));
+        setTimeout(
+          () =>
+            resolve(
+              new Response(JSON.stringify({ results: [] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              })
+            ),
+          100
+        );
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      Promise.race([
+        runCouplingAttribution(
+          [
+            {
+              assetPath: 'Assets/Character/body.png',
+              assetType: 'png',
+              filePath: assetFixturePath,
+            },
+          ],
+          candidates,
+          { ...config, requestTimeoutMs: 100, attributionTimeoutMs: 1 }
+        ),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('attribution timeout was not preferred')), 50)
+        ),
+      ])
+    ).rejects.toThrow('Coupling attribution timed out');
+  });
+
   it('keeps the attribution timeout active while reading the response body', async () => {
     const fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
       const signal = init?.signal;
@@ -605,14 +723,15 @@ describe('legacy coupling service scan paths', () => {
       ).rejects.toThrow('Coupling service returned invalid JSON');
     });
 
-    it(`maps unreachable ${name} requests to coupling service errors`, async () => {
+    it(`maps unreachable ${name} requests to generic coupling service errors`, async () => {
       const fetchMock = mock(async () => {
-        throw new Error(`${name} network down`);
+        throw new Error(`dial tcp ${name}.coupling.internal:443: network down`);
       });
       globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-      await expect(
-        run(
+      let caught: unknown;
+      try {
+        await run(
           [
             {
               assetPath: 'Assets/Character/body.png',
@@ -621,8 +740,54 @@ describe('legacy coupling service scan paths', () => {
             },
           ],
           config
-        )
-      ).rejects.toThrow(`Coupling service is unreachable: ${name} network down`);
+        );
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(Error);
+      const message = caught instanceof Error ? caught.message : String(caught);
+      expect(message).toBe('Coupling service is unreachable');
+      expect(message).not.toContain('coupling.internal');
+      expect(message).not.toContain('network down');
+    });
+
+    it(`does not apply attribution-specific timeouts to ${name} requests`, async () => {
+      const fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+        const signal = init?.signal;
+        return await new Promise<Response>((resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(new Error('fetch aborted')));
+          setTimeout(
+            () =>
+              resolve(
+                new Response(JSON.stringify({ results: [] }), {
+                  status: 200,
+                  headers: { 'Content-Type': 'application/json' },
+                })
+              ),
+            25
+          );
+        });
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(
+        Promise.race([
+          run(
+            [
+              {
+                assetPath: 'Assets/Character/body.png',
+                assetType: 'png',
+                filePath: assetFixturePath,
+              },
+            ],
+            { ...config, attributionTimeoutMs: 1 }
+          ),
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error('legacy request did not finish')), 100)
+          ),
+        ])
+      ).resolves.toBeDefined();
     });
 
     it(`maps timed-out ${name} requests to 504 coupling service errors`, async () => {
@@ -654,7 +819,7 @@ describe('legacy coupling service scan paths', () => {
                 filePath: assetFixturePath,
               },
             ],
-            { ...config, attributionTimeoutMs: 1 }
+            { ...config, requestTimeoutMs: 1 }
           ),
           new Promise((_, reject) =>
             setTimeout(() => reject(new Error('timeout was not enforced')), 50)

--- a/apps/api/src/lib/couplingForensicsService.test.ts
+++ b/apps/api/src/lib/couplingForensicsService.test.ts
@@ -192,6 +192,30 @@ describe('runCouplingAttribution', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('rejects bracketed IPv6 metadata attribution base URLs before sending requests', async () => {
+    const fetchMock = mock(async () => {
+      throw new Error('Attribution must not fetch bracketed metadata service URLs');
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    for (const baseUrl of ['http://[fe80::1]', 'http://[::ffff:169.254.169.254]']) {
+      await expect(
+        runCouplingAttribution(
+          [
+            {
+              assetPath: 'Assets/Character/body.png',
+              assetType: 'png',
+              filePath: assetFixturePath,
+            },
+          ],
+          candidates,
+          { ...config, baseUrl }
+        )
+      ).rejects.toThrow('Coupling service base URL host is not allowed');
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('rejects invalid JSON attribution responses', async () => {
     const fetchMock = mock(async () => {
       return new Response('not-json', {

--- a/apps/api/src/lib/couplingForensicsService.test.ts
+++ b/apps/api/src/lib/couplingForensicsService.test.ts
@@ -311,6 +311,93 @@ describe('runCouplingAttribution', () => {
     expect(message).not.toContain(unsafeAssetPath);
   });
 
+  it('does not include unknown uploaded asset paths in attribution validation errors', async () => {
+    const unsafeAssetPath = 'Assets/Customers/buyer@example.com/private.png';
+    const fetchMock = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          results: [
+            {
+              assetPath: unsafeAssetPath,
+              assetType: 'png',
+              matched: false,
+            },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    let caught: unknown;
+    try {
+      await runCouplingAttribution(
+        [
+          {
+            assetPath: 'Assets/Character/body.png',
+            assetType: 'png',
+            filePath: assetFixturePath,
+          },
+        ],
+        candidates,
+        config
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    const message = caught instanceof Error ? caught.message : String(caught);
+    expect(message).toBe('Coupling service returned an unknown asset path');
+    expect(message).not.toContain(unsafeAssetPath);
+  });
+
+  it('does not include duplicate uploaded asset paths in attribution validation errors', async () => {
+    const unsafeAssetPath = 'Assets/Customers/buyer@example.com/private.png';
+    const fetchMock = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          results: [
+            {
+              assetPath: unsafeAssetPath,
+              assetType: 'png',
+              matched: false,
+            },
+            {
+              assetPath: unsafeAssetPath,
+              assetType: 'png',
+              matched: false,
+            },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    let caught: unknown;
+    try {
+      await runCouplingAttribution(
+        [
+          {
+            assetPath: unsafeAssetPath,
+            assetType: 'png',
+            filePath: assetFixturePath,
+          },
+        ],
+        [{ ...candidates[0], assetPath: unsafeAssetPath }],
+        config
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    const message = caught instanceof Error ? caught.message : String(caught);
+    expect(message).toBe('Coupling service returned a duplicate asset path');
+    expect(message).not.toContain(unsafeAssetPath);
+  });
+
   it('maps attribution timeout aborts to 504 errors', async () => {
     const fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
       const signal = init?.signal;
@@ -451,4 +538,69 @@ describe('legacy coupling service scan paths', () => {
       ).rejects.toThrow(`Coupling service is unreachable: ${name} network down`);
     });
   }
+
+  it('does not include uploaded asset paths in scan validation errors', async () => {
+    const unsafeAssetPath = 'Assets/Customers/buyer@example.com/private.png';
+    const cases = [
+      {
+        result: {
+          assetPath: unsafeAssetPath,
+          assetType: 'png',
+          tokenHex: 'deadbeef',
+          tokenLength: 8,
+        },
+        expectedMessage: 'Coupling service returned an unknown asset path',
+      },
+      {
+        result: {
+          assetPath: 'Assets/Character/body.png',
+          assetType: 'png',
+          tokenHex: 'not-a-token',
+          tokenLength: 11,
+        },
+        expectedMessage: 'Coupling service returned an invalid token',
+      },
+      {
+        result: {
+          assetPath: 'Assets/Character/body.png',
+          assetType: 'png',
+          tokenHex: 'deadbeef',
+          tokenLength: 7,
+        },
+        expectedMessage: 'Coupling service token length mismatch',
+      },
+    ];
+
+    for (const testCase of cases) {
+      const fetchMock = mock(async () => {
+        return new Response(JSON.stringify({ results: [testCase.result] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      let caught: unknown;
+      try {
+        await runCouplingForensicsScan(
+          [
+            {
+              assetPath: 'Assets/Character/body.png',
+              assetType: 'png',
+              filePath: assetFixturePath,
+            },
+          ],
+          config
+        );
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(Error);
+      const message = caught instanceof Error ? caught.message : String(caught);
+      expect(message).toBe(testCase.expectedMessage);
+      expect(message).not.toContain(unsafeAssetPath);
+      expect(message).not.toContain('Assets/Character/body.png');
+    }
+  });
 });

--- a/apps/api/src/lib/couplingForensicsService.test.ts
+++ b/apps/api/src/lib/couplingForensicsService.test.ts
@@ -220,7 +220,11 @@ describe('runCouplingAttribution', () => {
     });
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    for (const baseUrl of ['http://[fe80::1]', 'http://[::ffff:169.254.169.254]']) {
+    for (const baseUrl of [
+      'http://[fe80::1]',
+      'http://[::ffff:169.254.169.254]',
+      'http://[fd00:ec2::254]',
+    ]) {
       await expect(
         runCouplingAttribution(
           [

--- a/apps/api/src/lib/couplingForensicsService.test.ts
+++ b/apps/api/src/lib/couplingForensicsService.test.ts
@@ -5,6 +5,8 @@ import {
   type CouplingForensicsServiceConfig,
   CouplingServiceConfigurationError,
   runCouplingAttribution,
+  runCouplingForensicsScan,
+  runCouplingForensicsScore,
 } from './couplingForensicsService';
 
 const originalFetch = globalThis.fetch;
@@ -347,4 +349,106 @@ describe('runCouplingAttribution', () => {
       ])
     ).rejects.toThrow('Coupling attribution timed out');
   });
+});
+
+describe('legacy coupling service scan paths', () => {
+  for (const [name, run, expectedUrl] of [
+    ['score', runCouplingForensicsScore, 'https://coupling.internal/v1/coupling/forensic-score'],
+    ['scan', runCouplingForensicsScan, 'https://coupling.internal/v1/coupling/scan'],
+  ] as const) {
+    it(`uses a non-redirecting request for ${name}`, async () => {
+      let requestUrl = '';
+      let requestInit: RequestInit | undefined;
+      const fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
+        requestUrl =
+          typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+        requestInit = init;
+        return new Response(JSON.stringify({ results: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await run(
+        [
+          {
+            assetPath: 'Assets/Character/body.png',
+            assetType: 'png',
+            filePath: assetFixturePath,
+          },
+        ],
+        config
+      );
+
+      expect(requestUrl).toBe(expectedUrl);
+      expect(requestInit?.redirect).toBe('error');
+    });
+
+    it(`rejects invalid ${name} base URLs before sending requests`, async () => {
+      const fetchMock = mock(async () => {
+        throw new Error(`${name} must not fetch invalid service URLs`);
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      for (const baseUrl of ['file:///tmp/coupling', 'https://user:pass@coupling.internal']) {
+        await expect(
+          run(
+            [
+              {
+                assetPath: 'Assets/Character/body.png',
+                assetType: 'png',
+                filePath: assetFixturePath,
+              },
+            ],
+            { ...config, baseUrl }
+          )
+        ).rejects.toThrow('Coupling service base URL');
+      }
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it(`rejects invalid JSON ${name} responses`, async () => {
+      const fetchMock = mock(async () => {
+        return new Response('not-json', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(
+        run(
+          [
+            {
+              assetPath: 'Assets/Character/body.png',
+              assetType: 'png',
+              filePath: assetFixturePath,
+            },
+          ],
+          config
+        )
+      ).rejects.toThrow('Coupling service returned invalid JSON');
+    });
+
+    it(`maps unreachable ${name} requests to coupling service errors`, async () => {
+      const fetchMock = mock(async () => {
+        throw new Error(`${name} network down`);
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(
+        run(
+          [
+            {
+              assetPath: 'Assets/Character/body.png',
+              assetType: 'png',
+              filePath: assetFixturePath,
+            },
+          ],
+          config
+        )
+      ).rejects.toThrow(`Coupling service is unreachable: ${name} network down`);
+    });
+  }
 });

--- a/apps/api/src/lib/couplingForensicsService.test.ts
+++ b/apps/api/src/lib/couplingForensicsService.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { fileURLToPath } from 'node:url';
+import {
+  type CouplingAttributionCandidate,
+  type CouplingForensicsServiceConfig,
+  runCouplingAttribution,
+} from './couplingForensicsService';
+
+const originalFetch = globalThis.fetch;
+const assetFixturePath = fileURLToPath(new URL(import.meta.url));
+const config: CouplingForensicsServiceConfig = {
+  baseUrl: 'https://coupling.internal',
+  sharedSecret: ['unit', 'test', 'coupling', 'bearer'].join('-'),
+};
+const candidates: CouplingAttributionCandidate[] = [
+  {
+    assetPath: 'Assets/Character/body.png',
+    licenseSubject: 'license-subject-1',
+    tokenHash: '0'.repeat(64),
+  },
+];
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('runCouplingAttribution', () => {
+  it('rejects duplicate attribution input paths before correlating service results', async () => {
+    const fetchMock = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          results: [
+            {
+              assetPath: 'Assets/Character/body.png',
+              assetType: 'png',
+              matched: false,
+            },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      runCouplingAttribution(
+        [
+          {
+            assetPath: 'Assets/Character/body.png',
+            assetType: 'png',
+            filePath: assetFixturePath,
+          },
+          {
+            assetPath: 'Assets/Character/body.png',
+            assetType: 'png',
+            filePath: assetFixturePath,
+          },
+        ],
+        candidates,
+        config
+      )
+    ).rejects.toThrow('Duplicate asset path in attribution input: Assets/Character/body.png');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('uses an abortable non-redirecting request for attribution calls', async () => {
+    let requestInit: RequestInit | undefined;
+    const fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+      requestInit = init;
+      return new Response(
+        JSON.stringify({
+          results: [
+            {
+              assetPath: 'Assets/Character/body.png',
+              assetType: 'png',
+              matched: false,
+            },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await runCouplingAttribution(
+      [
+        {
+          assetPath: 'Assets/Character/body.png',
+          assetType: 'png',
+          filePath: assetFixturePath,
+        },
+      ],
+      candidates,
+      config
+    );
+
+    expect(requestInit?.signal).toBeInstanceOf(AbortSignal);
+    expect(requestInit?.redirect).toBe('error');
+  });
+
+  it('rejects non-http attribution base URLs before sending requests', async () => {
+    const fetchMock = mock(async () => {
+      throw new Error('Attribution must not fetch non-http service URLs');
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      runCouplingAttribution(
+        [
+          {
+            assetPath: 'Assets/Character/body.png',
+            assetType: 'png',
+            filePath: assetFixturePath,
+          },
+        ],
+        candidates,
+        { ...config, baseUrl: 'file:///tmp/coupling' }
+      )
+    ).rejects.toThrow('Coupling service base URL must use http or https');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/lib/couplingForensicsService.test.ts
+++ b/apps/api/src/lib/couplingForensicsService.test.ts
@@ -192,6 +192,28 @@ describe('runCouplingAttribution', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('rejects trailing-dot metadata attribution base URLs before sending requests', async () => {
+    const fetchMock = mock(async () => {
+      throw new Error('Attribution must not fetch trailing-dot metadata service URLs');
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      runCouplingAttribution(
+        [
+          {
+            assetPath: 'Assets/Character/body.png',
+            assetType: 'png',
+            filePath: assetFixturePath,
+          },
+        ],
+        candidates,
+        { ...config, baseUrl: 'http://metadata.google.internal.' }
+      )
+    ).rejects.toThrow('Coupling service base URL host is not allowed');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('rejects bracketed IPv6 metadata attribution base URLs before sending requests', async () => {
     const fetchMock = mock(async () => {
       throw new Error('Attribution must not fetch bracketed metadata service URLs');

--- a/apps/api/src/lib/couplingForensicsService.test.ts
+++ b/apps/api/src/lib/couplingForensicsService.test.ts
@@ -262,6 +262,49 @@ describe('runCouplingAttribution', () => {
     ).rejects.toThrow('Coupling service returned invalid JSON');
   });
 
+  it('does not include uploaded asset paths when rejecting invalid matched license subjects', async () => {
+    const unsafeAssetPath = 'Assets/Customers/buyer@example.com/private.png';
+    const fetchMock = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          results: [
+            {
+              assetPath: unsafeAssetPath,
+              assetType: 'png',
+              matched: true,
+              tokenHex: 'deadbeef',
+              matchedLicenseSubject: 'not-a-sha256-subject',
+            },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    let caught: unknown;
+    try {
+      await runCouplingAttribution(
+        [
+          {
+            assetPath: unsafeAssetPath,
+            assetType: 'png',
+            filePath: assetFixturePath,
+          },
+        ],
+        [{ ...candidates[0], assetPath: unsafeAssetPath }],
+        config
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    const message = caught instanceof Error ? caught.message : String(caught);
+    expect(message).toBe('Coupling service returned an invalid matched license subject');
+    expect(message).not.toContain(unsafeAssetPath);
+  });
+
   it('maps attribution timeout aborts to 504 errors', async () => {
     const fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
       const signal = init?.signal;

--- a/apps/api/src/lib/couplingForensicsService.test.ts
+++ b/apps/api/src/lib/couplingForensicsService.test.ts
@@ -147,4 +147,111 @@ describe('runCouplingAttribution', () => {
     expect(caught).toBeInstanceOf(CouplingServiceConfigurationError);
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it('rejects credential-bearing attribution base URLs before sending requests', async () => {
+    const fetchMock = mock(async () => {
+      throw new Error('Attribution must not fetch credential-bearing service URLs');
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      runCouplingAttribution(
+        [
+          {
+            assetPath: 'Assets/Character/body.png',
+            assetType: 'png',
+            filePath: assetFixturePath,
+          },
+        ],
+        candidates,
+        { ...config, baseUrl: 'https://user:pass@coupling.internal' }
+      )
+    ).rejects.toThrow('Coupling service base URL must not include credentials');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects metadata-IP attribution base URLs before sending requests', async () => {
+    const fetchMock = mock(async () => {
+      throw new Error('Attribution must not fetch metadata service URLs');
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      runCouplingAttribution(
+        [
+          {
+            assetPath: 'Assets/Character/body.png',
+            assetType: 'png',
+            filePath: assetFixturePath,
+          },
+        ],
+        candidates,
+        { ...config, baseUrl: 'http://169.254.169.254' }
+      )
+    ).rejects.toThrow('Coupling service base URL host is not allowed');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid JSON attribution responses', async () => {
+    const fetchMock = mock(async () => {
+      return new Response('not-json', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      runCouplingAttribution(
+        [
+          {
+            assetPath: 'Assets/Character/body.png',
+            assetType: 'png',
+            filePath: assetFixturePath,
+          },
+        ],
+        candidates,
+        config
+      )
+    ).rejects.toThrow('Coupling service returned invalid JSON');
+  });
+
+  it('maps attribution timeout aborts to 504 errors', async () => {
+    const fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+      const signal = init?.signal;
+      return await new Promise<Response>((resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(new Error('fetch aborted')));
+        setTimeout(
+          () =>
+            resolve(
+              new Response(JSON.stringify({ results: [] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              })
+            ),
+          100
+        );
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      Promise.race([
+        runCouplingAttribution(
+          [
+            {
+              assetPath: 'Assets/Character/body.png',
+              assetType: 'png',
+              filePath: assetFixturePath,
+            },
+          ],
+          candidates,
+          { ...config, attributionTimeoutMs: 1 }
+        ),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('timeout was not enforced')), 50)
+        ),
+      ])
+    ).rejects.toThrow('Coupling attribution timed out');
+  });
 });

--- a/apps/api/src/lib/couplingForensicsService.test.ts
+++ b/apps/api/src/lib/couplingForensicsService.test.ts
@@ -311,6 +311,53 @@ describe('runCouplingAttribution', () => {
     expect(message).not.toContain(unsafeAssetPath);
   });
 
+  it('rejects matched attribution responses without a valid recovered token', async () => {
+    const unsafeAssetPath = 'Assets/Customers/buyer@example.com/private.png';
+
+    for (const tokenHex of [undefined, 'not-a-token']) {
+      const fetchMock = mock(async () => {
+        return new Response(
+          JSON.stringify({
+            results: [
+              {
+                assetPath: unsafeAssetPath,
+                assetType: 'png',
+                matched: true,
+                tokenHex,
+                matchedLicenseSubject: 'f'.repeat(64),
+                matchedCandidateAssetPath: unsafeAssetPath,
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      let caught: unknown;
+      try {
+        await runCouplingAttribution(
+          [
+            {
+              assetPath: unsafeAssetPath,
+              assetType: 'png',
+              filePath: assetFixturePath,
+            },
+          ],
+          [{ ...candidates[0], assetPath: unsafeAssetPath, licenseSubject: 'f'.repeat(64) }],
+          config
+        );
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(Error);
+      const message = caught instanceof Error ? caught.message : String(caught);
+      expect(message).toBe('Coupling service returned an invalid token');
+      expect(message).not.toContain(unsafeAssetPath);
+    }
+  });
+
   it('does not include unknown uploaded asset paths in attribution validation errors', async () => {
     const unsafeAssetPath = 'Assets/Customers/buyer@example.com/private.png';
     const fetchMock = mock(async () => {
@@ -436,6 +483,45 @@ describe('runCouplingAttribution', () => {
       ])
     ).rejects.toThrow('Coupling attribution timed out');
   });
+
+  it('keeps the attribution timeout active while reading the response body', async () => {
+    const fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+      const signal = init?.signal;
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            signal?.addEventListener('abort', () =>
+              controller.error(new Error('body read aborted'))
+            );
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      Promise.race([
+        runCouplingAttribution(
+          [
+            {
+              assetPath: 'Assets/Character/body.png',
+              assetType: 'png',
+              filePath: assetFixturePath,
+            },
+          ],
+          candidates,
+          { ...config, attributionTimeoutMs: 1 }
+        ),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('body timeout was not enforced')), 50)
+        ),
+      ])
+    ).rejects.toThrow('Coupling attribution timed out');
+  });
 });
 
 describe('legacy coupling service scan paths', () => {
@@ -470,6 +556,7 @@ describe('legacy coupling service scan paths', () => {
 
       expect(requestUrl).toBe(expectedUrl);
       expect(requestInit?.redirect).toBe('error');
+      expect(requestInit?.signal).toBeInstanceOf(AbortSignal);
     });
 
     it(`rejects invalid ${name} base URLs before sending requests`, async () => {
@@ -536,6 +623,46 @@ describe('legacy coupling service scan paths', () => {
           config
         )
       ).rejects.toThrow(`Coupling service is unreachable: ${name} network down`);
+    });
+
+    it(`maps timed-out ${name} requests to 504 coupling service errors`, async () => {
+      const fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+        const signal = init?.signal;
+        return await new Promise<Response>((resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(new Error('fetch aborted')));
+          setTimeout(
+            () =>
+              resolve(
+                new Response(JSON.stringify({ results: [] }), {
+                  status: 200,
+                  headers: { 'Content-Type': 'application/json' },
+                })
+              ),
+            100
+          );
+        });
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(
+        Promise.race([
+          run(
+            [
+              {
+                assetPath: 'Assets/Character/body.png',
+                assetType: 'png',
+                filePath: assetFixturePath,
+              },
+            ],
+            { ...config, attributionTimeoutMs: 1 }
+          ),
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error('timeout was not enforced')), 50)
+          ),
+        ])
+      ).rejects.toThrow(
+        `Coupling ${name === 'score' ? 'forensic-score' : 'service scan'} timed out`
+      );
     });
   }
 

--- a/apps/api/src/lib/couplingForensicsService.test.ts
+++ b/apps/api/src/lib/couplingForensicsService.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import {
   type CouplingAttributionCandidate,
   type CouplingForensicsServiceConfig,
+  CouplingServiceConfigurationError,
   runCouplingAttribution,
 } from './couplingForensicsService';
 
@@ -117,6 +118,33 @@ describe('runCouplingAttribution', () => {
         { ...config, baseUrl: 'file:///tmp/coupling' }
       )
     ).rejects.toThrow('Coupling service base URL must use http or https');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves attribution URL configuration errors for route-level handling', async () => {
+    const fetchMock = mock(async () => {
+      throw new Error('Attribution must not fetch invalid service URLs');
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    let caught: unknown;
+    try {
+      await runCouplingAttribution(
+        [
+          {
+            assetPath: 'Assets/Character/body.png',
+            assetType: 'png',
+            filePath: assetFixturePath,
+          },
+        ],
+        candidates,
+        { ...config, baseUrl: 'file:///tmp/coupling' }
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(CouplingServiceConfigurationError);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/lib/couplingForensicsService.ts
+++ b/apps/api/src/lib/couplingForensicsService.ts
@@ -526,7 +526,10 @@ export async function runCouplingAttribution(
       clearTimeout(timeout);
     }
   } catch (error) {
-    if (error instanceof CouplingServiceRequestError) {
+    if (
+      error instanceof CouplingServiceRequestError ||
+      error instanceof CouplingServiceConfigurationError
+    ) {
       throw error;
     }
     const message = error instanceof Error ? error.message : String(error);

--- a/apps/api/src/lib/couplingForensicsService.ts
+++ b/apps/api/src/lib/couplingForensicsService.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { isIP } from 'node:net';
 import type { ExtractedForensicsAsset } from './couplingForensicsArchives';
@@ -5,6 +6,7 @@ import type { ExtractedForensicsAsset } from './couplingForensicsArchives';
 export type CouplingForensicsServiceConfig = {
   baseUrl: string;
   sharedSecret: string;
+  requestTimeoutMs?: number;
   attributionTimeoutMs?: number;
 };
 
@@ -26,6 +28,7 @@ export type ForensicsScoreResult = {
   tokenHex?: string;
   tokenLength?: number;
   matchedLicenseSubject?: string;
+  matchedCandidateAssetPath?: string;
   nativeCode?: number;
   decodeError?: string;
 };
@@ -302,6 +305,39 @@ function buildForensicScoreUrl(baseUrl: string): string {
   return buildCouplingServiceUrl(baseUrl, 'v1/coupling/forensic-score');
 }
 
+function resolveCouplingRequestTimeoutMs(config: CouplingForensicsServiceConfig): number {
+  const configured = config.requestTimeoutMs ?? config.attributionTimeoutMs;
+  if (typeof configured === 'number' && Number.isFinite(configured) && configured > 0) {
+    return Math.floor(configured);
+  }
+  return ATTRIBUTION_REQUEST_TIMEOUT_MS;
+}
+
+async function fetchCouplingServiceResponse(
+  input: string,
+  init: RequestInit,
+  config: CouplingForensicsServiceConfig,
+  timeoutMessage: string
+): Promise<{ response: Response; responseText: string }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), resolveCouplingRequestTimeoutMs(config));
+  try {
+    const response = await fetch(input, {
+      ...init,
+      signal: controller.signal,
+    });
+    const responseText = await response.text();
+    return { response, responseText };
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new CouplingServiceRequestError(timeoutMessage, 504);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 function validateForensicsScoreResult(
   input: ExtractedForensicsAsset[],
   payload: ForensicScoreServiceResponse
@@ -386,24 +422,35 @@ export async function runCouplingForensicsScore(
   }
 
   let response: Response;
+  let responseText: string;
   try {
-    response = await fetch(buildForensicScoreUrl(config.baseUrl), {
-      method: 'POST',
-      redirect: 'error',
-      headers: {
-        Accept: 'application/json',
-        Authorization: `Bearer ${sharedSecret}`,
-        'Cache-Control': 'no-store',
-        'Content-Type': 'application/json',
+    ({ response, responseText } = await fetchCouplingServiceResponse(
+      buildForensicScoreUrl(config.baseUrl),
+      {
+        method: 'POST',
+        redirect: 'error',
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${sharedSecret}`,
+          'Cache-Control': 'no-store',
+          'Content-Type': 'application/json',
+        },
+        body: await buildRequestBody(assets),
       },
-      body: await buildRequestBody(assets),
-    });
+      config,
+      'Coupling forensic-score timed out'
+    ));
   } catch (error) {
+    if (
+      error instanceof CouplingServiceRequestError ||
+      error instanceof CouplingServiceConfigurationError
+    ) {
+      throw error;
+    }
     const message = error instanceof Error ? error.message : String(error);
     throw new CouplingServiceRequestError(`Coupling service is unreachable: ${message}`, 503);
   }
 
-  const responseText = await response.text();
   const payload = parseResponsePayload(responseText) as ForensicScoreServiceResponse | null;
 
   if (!response.ok) {
@@ -444,6 +491,7 @@ type AttributeServiceResponse = {
     matched?: boolean;
     tokenHex?: string;
     matchedLicenseSubject?: string;
+    matchedCandidateAssetPath?: string;
     wmVersion?: number;
     attempted?: number;
   }>;
@@ -453,12 +501,12 @@ function buildAttributeUrl(baseUrl: string): string {
   return buildCouplingServiceUrl(baseUrl, 'v1/coupling/attribute');
 }
 
-function resolveAttributionTimeoutMs(config: CouplingForensicsServiceConfig): number {
-  const configured = config.attributionTimeoutMs;
-  if (typeof configured === 'number' && Number.isFinite(configured) && configured > 0) {
-    return Math.floor(configured);
-  }
-  return ATTRIBUTION_REQUEST_TIMEOUT_MS;
+function sha256HexFromString(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function buildAttributionCandidateKey(candidate: CouplingAttributionCandidate): string {
+  return `${candidate.assetPath.trim()}\0${candidate.licenseSubject.trim().toLowerCase()}\0${candidate.tokenHash.trim().toLowerCase()}`;
 }
 
 async function buildAttributeRequestBody(
@@ -485,9 +533,13 @@ async function buildAttributeRequestBody(
 
 function validateAttributionResult(
   input: ExtractedForensicsAsset[],
+  candidates: CouplingAttributionCandidate[],
   payload: AttributeServiceResponse
 ): ForensicsScoreResult[] {
   const assetByPath = buildAssetMapByPath(input, 'attribution input');
+  const candidateKeys = new Set(
+    candidates.map((candidate) => buildAttributionCandidateKey(candidate))
+  );
   const results = payload.results ?? [];
   const validatedResults = new Map<string, ForensicsScoreResult>();
 
@@ -507,27 +559,47 @@ function validateAttributionResult(
     const assetType = normalizeAssetType(entry.assetType || inputEntry.assetType);
     // Seed-iteration attribution decodes only when a candidate's re-derived seed matches, so a
     // matched asset is a recovered trace ('decoded'); anything else carries no usable signal.
-    if (entry.matched === true && entry.tokenHex) {
-      const tokenHex = entry.tokenHex.trim().toLowerCase();
-      if (HEX_RE.test(tokenHex) && tokenHex.length > 0) {
-        const matchedLicenseSubject = entry.matchedLicenseSubject?.trim().toLowerCase() || '';
-        if (!SHA256_HEX_RE.test(matchedLicenseSubject)) {
-          throw new CouplingServiceRequestError(
-            'Coupling service returned an invalid matched license subject',
-            502
-          );
-        }
-        validatedResults.set(assetPath, {
-          assetPath,
-          assetType,
-          decoderKind: assetType,
-          preclassification: 'decoded',
-          tokenHex,
-          tokenLength: tokenHex.length,
-          matchedLicenseSubject,
-        });
-        continue;
+    if (entry.matched === true) {
+      const tokenHex = entry.tokenHex?.trim().toLowerCase() || '';
+      if (!tokenHex || !HEX_RE.test(tokenHex)) {
+        throw new CouplingServiceRequestError('Coupling service returned an invalid token', 502);
       }
+      const matchedLicenseSubject = entry.matchedLicenseSubject?.trim().toLowerCase() || '';
+      if (!SHA256_HEX_RE.test(matchedLicenseSubject)) {
+        throw new CouplingServiceRequestError(
+          'Coupling service returned an invalid matched license subject',
+          502
+        );
+      }
+      const matchedCandidateAssetPath = entry.matchedCandidateAssetPath?.trim() || '';
+      if (!matchedCandidateAssetPath) {
+        throw new CouplingServiceRequestError(
+          'Coupling service returned an invalid matched candidate asset path',
+          502
+        );
+      }
+      const matchedCandidateKey = buildAttributionCandidateKey({
+        assetPath: matchedCandidateAssetPath,
+        licenseSubject: matchedLicenseSubject,
+        tokenHash: sha256HexFromString(tokenHex),
+      });
+      if (!candidateKeys.has(matchedCandidateKey)) {
+        throw new CouplingServiceRequestError(
+          'Coupling service returned an unknown matched candidate',
+          502
+        );
+      }
+      validatedResults.set(assetPath, {
+        assetPath,
+        assetType,
+        decoderKind: assetType,
+        preclassification: 'decoded',
+        tokenHex,
+        tokenLength: tokenHex.length,
+        matchedLicenseSubject,
+        matchedCandidateAssetPath,
+      });
+      continue;
     }
 
     validatedResults.set(assetPath, {
@@ -584,14 +656,13 @@ export async function runCouplingAttribution(
   }
 
   let response: Response;
+  let responseText: string;
   try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), resolveAttributionTimeoutMs(config));
-    try {
-      response = await fetch(buildAttributeUrl(config.baseUrl), {
+    ({ response, responseText } = await fetchCouplingServiceResponse(
+      buildAttributeUrl(config.baseUrl),
+      {
         method: 'POST',
         redirect: 'error',
-        signal: controller.signal,
         headers: {
           Accept: 'application/json',
           Authorization: `Bearer ${sharedSecret}`,
@@ -599,15 +670,10 @@ export async function runCouplingAttribution(
           'Content-Type': 'application/json',
         },
         body: await buildAttributeRequestBody(assets, candidates),
-      });
-    } catch (error) {
-      if (controller.signal.aborted) {
-        throw new CouplingServiceRequestError('Coupling attribution timed out', 504);
-      }
-      throw error;
-    } finally {
-      clearTimeout(timeout);
-    }
+      },
+      config,
+      'Coupling attribution timed out'
+    ));
   } catch (error) {
     if (
       error instanceof CouplingServiceRequestError ||
@@ -619,7 +685,6 @@ export async function runCouplingAttribution(
     throw new CouplingServiceRequestError(`Coupling service is unreachable: ${message}`, 503);
   }
 
-  const responseText = await response.text();
   const payload = parseResponsePayload(responseText) as AttributeServiceResponse | null;
 
   if (!response.ok) {
@@ -637,7 +702,7 @@ export async function runCouplingAttribution(
     );
   }
 
-  return validateAttributionResult(assets, payload);
+  return validateAttributionResult(assets, candidates, payload);
 }
 
 export async function runCouplingForensicsScan(
@@ -654,24 +719,35 @@ export async function runCouplingForensicsScan(
   }
 
   let response: Response;
+  let responseText: string;
   try {
-    response = await fetch(buildCouplingScanUrl(config.baseUrl), {
-      method: 'POST',
-      redirect: 'error',
-      headers: {
-        Accept: 'application/json',
-        Authorization: `Bearer ${sharedSecret}`,
-        'Cache-Control': 'no-store',
-        'Content-Type': 'application/json',
+    ({ response, responseText } = await fetchCouplingServiceResponse(
+      buildCouplingScanUrl(config.baseUrl),
+      {
+        method: 'POST',
+        redirect: 'error',
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${sharedSecret}`,
+          'Cache-Control': 'no-store',
+          'Content-Type': 'application/json',
+        },
+        body: await buildRequestBody(assets),
       },
-      body: await buildRequestBody(assets),
-    });
+      config,
+      'Coupling service scan timed out'
+    ));
   } catch (error) {
+    if (
+      error instanceof CouplingServiceRequestError ||
+      error instanceof CouplingServiceConfigurationError
+    ) {
+      throw error;
+    }
     const message = error instanceof Error ? error.message : String(error);
     throw new CouplingServiceRequestError(`Coupling service is unreachable: ${message}`, 503);
   }
 
-  const responseText = await response.text();
   const payload = parseResponsePayload(responseText);
 
   if (!response.ok) {

--- a/apps/api/src/lib/couplingForensicsService.ts
+++ b/apps/api/src/lib/couplingForensicsService.ts
@@ -8,6 +8,7 @@ export type CouplingForensicsServiceConfig = {
   sharedSecret: string;
   requestTimeoutMs?: number;
   attributionTimeoutMs?: number;
+  responseMaxBytes?: number;
 };
 
 export type CouplingForensicsFinding = {
@@ -72,6 +73,7 @@ type ForensicScoreServiceResponse = {
 const HEX_RE = /^[0-9a-f]+$/;
 const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
 const ATTRIBUTION_REQUEST_TIMEOUT_MS = 15_000;
+const COUPLING_SERVICE_RESPONSE_MAX_BYTES = 1024 * 1024;
 const METADATA_SERVICE_HOSTS = new Set([
   '169.254.169.254',
   'fd00:ec2::254',
@@ -205,7 +207,15 @@ function isLinkLocalIp(hostname: string): boolean {
   if (hostname.startsWith('169.254.')) {
     return true;
   }
-  return hostname === '::ffff:169.254.169.254' || hostname.toLowerCase().startsWith('fe80:');
+  return hostname === '::ffff:169.254.169.254' || isIpv6LinkLocal(hostname);
+}
+
+function isIpv6LinkLocal(hostname: string): boolean {
+  const firstHextet = hostname.toLowerCase().split(':', 1)[0] ?? '';
+  if (!/^[0-9a-f]{1,4}$/.test(firstHextet)) {
+    return false;
+  }
+  return (Number.parseInt(firstHextet, 16) & 0xffc0) === 0xfe80;
 }
 
 function buildCouplingScanUrl(baseUrl: string): string {
@@ -217,7 +227,7 @@ function validateCouplingScanResult(
   payload: CouplingServiceResponse
 ): CouplingForensicsFinding[] {
   const assetByPath = new Map(input.map((entry) => [entry.assetPath, entry]));
-  const results = payload.results ?? [];
+  const results = getServiceResults(payload);
   return results.map((entry) => {
     const assetPath = entry.assetPath?.trim() || '';
     const tokenHex = entry.tokenHex?.trim().toLowerCase() || '';
@@ -301,32 +311,92 @@ function extractCouplingServiceErrorDetail(
   return responseText.trim() || statusText.trim();
 }
 
+function getServiceResults<T>(payload: { results?: T[] }): T[] {
+  if (payload.results === undefined) {
+    return [];
+  }
+  if (!Array.isArray(payload.results)) {
+    throw new CouplingServiceRequestError('Coupling service returned invalid results', 502);
+  }
+  return payload.results;
+}
+
 function buildForensicScoreUrl(baseUrl: string): string {
   return buildCouplingServiceUrl(baseUrl, 'v1/coupling/forensic-score');
 }
 
-function resolveCouplingRequestTimeoutMs(config: CouplingForensicsServiceConfig): number {
-  const configured = config.requestTimeoutMs ?? config.attributionTimeoutMs;
+function resolveCouplingRequestTimeoutMs(configured?: number): number {
   if (typeof configured === 'number' && Number.isFinite(configured) && configured > 0) {
     return Math.floor(configured);
   }
   return ATTRIBUTION_REQUEST_TIMEOUT_MS;
 }
 
+function resolveCouplingResponseMaxBytes(config: CouplingForensicsServiceConfig): number {
+  const configured = config.responseMaxBytes;
+  if (typeof configured === 'number' && Number.isFinite(configured) && configured > 0) {
+    return Math.floor(configured);
+  }
+  return COUPLING_SERVICE_RESPONSE_MAX_BYTES;
+}
+
+async function readResponseTextWithLimit(response: Response, maxBytes: number): Promise<string> {
+  if (!response.body) {
+    return '';
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value) {
+        continue;
+      }
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        throw new CouplingServiceRequestError('Coupling service response is too large', 502);
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => undefined);
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(bytes);
+}
+
 async function fetchCouplingServiceResponse(
   input: string,
   init: RequestInit,
   config: CouplingForensicsServiceConfig,
-  timeoutMessage: string
+  timeoutMessage: string,
+  timeoutMs?: number
 ): Promise<{ response: Response; responseText: string }> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), resolveCouplingRequestTimeoutMs(config));
+  const timeout = setTimeout(() => controller.abort(), resolveCouplingRequestTimeoutMs(timeoutMs));
   try {
     const response = await fetch(input, {
       ...init,
       signal: controller.signal,
     });
-    const responseText = await response.text();
+    const responseText = await readResponseTextWithLimit(
+      response,
+      resolveCouplingResponseMaxBytes(config)
+    );
     return { response, responseText };
   } catch (error) {
     if (controller.signal.aborted) {
@@ -343,7 +413,7 @@ function validateForensicsScoreResult(
   payload: ForensicScoreServiceResponse
 ): ForensicsScoreResult[] {
   const assetByPath = new Map(input.map((entry) => [entry.assetPath, entry]));
-  const results = payload.results ?? [];
+  const results = getServiceResults(payload);
   const validatedResults = new Map<string, ForensicsScoreResult>();
 
   for (const entry of results) {
@@ -438,7 +508,8 @@ export async function runCouplingForensicsScore(
         body: await buildRequestBody(assets),
       },
       config,
-      'Coupling forensic-score timed out'
+      'Coupling forensic-score timed out',
+      config.requestTimeoutMs
     ));
   } catch (error) {
     if (
@@ -447,8 +518,7 @@ export async function runCouplingForensicsScore(
     ) {
       throw error;
     }
-    const message = error instanceof Error ? error.message : String(error);
-    throw new CouplingServiceRequestError(`Coupling service is unreachable: ${message}`, 503);
+    throw new CouplingServiceRequestError('Coupling service is unreachable', 503);
   }
 
   const payload = parseResponsePayload(responseText) as ForensicScoreServiceResponse | null;
@@ -540,7 +610,7 @@ function validateAttributionResult(
   const candidateKeys = new Set(
     candidates.map((candidate) => buildAttributionCandidateKey(candidate))
   );
-  const results = payload.results ?? [];
+  const results = getServiceResults(payload);
   const validatedResults = new Map<string, ForensicsScoreResult>();
 
   for (const entry of results) {
@@ -672,7 +742,8 @@ export async function runCouplingAttribution(
         body: await buildAttributeRequestBody(assets, candidates),
       },
       config,
-      'Coupling attribution timed out'
+      'Coupling attribution timed out',
+      config.attributionTimeoutMs ?? config.requestTimeoutMs
     ));
   } catch (error) {
     if (
@@ -681,8 +752,7 @@ export async function runCouplingAttribution(
     ) {
       throw error;
     }
-    const message = error instanceof Error ? error.message : String(error);
-    throw new CouplingServiceRequestError(`Coupling service is unreachable: ${message}`, 503);
+    throw new CouplingServiceRequestError('Coupling service is unreachable', 503);
   }
 
   const payload = parseResponsePayload(responseText) as AttributeServiceResponse | null;
@@ -735,7 +805,8 @@ export async function runCouplingForensicsScan(
         body: await buildRequestBody(assets),
       },
       config,
-      'Coupling service scan timed out'
+      'Coupling service scan timed out',
+      config.requestTimeoutMs
     ));
   } catch (error) {
     if (
@@ -744,8 +815,7 @@ export async function runCouplingForensicsScan(
     ) {
       throw error;
     }
-    const message = error instanceof Error ? error.message : String(error);
-    throw new CouplingServiceRequestError(`Coupling service is unreachable: ${message}`, 503);
+    throw new CouplingServiceRequestError('Coupling service is unreachable', 503);
   }
 
   const payload = parseResponsePayload(responseText);

--- a/apps/api/src/lib/couplingForensicsService.ts
+++ b/apps/api/src/lib/couplingForensicsService.ts
@@ -1,9 +1,11 @@
 import { readFile } from 'node:fs/promises';
+import { isIP } from 'node:net';
 import type { ExtractedForensicsAsset } from './couplingForensicsArchives';
 
 export type CouplingForensicsServiceConfig = {
   baseUrl: string;
   sharedSecret: string;
+  attributionTimeoutMs?: number;
 };
 
 export type CouplingForensicsFinding = {
@@ -65,6 +67,11 @@ type ForensicScoreServiceResponse = {
 
 const HEX_RE = /^[0-9a-f]+$/;
 const ATTRIBUTION_REQUEST_TIMEOUT_MS = 15_000;
+const METADATA_SERVICE_HOSTS = new Set([
+  '169.254.169.254',
+  'metadata.google.internal',
+  'metadata.azure.internal',
+]);
 
 export class CouplingServiceConfigurationError extends Error {
   constructor(message: string) {
@@ -122,7 +129,26 @@ function buildCouplingServiceUrl(baseUrl: string, path: string): string {
       'Coupling service base URL must not include credentials'
     );
   }
+  assertAllowedCouplingServiceHost(url);
   return url.toString();
+}
+
+function assertAllowedCouplingServiceHost(url: URL): void {
+  const hostname = url.hostname.toLowerCase();
+  if (METADATA_SERVICE_HOSTS.has(hostname) || hostname === '100.100.100.200') {
+    throw new CouplingServiceConfigurationError('Coupling service base URL host is not allowed');
+  }
+
+  if (isIP(hostname) && isLinkLocalIp(hostname)) {
+    throw new CouplingServiceConfigurationError('Coupling service base URL host is not allowed');
+  }
+}
+
+function isLinkLocalIp(hostname: string): boolean {
+  if (hostname.startsWith('169.254.')) {
+    return true;
+  }
+  return hostname === '::ffff:169.254.169.254' || hostname.toLowerCase().startsWith('fe80:');
 }
 
 function buildCouplingScanUrl(baseUrl: string): string {
@@ -321,6 +347,7 @@ export async function runCouplingForensicsScore(
   try {
     response = await fetch(buildForensicScoreUrl(config.baseUrl), {
       method: 'POST',
+      redirect: 'error',
       headers: {
         Accept: 'application/json',
         Authorization: `Bearer ${sharedSecret}`,
@@ -382,6 +409,14 @@ type AttributeServiceResponse = {
 
 function buildAttributeUrl(baseUrl: string): string {
   return buildCouplingServiceUrl(baseUrl, 'v1/coupling/attribute');
+}
+
+function resolveAttributionTimeoutMs(config: CouplingForensicsServiceConfig): number {
+  const configured = config.attributionTimeoutMs;
+  if (typeof configured === 'number' && Number.isFinite(configured) && configured > 0) {
+    return Math.floor(configured);
+  }
+  return ATTRIBUTION_REQUEST_TIMEOUT_MS;
 }
 
 async function buildAttributeRequestBody(
@@ -503,7 +538,7 @@ export async function runCouplingAttribution(
   let response: Response;
   try {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), ATTRIBUTION_REQUEST_TIMEOUT_MS);
+    const timeout = setTimeout(() => controller.abort(), resolveAttributionTimeoutMs(config));
     try {
       response = await fetch(buildAttributeUrl(config.baseUrl), {
         method: 'POST',
@@ -574,6 +609,7 @@ export async function runCouplingForensicsScan(
   try {
     response = await fetch(buildCouplingScanUrl(config.baseUrl), {
       method: 'POST',
+      redirect: 'error',
       headers: {
         Accept: 'application/json',
         Authorization: `Bearer ${sharedSecret}`,

--- a/apps/api/src/lib/couplingForensicsService.ts
+++ b/apps/api/src/lib/couplingForensicsService.ts
@@ -25,6 +25,7 @@ export type ForensicsScoreResult = {
   preclassification: ForensicPreclassification;
   tokenHex?: string;
   tokenLength?: number;
+  matchedLicenseSubject?: string;
   nativeCode?: number;
   decodeError?: string;
 };
@@ -66,6 +67,7 @@ type ForensicScoreServiceResponse = {
 };
 
 const HEX_RE = /^[0-9a-f]+$/;
+const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
 const ATTRIBUTION_REQUEST_TIMEOUT_MS = 15_000;
 const METADATA_SERVICE_HOSTS = new Set([
   '169.254.169.254',
@@ -522,6 +524,13 @@ function validateAttributionResult(
     if (entry.matched === true && entry.tokenHex) {
       const tokenHex = entry.tokenHex.trim().toLowerCase();
       if (HEX_RE.test(tokenHex) && tokenHex.length > 0) {
+        const matchedLicenseSubject = entry.matchedLicenseSubject?.trim().toLowerCase() || '';
+        if (!SHA256_HEX_RE.test(matchedLicenseSubject)) {
+          throw new CouplingServiceRequestError(
+            `Coupling service returned an invalid matched license subject for ${assetPath}`,
+            502
+          );
+        }
         validatedResults.set(assetPath, {
           assetPath,
           assetType,
@@ -529,6 +538,7 @@ function validateAttributionResult(
           preclassification: 'decoded',
           tokenHex,
           tokenLength: tokenHex.length,
+          matchedLicenseSubject,
         });
         continue;
       }
@@ -559,9 +569,10 @@ function validateAttributionResult(
 /**
  * Forensic attribution: ask the closed coupling service to decode each leaked asset by iterating
  * the supplied buyer candidates (it re-derives each per-job placement seed from the recorded
- * assetPath + licenseSubject). A matched asset comes back as a recovered trace with its token; the
- * caller turns that token into a tokenHash for identity enrichment. No watermark secrets leave the
- * service — only candidate (assetPath, licenseSubject, tokenHash) tuples go in.
+ * assetPath + licenseSubject). A matched asset comes back as a recovered trace with its token and
+ * matched subject; the caller turns that into an exact candidate lookup for identity enrichment.
+ * No watermark secrets leave the service; only candidate (assetPath, licenseSubject, tokenHash)
+ * tuples go in.
  */
 export async function runCouplingAttribution(
   assets: ExtractedForensicsAsset[],

--- a/apps/api/src/lib/couplingForensicsService.ts
+++ b/apps/api/src/lib/couplingForensicsService.ts
@@ -331,6 +331,192 @@ export async function runCouplingForensicsScore(
   return validateForensicsScoreResult(assets, payload);
 }
 
+export type CouplingAttributionCandidate = {
+  assetPath: string;
+  licenseSubject: string;
+  tokenHash: string;
+};
+
+type AttributeServiceResponse = {
+  error?:
+    | string
+    | {
+        code?: unknown;
+        message?: unknown;
+      };
+  requestId?: string;
+  results?: Array<{
+    assetPath?: string;
+    assetType?: string;
+    matched?: boolean;
+    tokenHex?: string;
+    matchedLicenseSubject?: string;
+    wmVersion?: number;
+    attempted?: number;
+  }>;
+};
+
+function buildAttributeUrl(baseUrl: string): string {
+  const normalizedBaseUrl = baseUrl.trim();
+  if (!normalizedBaseUrl) {
+    throw new CouplingServiceConfigurationError('Coupling service base URL is not configured');
+  }
+  return new URL('v1/coupling/attribute', `${normalizedBaseUrl.replace(/\/$/, '')}/`).toString();
+}
+
+async function buildAttributeRequestBody(
+  assets: ExtractedForensicsAsset[],
+  candidates: CouplingAttributionCandidate[]
+): Promise<string> {
+  const serializedAssets = await Promise.all(
+    assets.map(async (asset) => ({
+      assetPath: asset.assetPath,
+      assetType: asset.assetType,
+      contentBase64: Buffer.from(await readFile(asset.filePath)).toString('base64'),
+    }))
+  );
+
+  return JSON.stringify({
+    assets: serializedAssets,
+    candidates: candidates.map((candidate) => ({
+      assetPath: candidate.assetPath,
+      licenseSubject: candidate.licenseSubject,
+      tokenHash: candidate.tokenHash,
+    })),
+  });
+}
+
+function validateAttributionResult(
+  input: ExtractedForensicsAsset[],
+  payload: AttributeServiceResponse
+): ForensicsScoreResult[] {
+  const assetByPath = new Map(input.map((entry) => [entry.assetPath, entry]));
+  const results = payload.results ?? [];
+  const validatedResults = new Map<string, ForensicsScoreResult>();
+
+  for (const entry of results) {
+    const assetPath = entry.assetPath?.trim() || '';
+    const inputEntry = assetByPath.get(assetPath);
+    if (!inputEntry) {
+      throw new CouplingServiceRequestError(
+        `Coupling service returned an unknown asset path: ${assetPath || '[missing]'}`,
+        502
+      );
+    }
+    if (validatedResults.has(assetPath)) {
+      throw new CouplingServiceRequestError(
+        `Coupling service returned a duplicate asset path: ${assetPath}`,
+        502
+      );
+    }
+
+    const assetType = normalizeAssetType(entry.assetType || inputEntry.assetType);
+    // Seed-iteration attribution decodes only when a candidate's re-derived seed matches, so a
+    // matched asset is a recovered trace ('decoded'); anything else carries no usable signal.
+    if (entry.matched === true && entry.tokenHex) {
+      const tokenHex = entry.tokenHex.trim().toLowerCase();
+      if (HEX_RE.test(tokenHex) && tokenHex.length > 0) {
+        validatedResults.set(assetPath, {
+          assetPath,
+          assetType,
+          decoderKind: assetType,
+          preclassification: 'decoded',
+          tokenHex,
+          tokenLength: tokenHex.length,
+        });
+        continue;
+      }
+    }
+
+    validatedResults.set(assetPath, {
+      assetPath,
+      assetType,
+      decoderKind: assetType,
+      preclassification: 'no-signal',
+    });
+  }
+
+  return input.map((asset) => {
+    const existing = validatedResults.get(asset.assetPath);
+    if (existing) {
+      return existing;
+    }
+    return {
+      assetPath: asset.assetPath,
+      assetType: asset.assetType,
+      decoderKind: asset.assetType,
+      preclassification: 'no-signal',
+    };
+  });
+}
+
+/**
+ * Forensic attribution: ask the closed coupling service to decode each leaked asset by iterating
+ * the supplied buyer candidates (it re-derives each per-job placement seed from the recorded
+ * assetPath + licenseSubject). A matched asset comes back as a recovered trace with its token; the
+ * caller turns that token into a tokenHash for identity enrichment. No watermark secrets leave the
+ * service — only candidate (assetPath, licenseSubject, tokenHash) tuples go in.
+ */
+export async function runCouplingAttribution(
+  assets: ExtractedForensicsAsset[],
+  candidates: CouplingAttributionCandidate[],
+  config: CouplingForensicsServiceConfig
+): Promise<ForensicsScoreResult[]> {
+  if (assets.length === 0) {
+    return [];
+  }
+  if (candidates.length === 0) {
+    return assets.map((asset) => ({
+      assetPath: asset.assetPath,
+      assetType: asset.assetType,
+      decoderKind: asset.assetType,
+      preclassification: 'no-signal',
+    }));
+  }
+
+  const sharedSecret = config.sharedSecret.trim();
+  if (!sharedSecret) {
+    throw new CouplingServiceConfigurationError('Coupling service shared secret is not configured');
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(buildAttributeUrl(config.baseUrl), {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${sharedSecret}`,
+        'Cache-Control': 'no-store',
+        'Content-Type': 'application/json',
+      },
+      body: await buildAttributeRequestBody(assets, candidates),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new CouplingServiceRequestError(`Coupling service is unreachable: ${message}`, 503);
+  }
+
+  const responseText = await response.text();
+  const payload = parseResponsePayload(responseText) as AttributeServiceResponse | null;
+
+  if (!response.ok) {
+    const detail = extractCouplingServiceErrorDetail(payload, responseText, response.statusText);
+    throw new CouplingServiceRequestError(
+      `Coupling attribution failed with status ${response.status}${detail ? `: ${detail}` : ''}`,
+      response.status
+    );
+  }
+
+  if (!payload) {
+    throw new CouplingServiceRequestError(
+      'Coupling service returned invalid JSON',
+      response.status
+    );
+  }
+
+  return validateAttributionResult(assets, payload);
+}
+
 export async function runCouplingForensicsScan(
   assets: ExtractedForensicsAsset[],
   config: CouplingForensicsServiceConfig

--- a/apps/api/src/lib/couplingForensicsService.ts
+++ b/apps/api/src/lib/couplingForensicsService.ts
@@ -64,6 +64,7 @@ type ForensicScoreServiceResponse = {
 };
 
 const HEX_RE = /^[0-9a-f]+$/;
+const ATTRIBUTION_REQUEST_TIMEOUT_MS = 15_000;
 
 export class CouplingServiceConfigurationError extends Error {
   constructor(message: string) {
@@ -90,12 +91,42 @@ function normalizeAssetType(value: string): 'png' | 'fbx' {
   return normalized;
 }
 
-function buildCouplingScanUrl(baseUrl: string): string {
+function buildAssetMapByPath(
+  input: ExtractedForensicsAsset[],
+  duplicateContext: string
+): Map<string, ExtractedForensicsAsset> {
+  const assetByPath = new Map<string, ExtractedForensicsAsset>();
+  for (const entry of input) {
+    if (assetByPath.has(entry.assetPath)) {
+      throw new CouplingServiceRequestError(
+        `Duplicate asset path in ${duplicateContext}: ${entry.assetPath}`,
+        502
+      );
+    }
+    assetByPath.set(entry.assetPath, entry);
+  }
+  return assetByPath;
+}
+
+function buildCouplingServiceUrl(baseUrl: string, path: string): string {
   const normalizedBaseUrl = baseUrl.trim();
   if (!normalizedBaseUrl) {
     throw new CouplingServiceConfigurationError('Coupling service base URL is not configured');
   }
-  return new URL('v1/coupling/scan', `${normalizedBaseUrl.replace(/\/$/, '')}/`).toString();
+  const url = new URL(path, `${normalizedBaseUrl.replace(/\/$/, '')}/`);
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new CouplingServiceConfigurationError('Coupling service base URL must use http or https');
+  }
+  if (url.username || url.password) {
+    throw new CouplingServiceConfigurationError(
+      'Coupling service base URL must not include credentials'
+    );
+  }
+  return url.toString();
+}
+
+function buildCouplingScanUrl(baseUrl: string): string {
+  return buildCouplingServiceUrl(baseUrl, 'v1/coupling/scan');
 }
 
 function validateCouplingScanResult(
@@ -197,14 +228,7 @@ function extractCouplingServiceErrorDetail(
 }
 
 function buildForensicScoreUrl(baseUrl: string): string {
-  const normalizedBaseUrl = baseUrl.trim();
-  if (!normalizedBaseUrl) {
-    throw new CouplingServiceConfigurationError('Coupling service base URL is not configured');
-  }
-  return new URL(
-    'v1/coupling/forensic-score',
-    `${normalizedBaseUrl.replace(/\/$/, '')}/`
-  ).toString();
+  return buildCouplingServiceUrl(baseUrl, 'v1/coupling/forensic-score');
 }
 
 function validateForensicsScoreResult(
@@ -357,11 +381,7 @@ type AttributeServiceResponse = {
 };
 
 function buildAttributeUrl(baseUrl: string): string {
-  const normalizedBaseUrl = baseUrl.trim();
-  if (!normalizedBaseUrl) {
-    throw new CouplingServiceConfigurationError('Coupling service base URL is not configured');
-  }
-  return new URL('v1/coupling/attribute', `${normalizedBaseUrl.replace(/\/$/, '')}/`).toString();
+  return buildCouplingServiceUrl(baseUrl, 'v1/coupling/attribute');
 }
 
 async function buildAttributeRequestBody(
@@ -390,7 +410,7 @@ function validateAttributionResult(
   input: ExtractedForensicsAsset[],
   payload: AttributeServiceResponse
 ): ForensicsScoreResult[] {
-  const assetByPath = new Map(input.map((entry) => [entry.assetPath, entry]));
+  const assetByPath = buildAssetMapByPath(input, 'attribution input');
   const results = payload.results ?? [];
   const validatedResults = new Map<string, ForensicsScoreResult>();
 
@@ -473,6 +493,7 @@ export async function runCouplingAttribution(
       preclassification: 'no-signal',
     }));
   }
+  buildAssetMapByPath(assets, 'attribution input');
 
   const sharedSecret = config.sharedSecret.trim();
   if (!sharedSecret) {
@@ -481,17 +502,33 @@ export async function runCouplingAttribution(
 
   let response: Response;
   try {
-    response = await fetch(buildAttributeUrl(config.baseUrl), {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        Authorization: `Bearer ${sharedSecret}`,
-        'Cache-Control': 'no-store',
-        'Content-Type': 'application/json',
-      },
-      body: await buildAttributeRequestBody(assets, candidates),
-    });
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), ATTRIBUTION_REQUEST_TIMEOUT_MS);
+    try {
+      response = await fetch(buildAttributeUrl(config.baseUrl), {
+        method: 'POST',
+        redirect: 'error',
+        signal: controller.signal,
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${sharedSecret}`,
+          'Cache-Control': 'no-store',
+          'Content-Type': 'application/json',
+        },
+        body: await buildAttributeRequestBody(assets, candidates),
+      });
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw new CouplingServiceRequestError('Coupling attribution timed out', 504);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
   } catch (error) {
+    if (error instanceof CouplingServiceRequestError) {
+      throw error;
+    }
     const message = error instanceof Error ? error.message : String(error);
     throw new CouplingServiceRequestError(`Coupling service is unreachable: ${message}`, 503);
   }

--- a/apps/api/src/lib/couplingForensicsService.ts
+++ b/apps/api/src/lib/couplingForensicsService.ts
@@ -153,7 +153,10 @@ function isDeniedMetadataHostname(hostname: string): boolean {
 }
 
 function normalizeUrlHostname(hostname: string): string {
-  const normalized = hostname.toLowerCase();
+  let normalized = hostname.toLowerCase();
+  while (normalized.endsWith('.')) {
+    normalized = normalized.slice(0, -1);
+  }
   if (normalized.startsWith('[') && normalized.endsWith(']')) {
     return normalized.slice(1, -1);
   }

--- a/apps/api/src/lib/couplingForensicsService.ts
+++ b/apps/api/src/lib/couplingForensicsService.ts
@@ -221,22 +221,13 @@ function validateCouplingScanResult(
     const tokenLength = Number(entry.tokenLength ?? 0);
     const inputEntry = assetByPath.get(assetPath);
     if (!inputEntry) {
-      throw new CouplingServiceRequestError(
-        `Coupling service returned an unknown asset path: ${assetPath || '[missing]'}`,
-        502
-      );
+      throw new CouplingServiceRequestError('Coupling service returned an unknown asset path', 502);
     }
     if (!tokenHex || !HEX_RE.test(tokenHex)) {
-      throw new CouplingServiceRequestError(
-        `Coupling service returned an invalid token for ${assetPath}`,
-        502
-      );
+      throw new CouplingServiceRequestError('Coupling service returned an invalid token', 502);
     }
     if (tokenLength <= 0 || tokenHex.length !== tokenLength) {
-      throw new CouplingServiceRequestError(
-        `Coupling service token length mismatch for ${assetPath}`,
-        502
-      );
+      throw new CouplingServiceRequestError('Coupling service token length mismatch', 502);
     }
     return {
       assetPath,
@@ -323,14 +314,11 @@ function validateForensicsScoreResult(
     const assetPath = entry.assetPath?.trim() || '';
     const inputEntry = assetByPath.get(assetPath);
     if (!inputEntry) {
-      throw new CouplingServiceRequestError(
-        `Coupling service returned an unknown asset path: ${assetPath || '[missing]'}`,
-        502
-      );
+      throw new CouplingServiceRequestError('Coupling service returned an unknown asset path', 502);
     }
     if (validatedResults.has(assetPath)) {
       throw new CouplingServiceRequestError(
-        `Coupling service returned a duplicate asset path: ${assetPath}`,
+        'Coupling service returned a duplicate asset path',
         502
       );
     }
@@ -507,14 +495,11 @@ function validateAttributionResult(
     const assetPath = entry.assetPath?.trim() || '';
     const inputEntry = assetByPath.get(assetPath);
     if (!inputEntry) {
-      throw new CouplingServiceRequestError(
-        `Coupling service returned an unknown asset path: ${assetPath || '[missing]'}`,
-        502
-      );
+      throw new CouplingServiceRequestError('Coupling service returned an unknown asset path', 502);
     }
     if (validatedResults.has(assetPath)) {
       throw new CouplingServiceRequestError(
-        `Coupling service returned a duplicate asset path: ${assetPath}`,
+        'Coupling service returned a duplicate asset path',
         502
       );
     }

--- a/apps/api/src/lib/couplingForensicsService.ts
+++ b/apps/api/src/lib/couplingForensicsService.ts
@@ -527,7 +527,7 @@ function validateAttributionResult(
         const matchedLicenseSubject = entry.matchedLicenseSubject?.trim().toLowerCase() || '';
         if (!SHA256_HEX_RE.test(matchedLicenseSubject)) {
           throw new CouplingServiceRequestError(
-            `Coupling service returned an invalid matched license subject for ${assetPath}`,
+            'Coupling service returned an invalid matched license subject',
             502
           );
         }

--- a/apps/api/src/lib/couplingForensicsService.ts
+++ b/apps/api/src/lib/couplingForensicsService.ts
@@ -134,14 +134,62 @@ function buildCouplingServiceUrl(baseUrl: string, path: string): string {
 }
 
 function assertAllowedCouplingServiceHost(url: URL): void {
-  const hostname = url.hostname.toLowerCase();
-  if (METADATA_SERVICE_HOSTS.has(hostname) || hostname === '100.100.100.200') {
+  const hostname = normalizeUrlHostname(url.hostname);
+  const mappedIpv4Hostname = parseIpv4MappedIpv6Hostname(hostname);
+  if (
+    isDeniedMetadataHostname(hostname) ||
+    (mappedIpv4Hostname && isDeniedMetadataHostname(mappedIpv4Hostname))
+  ) {
     throw new CouplingServiceConfigurationError('Coupling service base URL host is not allowed');
   }
 
-  if (isIP(hostname) && isLinkLocalIp(hostname)) {
+  if (isIP(hostname) && isLinkLocalIp(mappedIpv4Hostname ?? hostname)) {
     throw new CouplingServiceConfigurationError('Coupling service base URL host is not allowed');
   }
+}
+
+function isDeniedMetadataHostname(hostname: string): boolean {
+  return METADATA_SERVICE_HOSTS.has(hostname) || hostname === '100.100.100.200';
+}
+
+function normalizeUrlHostname(hostname: string): string {
+  const normalized = hostname.toLowerCase();
+  if (normalized.startsWith('[') && normalized.endsWith(']')) {
+    return normalized.slice(1, -1);
+  }
+  return normalized;
+}
+
+function parseIpv4MappedIpv6Hostname(hostname: string): string | null {
+  if (!hostname.startsWith('::ffff:')) {
+    return null;
+  }
+
+  const suffix = hostname.slice('::ffff:'.length);
+  if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(suffix)) {
+    return suffix;
+  }
+
+  const hextets = suffix.split(':');
+  if (hextets.length !== 2) {
+    return null;
+  }
+  const parsed = hextets.map((hextet) => Number.parseInt(hextet, 16));
+  if (
+    parsed.some(
+      (value, index) =>
+        !/^[0-9a-f]{1,4}$/.test(hextets[index] ?? '') || !Number.isFinite(value) || value < 0
+    )
+  ) {
+    return null;
+  }
+
+  return [
+    (parsed[0] ?? 0) >> 8,
+    (parsed[0] ?? 0) & 0xff,
+    (parsed[1] ?? 0) >> 8,
+    (parsed[1] ?? 0) & 0xff,
+  ].join('.');
 }
 
 function isLinkLocalIp(hostname: string): boolean {

--- a/apps/api/src/lib/couplingForensicsService.ts
+++ b/apps/api/src/lib/couplingForensicsService.ts
@@ -71,6 +71,7 @@ const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
 const ATTRIBUTION_REQUEST_TIMEOUT_MS = 15_000;
 const METADATA_SERVICE_HOSTS = new Set([
   '169.254.169.254',
+  'fd00:ec2::254',
   'metadata.google.internal',
   'metadata.azure.internal',
 ]);

--- a/apps/api/src/lib/requestBody.ts
+++ b/apps/api/src/lib/requestBody.ts
@@ -11,16 +11,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-export async function readRequestTextWithLimit(
+export async function readRequestBytesWithLimit(
   request: Request,
   maxBytes: number
-): Promise<string> {
+): Promise<Uint8Array> {
   const contentLength = Number.parseInt(request.headers.get('content-length') ?? '', 10);
   if (Number.isFinite(contentLength) && contentLength > maxBytes) {
     throw new RequestBodyError('Request body too large', 413);
   }
   if (!request.body) {
-    return '';
+    return new Uint8Array();
   }
 
   const reader = request.body.getReader();
@@ -48,6 +48,14 @@ export async function readRequestTextWithLimit(
     bodyBytes.set(chunk, offset);
     offset += chunk.byteLength;
   }
+  return bodyBytes;
+}
+
+export async function readRequestTextWithLimit(
+  request: Request,
+  maxBytes: number
+): Promise<string> {
+  const bodyBytes = await readRequestBytesWithLimit(request, maxBytes);
   return new TextDecoder().decode(bodyBytes);
 }
 

--- a/apps/api/src/routes/forensics.logging.test.ts
+++ b/apps/api/src/routes/forensics.logging.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { createHash } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import type { Auth } from '../auth';
+
+const apiMock = {
+  couplingForensics: {
+    listCouplingTraceCandidatesForAuthUser:
+      'couplingForensics.listCouplingTraceCandidatesForAuthUser',
+    lookupTraceMatchesForAuthUser: 'couplingForensics.lookupTraceMatchesForAuthUser',
+    recordLookupAudit: 'couplingForensics.recordLookupAudit',
+  },
+} as const;
+
+const queryMock = mock(async (_ref: unknown, _args?: unknown): Promise<unknown> => undefined);
+const mutationMock = mock(async (_ref: unknown, _args?: unknown): Promise<unknown> => undefined);
+const loggerErrorMock = mock((_message: string, _metadata?: Record<string, unknown>) => {});
+const loggerInfoMock = mock((_message: string, _metadata?: Record<string, unknown>) => {});
+const loggerWarnMock = mock((_message: string, _metadata?: Record<string, unknown>) => {});
+const loggerDebugMock = mock((_message: string, _metadata?: Record<string, unknown>) => {});
+const unsafeAssetPath = 'Assets/Customers/buyer@example.com/private.png';
+
+class MockCouplingServiceConfigurationError extends Error {}
+class MockCouplingServiceRequestError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number
+  ) {
+    super(message);
+  }
+}
+
+mock.module('../../../../convex/_generated/api', () => ({
+  api: apiMock,
+  internal: apiMock,
+  components: {},
+}));
+
+mock.module('../lib/convex', () => ({
+  getConvexClientFromUrl: () => ({
+    query: queryMock,
+    mutation: mutationMock,
+  }),
+}));
+
+mock.module('../lib/csrf', () => ({
+  rejectCrossSiteRequest: () => null,
+}));
+
+mock.module('../lib/logger', () => ({
+  logger: {
+    debug: loggerDebugMock,
+    error: loggerErrorMock,
+    info: loggerInfoMock,
+    warn: loggerWarnMock,
+  },
+}));
+
+mock.module('../lib/couplingForensicsArchives', () => ({
+  extractCouplingForensicsArchive: async () => ({
+    assets: [
+      {
+        assetPath: unsafeAssetPath,
+        assetType: 'png',
+        filePath: fileURLToPath(new URL(import.meta.url)),
+      },
+    ],
+    declaredPackageIds: ['creator.package'],
+  }),
+}));
+
+mock.module('../lib/couplingForensicsService', () => ({
+  CouplingServiceConfigurationError: MockCouplingServiceConfigurationError,
+  CouplingServiceRequestError: MockCouplingServiceRequestError,
+  runCouplingAttribution: async () => [
+    {
+      assetPath: unsafeAssetPath,
+      assetType: 'png',
+      decoderKind: 'png',
+      preclassification: 'decoded',
+      tokenHex: 'deadbeef',
+      tokenLength: 8,
+    },
+  ],
+}));
+
+const { createForensicsRoutes } = await import('./forensics');
+
+function sha256Hex(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+describe('forensics route safe logging', () => {
+  const routes = createForensicsRoutes(
+    {
+      getSession: async () => ({ user: { id: 'creator-user' } }),
+    } as unknown as Auth,
+    {
+      apiBaseUrl: 'http://localhost:3001',
+      couplingServiceBaseUrl: 'https://coupling.internal',
+      couplingServiceSharedSecret: 'unit-test-coupling-bearer',
+      frontendBaseUrl: 'http://localhost:3000',
+      convexApiSecret: 'unit-test-convex-api-token',
+      convexUrl: 'http://convex.invalid',
+      encryptionSecret: 'unit-test-encryption-key',
+    }
+  );
+
+  beforeEach(() => {
+    queryMock.mockReset();
+    mutationMock.mockReset();
+    loggerDebugMock.mockReset();
+    loggerErrorMock.mockReset();
+    loggerInfoMock.mockReset();
+    loggerWarnMock.mockReset();
+  });
+
+  it('does not log uploaded asset paths when decoded matches are missing subjects', async () => {
+    const expectedTokenHash = sha256Hex('deadbeef');
+    queryMock.mockImplementation(async (ref: unknown) => {
+      if (ref === apiMock.couplingForensics.listCouplingTraceCandidatesForAuthUser) {
+        return {
+          capabilityEnabled: true,
+          packageOwned: true,
+          candidates: [
+            {
+              assetPath: unsafeAssetPath,
+              licenseSubject: 'f'.repeat(64),
+              tokenHash: expectedTokenHash,
+            },
+          ],
+        };
+      }
+      throw new Error(`Unexpected query ${String(ref)}`);
+    });
+    mutationMock.mockResolvedValue(undefined);
+
+    const formData = new FormData();
+    formData.set('packageId', 'creator.package');
+    formData.set(
+      'file',
+      new File([Uint8Array.from([1, 2, 3])], 'bundle.zip', { type: 'application/zip' })
+    );
+
+    const response = await routes.lookup(
+      new Request('http://localhost:3001/api/forensics/lookup', {
+        method: 'POST',
+        body: formData,
+      })
+    );
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Coupling forensics lookup failed',
+    });
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      'Coupling service scan failed',
+      expect.objectContaining({
+        error: 'Coupling attribution returned a decoded match without a license subject',
+      })
+    );
+    const loggedMetadata = loggerErrorMock.mock.calls[0]?.[1];
+    expect(JSON.stringify(loggedMetadata)).not.toContain(unsafeAssetPath);
+  });
+});

--- a/apps/api/src/routes/forensics.startup.test.ts
+++ b/apps/api/src/routes/forensics.startup.test.ts
@@ -18,12 +18,12 @@ const START_API_FROM_CWD_PATH = path.resolve(
 );
 const SERVICE_BOOT_TIMEOUT_MS = 60_000;
 const TEST_INTERNAL_SECRET = 'test-internal-rpc-secret-32-chars!!';
-const WRONG_LEGACY_COUPLING_SECRET = 'legacy-coupling-secret-from-env';
+const WRONG_LEGACY_COUPLING_SECRET = 'test-placeholder-legacy-coupling-value';
 const INFISICAL_CLIENT_ID = 'forensics-test-client-id';
 const INFISICAL_CLIENT_SECRET = 'forensics-test-client-secret';
 const INFISICAL_PROJECT_ID = 'forensics-test-project-id';
 const INFISICAL_ACCESS_TOKEN = 'forensics-test-access-token';
-const COUPLING_SHARED_SECRET = 'forensics-secret-from-infisical';
+const COUPLING_SHARED_SECRET = 'test-placeholder-infisical-coupling-value';
 
 class ManagedProcess {
   private readonly child: ChildProcess;

--- a/apps/api/src/routes/forensics.startup.test.ts
+++ b/apps/api/src/routes/forensics.startup.test.ts
@@ -181,7 +181,7 @@ test('loads Infisical bootstrap credentials from local .env.infisical before run
     port: couplingPort,
     async fetch(request): Promise<Response> {
       const url = new URL(request.url);
-      if (url.pathname !== '/v1/coupling/forensic-score' || request.method !== 'POST') {
+      if (url.pathname !== '/v1/coupling/attribute' || request.method !== 'POST') {
         return new Response('Not found', { status: 404 });
       }
 
@@ -201,18 +201,33 @@ test('loads Infisical bootstrap credentials from local .env.infisical before run
       };
       const assets = Array.isArray(payload.assets) ? payload.assets : [];
 
+      // No candidate seed decodes this asset, so every entry comes back unmatched.
       return Response.json({
+        requestId: 'startup-req-1',
         results: assets.map((asset) => ({
           assetPath: asset.assetPath ?? '',
           assetType: asset.assetType ?? 'fbx',
-          decoderKind: asset.assetType ?? 'fbx',
-          preclassification: 'no-signal',
+          matched: false,
+          attempted: 1,
         })),
       });
     },
   });
 
   const convex = startFakeConvexServer({
+    query: {
+      'couplingForensics:listCouplingTraceCandidatesForAuthUser': () => ({
+        capabilityEnabled: true,
+        packageOwned: true,
+        candidates: [
+          {
+            assetPath: 'bundle/model.fbx',
+            licenseSubject: 'b'.repeat(64),
+            tokenHash: '1'.repeat(64),
+          },
+        ],
+      }),
+    },
     mutation: {
       'couplingForensics:recordLookupAudit': () => null,
     },

--- a/apps/api/src/routes/forensics.test.ts
+++ b/apps/api/src/routes/forensics.test.ts
@@ -322,12 +322,22 @@ describe('forensics routes', () => {
     });
   });
 
-  it('rejects oversized declared lookup bodies before multipart parsing', async () => {
-    const response = await routes.lookup(
+  it('rejects oversized declared lookup bodies above the multipart request cap', async () => {
+    const cappedRoutes = createForensicsRoutes(auth, {
+      apiBaseUrl: 'http://localhost:3001',
+      couplingServiceBaseUrl: 'https://coupling.internal',
+      couplingServiceSharedSecret: TEST_COUPLING_BEARER,
+      frontendBaseUrl: 'http://localhost:3000',
+      convexApiSecret: TEST_CONVEX_API_TOKEN,
+      convexUrl: 'http://convex.invalid',
+      encryptionSecret: TEST_ENCRYPTION_KEY,
+      maxLookupUploadBytes: 3,
+    });
+    const response = await cappedRoutes.lookup(
       new Request('http://localhost:3001/api/forensics/lookup', {
         method: 'POST',
         headers: {
-          'Content-Length': String(100 * 1024 * 1024 + 1),
+          'Content-Length': String(3 + 1024 * 1024 + 1),
           'Content-Type': 'multipart/form-data; boundary=x',
         },
         body: '--x--',
@@ -341,7 +351,7 @@ describe('forensics routes', () => {
     expect(extractCouplingForensicsArchiveMock).not.toHaveBeenCalled();
   });
 
-  it('rejects streamed lookup bodies over the cap before multipart parsing', async () => {
+  it('rejects streamed lookup bodies above the multipart request cap before parsing', async () => {
     const cappedRoutes = createForensicsRoutes(auth, {
       apiBaseUrl: 'http://localhost:3001',
       couplingServiceBaseUrl: 'https://coupling.internal',
@@ -354,7 +364,10 @@ describe('forensics routes', () => {
     });
     const body = new FormData();
     body.set('packageId', 'creator.package');
-    body.set('file', new File(['oversized'], 'package.zip', { type: 'application/zip' }));
+    body.set(
+      'file',
+      new File([new Uint8Array(1024 * 1024 + 6)], 'package.zip', { type: 'application/zip' })
+    );
 
     const request = new Request('http://localhost:3001/api/forensics/lookup', {
       method: 'POST',
@@ -369,6 +382,50 @@ describe('forensics routes', () => {
     expect(queryMock).not.toHaveBeenCalled();
     expect(mutationMock).not.toHaveBeenCalled();
     expect(extractCouplingForensicsArchiveMock).not.toHaveBeenCalled();
+  });
+
+  it('allows multipart overhead above the exact file-size cap', async () => {
+    const cappedRoutes = createForensicsRoutes(auth, {
+      apiBaseUrl: 'http://localhost:3001',
+      couplingServiceBaseUrl: 'https://coupling.internal',
+      couplingServiceSharedSecret: TEST_COUPLING_BEARER,
+      frontendBaseUrl: 'http://localhost:3000',
+      convexApiSecret: TEST_CONVEX_API_TOKEN,
+      convexUrl: 'http://convex.invalid',
+      encryptionSecret: TEST_ENCRYPTION_KEY,
+      maxLookupUploadBytes: 3,
+    });
+    queryMock.mockImplementation(async (ref: unknown) => {
+      if (ref === apiMock.couplingForensics.listCouplingTraceCandidatesForAuthUser) {
+        return {
+          capabilityEnabled: true,
+          packageOwned: true,
+          truncated: false,
+          candidateLimit: 512,
+          candidates: [],
+        };
+      }
+      throw new Error(`Unexpected query ${String(ref)}`);
+    });
+    mutationMock.mockResolvedValue(undefined);
+
+    const formData = new FormData();
+    formData.set('packageId', 'creator.package');
+    formData.set('file', new File([Uint8Array.from([1, 2, 3])], 'bundle.zip'));
+    const request = new Request('http://localhost:3001/api/forensics/lookup', {
+      method: 'POST',
+      body: formData,
+    });
+    expect((await request.clone().arrayBuffer()).byteLength).toBeGreaterThan(3);
+
+    const response = await cappedRoutes.lookup(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      packageId: 'creator.package',
+      lookupStatus: 'hostile_unknown',
+    });
+    expect(extractCouplingForensicsArchiveMock).toHaveBeenCalledTimes(1);
   });
 
   it('rejects malformed lookup multipart bodies with a safe client error', async () => {

--- a/apps/api/src/routes/forensics.test.ts
+++ b/apps/api/src/routes/forensics.test.ts
@@ -324,6 +324,35 @@ describe('forensics routes', () => {
     expect(extractCouplingForensicsArchiveMock).not.toHaveBeenCalled();
   });
 
+  it('rejects streamed lookup bodies over the cap before multipart parsing', async () => {
+    const cappedRoutes = createForensicsRoutes(auth, {
+      apiBaseUrl: 'http://localhost:3001',
+      couplingServiceBaseUrl: 'https://coupling.internal',
+      couplingServiceSharedSecret: TEST_COUPLING_BEARER,
+      frontendBaseUrl: 'http://localhost:3000',
+      convexApiSecret: TEST_CONVEX_API_TOKEN,
+      convexUrl: 'http://convex.invalid',
+      encryptionSecret: TEST_ENCRYPTION_KEY,
+      maxLookupUploadBytes: 5,
+    });
+    const body = new FormData();
+    body.set('packageId', 'creator.package');
+    body.set('file', new File(['oversized'], 'package.zip', { type: 'application/zip' }));
+
+    const response = await cappedRoutes.lookup(
+      new Request('http://localhost:3001/api/forensics/lookup', {
+        method: 'POST',
+        body,
+      })
+    );
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({ error: 'Upload exceeds the size limit' });
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(mutationMock).not.toHaveBeenCalled();
+    expect(extractCouplingForensicsArchiveMock).not.toHaveBeenCalled();
+  });
+
   it('returns hostile-unknown when the viewer does not own the package', async () => {
     queryMock.mockImplementation(async (ref: unknown) => {
       if (ref === apiMock.couplingForensics.listCouplingTraceCandidatesForAuthUser) {

--- a/apps/api/src/routes/forensics.test.ts
+++ b/apps/api/src/routes/forensics.test.ts
@@ -571,6 +571,25 @@ describe('forensics routes', () => {
     expect(extractCouplingForensicsArchiveMock).not.toHaveBeenCalled();
   });
 
+  it('rejects malformed lookup package ids with a safe client error', async () => {
+    const formData = new FormData();
+    formData.set('packageId', 'Creator Package');
+    formData.set('file', new File([Uint8Array.from([1, 2, 3])], 'bundle.zip'));
+
+    const response = await routes.lookup(
+      new Request('http://localhost:3001/api/forensics/lookup', {
+        method: 'POST',
+        body: formData,
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid packageId format' });
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(mutationMock).not.toHaveBeenCalled();
+    expect(extractCouplingForensicsArchiveMock).not.toHaveBeenCalled();
+  });
+
   it('rate limits lookup before reading the request body', async () => {
     const limitedRoutes = createForensicsRoutes(auth, {
       apiBaseUrl: 'http://localhost:3001',

--- a/apps/api/src/routes/forensics.test.ts
+++ b/apps/api/src/routes/forensics.test.ts
@@ -216,6 +216,7 @@ describe('forensics routes', () => {
               matched: true,
               tokenHex: 'deadbeef',
               matchedLicenseSubject: DEFAULT_LICENSE_SUBJECT,
+              matchedCandidateAssetPath: 'Assets/Character/body.png',
               wmVersion: 2,
               attempted: 1,
             },
@@ -362,6 +363,7 @@ describe('forensics routes', () => {
               matched: true,
               tokenHex: 'deadbeef',
               matchedLicenseSubject,
+              matchedCandidateAssetPath: 'Assets/Character/body.png',
               wmVersion: 2,
               attempted: 2,
             },
@@ -399,6 +401,130 @@ describe('forensics routes', () => {
           matches: [
             {
               runtimeArtifactVersion: 'matched-runtime-version',
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('uses the attribution-matched candidate asset path when a leaked asset was renamed', async () => {
+    const expectedTokenHash = sha256Hex('deadbeef');
+    const uploadedAssetPath = 'Assets/Repacked/body-renamed.png';
+    const recordedAssetPath = 'Assets/Character/body.png';
+
+    extractCouplingForensicsArchiveMock.mockResolvedValue({
+      assets: [
+        {
+          assetPath: uploadedAssetPath,
+          assetType: 'png',
+          filePath: assetFixturePath,
+        },
+      ],
+      declaredPackageIds: ['creator.package'],
+    });
+
+    queryMock.mockImplementation(async (ref: unknown, args: unknown) => {
+      if (ref === apiMock.couplingForensics.listCouplingTraceCandidatesForAuthUser) {
+        return {
+          capabilityEnabled: true,
+          packageOwned: true,
+          candidates: [
+            {
+              assetPath: recordedAssetPath,
+              licenseSubject: DEFAULT_LICENSE_SUBJECT,
+              tokenHash: expectedTokenHash,
+            },
+          ],
+        };
+      }
+      if (ref === apiMock.couplingForensics.lookupTraceMatchesForAuthUser) {
+        expect(args).toEqual({
+          apiSecret: TEST_CONVEX_API_TOKEN,
+          authUserId: 'creator-user',
+          packageId: 'creator.package',
+          matchedCandidates: [
+            {
+              assetPath: recordedAssetPath,
+              licenseSubject: DEFAULT_LICENSE_SUBJECT,
+              tokenHash: expectedTokenHash,
+            },
+          ],
+        });
+        return {
+          capabilityEnabled: true,
+          packageOwned: true,
+          matches: [
+            {
+              tokenHash: expectedTokenHash,
+              licenseSubject: DEFAULT_LICENSE_SUBJECT,
+              assetPath: recordedAssetPath,
+              correlationId: 'corr_renamed',
+              createdAt: 1_739_999_999_000,
+              runtimeArtifactVersion: 'renamed-runtime-version',
+              runtimePlaintextSha256: 'runtime-sha',
+            },
+          ],
+          unmatchedTokenHashes: [],
+          truncated: false,
+        };
+      }
+      throw new Error(`Unexpected query ${String(ref)}`);
+    });
+
+    mutationMock.mockResolvedValue(undefined);
+
+    const fetchMock = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          requestId: 'req-renamed-asset',
+          results: [
+            {
+              assetPath: uploadedAssetPath,
+              assetType: 'png',
+              matched: true,
+              tokenHex: 'deadbeef',
+              matchedLicenseSubject: DEFAULT_LICENSE_SUBJECT,
+              matchedCandidateAssetPath: recordedAssetPath,
+              wmVersion: 2,
+              attempted: 1,
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const formData = new FormData();
+    formData.set('packageId', 'creator.package');
+    formData.set(
+      'file',
+      new File([Uint8Array.from([31, 32, 33])], 'bundle.zip', { type: 'application/zip' })
+    );
+
+    const response = await routes.lookup(
+      new Request('http://localhost:3001/api/forensics/lookup', {
+        method: 'POST',
+        body: formData,
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      lookupStatus: 'attributed',
+      results: [
+        {
+          assetPath: uploadedAssetPath,
+          matched: true,
+          layerBClassification: 'trace-recovered',
+          matches: [
+            {
+              assetPath: recordedAssetPath,
+              runtimeArtifactVersion: 'renamed-runtime-version',
             },
           ],
         },
@@ -1146,6 +1272,7 @@ describe('forensics routes', () => {
               matched: true,
               tokenHex: 'deadbeef',
               matchedLicenseSubject: DEFAULT_LICENSE_SUBJECT,
+              matchedCandidateAssetPath: 'Assets/Character/body.png',
               wmVersion: 2,
               attempted: 1,
             },
@@ -1232,6 +1359,7 @@ describe('forensics routes', () => {
               matched: true,
               tokenHex: 'deadbeef',
               matchedLicenseSubject: DEFAULT_LICENSE_SUBJECT,
+              matchedCandidateAssetPath: 'Assets/Character/body.png',
               wmVersion: 2,
               attempted: 1,
             },
@@ -1338,6 +1466,7 @@ describe('forensics routes', () => {
               matched: true,
               tokenHex: 'deadbeef',
               matchedLicenseSubject: DEFAULT_LICENSE_SUBJECT,
+              matchedCandidateAssetPath: 'Assets/Character/body.png',
               wmVersion: 2,
               attempted: 1,
             },

--- a/apps/api/src/routes/forensics.test.ts
+++ b/apps/api/src/routes/forensics.test.ts
@@ -12,7 +12,6 @@ const apiMock = {
     lookupTraceMatchesForAuthUser: 'couplingForensics.lookupTraceMatchesForAuthUser',
     resolveBuyerIdentityForAuthUser: 'couplingForensics.resolveBuyerIdentityForAuthUser',
     recordLookupAudit: 'couplingForensics.recordLookupAudit',
-    revealCouplingLicenseKey: 'couplingForensics.revealCouplingLicenseKey',
   },
 } as const;
 
@@ -73,6 +72,7 @@ mock.module('../lib/couplingForensicsArchives', () => ({
 
 const { createForensicsRoutes } = await import('./forensics');
 const { encryptForensicsLicenseKey } = await import('../verification/forensicsLicenseKey');
+const { InMemoryPublicApiRateLimitStore } = await import('../lib/publicApiRateLimit');
 
 function sha256Hex(text: string): string {
   return createHash('sha256').update(text).digest('hex');
@@ -236,7 +236,11 @@ describe('forensics routes', () => {
     );
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({
+    const payload = (await response.json()) as {
+      investigationReport?: { topCandidates?: unknown };
+      results: Array<{ matches: Array<Record<string, unknown>> }>;
+    };
+    expect(payload).toMatchObject({
       packageId: 'creator.package',
       lookupStatus: 'attributed',
       candidateAssetCount: 1,
@@ -248,13 +252,26 @@ describe('forensics routes', () => {
           layerBClassification: 'trace-recovered',
           matches: [
             {
-              licenseSubject: 'license-subject-1',
               runtimeArtifactVersion: '2026.03.25.153000',
             },
           ],
         },
       ],
     });
+    const match = payload.results[0]?.matches[0];
+    expect(typeof match?.matchId).toBe('string');
+    expect(String(match?.matchId)).toHaveLength(64);
+    expect(match).not.toHaveProperty('licenseSubject');
+    expect(match).not.toHaveProperty('correlationId');
+    expect(match).not.toHaveProperty('runtimePlaintextSha256');
+    expect(match).not.toHaveProperty('machineFingerprintHash');
+    expect(match).not.toHaveProperty('projectIdHash');
+    expect(match).not.toHaveProperty('buyerProviderUserId');
+    expect(match).not.toHaveProperty('buyerSubjectDiscordUserId');
+    expect(payload.investigationReport?.topCandidates).toBeUndefined();
+    expect(JSON.stringify(payload)).not.toContain('license-subject-1');
+    expect(JSON.stringify(payload)).not.toContain('corr_1');
+    expect(JSON.stringify(payload)).not.toContain('runtime-sha');
     expect(mutationMock).toHaveBeenCalledTimes(1);
     expect(mutationMock.mock.calls[0]?.[1]).toMatchObject({
       apiSecret: TEST_CONVEX_API_TOKEN,
@@ -339,15 +356,105 @@ describe('forensics routes', () => {
     body.set('packageId', 'creator.package');
     body.set('file', new File(['oversized'], 'package.zip', { type: 'application/zip' }));
 
-    const response = await cappedRoutes.lookup(
-      new Request('http://localhost:3001/api/forensics/lookup', {
-        method: 'POST',
-        body,
-      })
-    );
+    const request = new Request('http://localhost:3001/api/forensics/lookup', {
+      method: 'POST',
+      body,
+    });
+    expect(request.headers.get('content-length')).toBeNull();
+
+    const response = await cappedRoutes.lookup(request);
 
     expect(response.status).toBe(413);
     await expect(response.json()).resolves.toEqual({ error: 'Upload exceeds the size limit' });
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(mutationMock).not.toHaveBeenCalled();
+    expect(extractCouplingForensicsArchiveMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed lookup multipart bodies with a safe client error', async () => {
+    const response = await routes.lookup(
+      new Request('http://localhost:3001/api/forensics/lookup', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'multipart/form-data; boundary=lookup-boundary',
+        },
+        body: 'not multipart content',
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid multipart form data' });
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(mutationMock).not.toHaveBeenCalled();
+    expect(extractCouplingForensicsArchiveMock).not.toHaveBeenCalled();
+  });
+
+  it('rate limits lookup before reading the request body', async () => {
+    const limitedRoutes = createForensicsRoutes(auth, {
+      apiBaseUrl: 'http://localhost:3001',
+      couplingServiceBaseUrl: 'https://coupling.internal',
+      couplingServiceSharedSecret: TEST_COUPLING_BEARER,
+      frontendBaseUrl: 'http://localhost:3000',
+      convexApiSecret: TEST_CONVEX_API_TOKEN,
+      convexUrl: 'http://convex.invalid',
+      encryptionSecret: TEST_ENCRYPTION_KEY,
+      lookupRateLimitMaxRequests: 1,
+      lookupRateLimitStore: new InMemoryPublicApiRateLimitStore(),
+      lookupRateLimitWindowMs: 60_000,
+    });
+
+    queryMock.mockImplementation(async (ref: unknown) => {
+      if (ref === apiMock.couplingForensics.listCouplingTraceCandidatesForAuthUser) {
+        return {
+          capabilityEnabled: true,
+          packageOwned: true,
+          truncated: false,
+          candidateLimit: 512,
+          candidates: [],
+        };
+      }
+      throw new Error(`Unexpected query ${String(ref)}`);
+    });
+    mutationMock.mockResolvedValue(undefined);
+
+    const formData = new FormData();
+    formData.set('packageId', 'creator.package');
+    formData.set('file', new File([Uint8Array.from([1, 2, 3])], 'bundle.zip'));
+
+    const firstResponse = await limitedRoutes.lookup(
+      new Request('http://localhost:3001/api/forensics/lookup', {
+        method: 'POST',
+        headers: { 'cf-connecting-ip': '203.0.113.40' },
+        body: formData,
+      })
+    );
+    expect(firstResponse.status).toBe(200);
+
+    queryMock.mockClear();
+    mutationMock.mockClear();
+    extractCouplingForensicsArchiveMock.mockClear();
+
+    const blockedBody = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(new TextEncoder().encode('--blocked--'));
+        controller.close();
+      },
+    });
+
+    const blockedRequest = new Request('http://localhost:3001/api/forensics/lookup', {
+      method: 'POST',
+      headers: {
+        'cf-connecting-ip': '203.0.113.40',
+        'Content-Type': 'multipart/form-data; boundary=blocked',
+      },
+      body: blockedBody,
+    });
+
+    const blockedResponse = await limitedRoutes.lookup(blockedRequest);
+
+    expect(blockedResponse.status).toBe(429);
+    await expect(blockedResponse.json()).resolves.toEqual({ error: 'Too many requests' });
+    expect(blockedRequest.bodyUsed).toBe(false);
     expect(queryMock).not.toHaveBeenCalled();
     expect(mutationMock).not.toHaveBeenCalled();
     expect(extractCouplingForensicsArchiveMock).not.toHaveBeenCalled();
@@ -984,80 +1091,28 @@ describe('forensics routes', () => {
         {
           matches: [
             {
-              buyerProviderUserId: 'customer-123',
               buyerProviderUsername: 'BuyerAccount',
               buyerSubjectDisplayName: 'Buyer One',
-              buyerSubjectDiscordUserId: 'discord-buyer-1',
             },
           ],
         },
       ],
     });
     const match = json.results[0]?.matches[0];
+    expect(typeof match?.matchId).toBe('string');
+    expect(String(match?.matchId)).toHaveLength(64);
+    expect(match?.buyerProviderUsername).toBe('BuyerAccount');
+    expect(match?.buyerSubjectDisplayName).toBe('Buyer One');
+    expect(match).not.toHaveProperty('licenseSubject');
+    expect(match).not.toHaveProperty('correlationId');
+    expect(match).not.toHaveProperty('runtimePlaintextSha256');
+    expect(match).not.toHaveProperty('buyerProviderUserId');
+    expect(match).not.toHaveProperty('buyerSubjectDiscordUserId');
     expect(match).not.toHaveProperty('licenseKey');
     expect(match).not.toHaveProperty('purchaserEmail');
   });
 
-  it('rejects invalid reveal package ids as a client error before Convex writes', async () => {
-    mutationMock.mockImplementation(async () => {
-      throw new Error('Invalid reveal package ids should not reach Convex');
-    });
-
-    const response = await routes.revealLicense(
-      new Request('http://localhost:3001/api/forensics/reveal-license', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          packageId: 'INVALID PACKAGE',
-          licenseSubject: 'a'.repeat(64),
-        }),
-      })
-    );
-
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toEqual({ error: 'Invalid packageId format' });
-    expect(mutationMock).not.toHaveBeenCalled();
-  });
-
-  it('rejects oversized reveal bodies before Convex writes', async () => {
-    mutationMock.mockImplementation(async () => {
-      throw new Error('Oversized reveal bodies should not reach Convex');
-    });
-
-    const response = await routes.revealLicense(
-      new Request('http://localhost:3001/api/forensics/reveal-license', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          packageId: 'creator.package',
-          licenseSubject: 'a'.repeat(64),
-          padding: 'x'.repeat(5_000),
-        }),
-      })
-    );
-
-    expect(response.status).toBe(413);
-    await expect(response.json()).resolves.toEqual({ error: 'Request body too large' });
-    expect(mutationMock).not.toHaveBeenCalled();
-  });
-
-  it('returns a fixed forbidden error when reveal access is denied', async () => {
-    mutationMock.mockResolvedValue({
-      error: 'internal authorization detail for license-subject',
-    });
-
-    const response = await routes.revealLicense(
-      new Request('http://localhost:3001/api/forensics/reveal-license', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          packageId: 'creator.package',
-          licenseSubject: 'a'.repeat(64),
-        }),
-      })
-    );
-
-    expect(response.status).toBe(403);
-    await expect(response.json()).resolves.toEqual({ error: 'Forbidden' });
+  it('does not expose a browser license reveal handler', () => {
+    expect(routes).not.toHaveProperty('revealLicense');
   });
 });

--- a/apps/api/src/routes/forensics.test.ts
+++ b/apps/api/src/routes/forensics.test.ts
@@ -90,6 +90,10 @@ function defaultCandidates(tokenHash: string) {
   ];
 }
 
+const TEST_COUPLING_BEARER = ['unit', 'test', 'coupling', 'bearer'].join('-');
+const TEST_CONVEX_API_TOKEN = ['unit', 'test', 'convex', 'api', 'token'].join('-');
+const TEST_ENCRYPTION_KEY = ['unit', 'test', 'encryption', 'key'].join('-');
+
 describe('forensics routes', () => {
   const originalFetch = globalThis.fetch;
   const auth = {
@@ -99,11 +103,11 @@ describe('forensics routes', () => {
   const routes = createForensicsRoutes(auth, {
     apiBaseUrl: 'http://localhost:3001',
     couplingServiceBaseUrl: 'https://coupling.internal',
-    couplingServiceSharedSecret: 'coupling-secret',
+    couplingServiceSharedSecret: TEST_COUPLING_BEARER,
     frontendBaseUrl: 'http://localhost:3000',
-    convexApiSecret: 'convex-secret',
+    convexApiSecret: TEST_CONVEX_API_TOKEN,
     convexUrl: 'http://convex.invalid',
-    encryptionSecret: 'encryption-secret',
+    encryptionSecret: TEST_ENCRYPTION_KEY,
   });
 
   beforeEach(() => {
@@ -134,7 +138,7 @@ describe('forensics routes', () => {
     queryMock.mockImplementation(async (ref: unknown, args: unknown) => {
       if (ref === apiMock.couplingForensics.listCouplingTraceCandidatesForAuthUser) {
         expect(args).toEqual({
-          apiSecret: 'convex-secret',
+          apiSecret: TEST_CONVEX_API_TOKEN,
           authUserId: 'creator-user',
           packageId: 'creator.package',
         });
@@ -146,7 +150,7 @@ describe('forensics routes', () => {
       }
       if (ref === apiMock.couplingForensics.lookupTraceMatchesForAuthUser) {
         expect(args).toEqual({
-          apiSecret: 'convex-secret',
+          apiSecret: TEST_CONVEX_API_TOKEN,
           authUserId: 'creator-user',
           packageId: 'creator.package',
           tokenHashes: [expectedTokenHash],
@@ -179,7 +183,7 @@ describe('forensics routes', () => {
       expect(url).toBe('https://coupling.internal/v1/coupling/attribute');
       expect(init?.method).toBe('POST');
       const headers = new Headers(init?.headers);
-      expect(headers.get('authorization')).toBe('Bearer coupling-secret');
+      expect(headers.get('authorization')).toBe(`Bearer ${TEST_COUPLING_BEARER}`);
       expect(headers.get('content-type')).toBe('application/json');
 
       const requestBody = JSON.parse(String(init?.body)) as {
@@ -253,7 +257,7 @@ describe('forensics routes', () => {
     });
     expect(mutationMock).toHaveBeenCalledTimes(1);
     expect(mutationMock.mock.calls[0]?.[1]).toMatchObject({
-      apiSecret: 'convex-secret',
+      apiSecret: TEST_CONVEX_API_TOKEN,
       authUserId: 'creator-user',
       packageId: 'creator.package',
       status: 'attributed',
@@ -301,6 +305,25 @@ describe('forensics routes', () => {
     });
   });
 
+  it('rejects oversized declared lookup bodies before multipart parsing', async () => {
+    const response = await routes.lookup(
+      new Request('http://localhost:3001/api/forensics/lookup', {
+        method: 'POST',
+        headers: {
+          'Content-Length': String(100 * 1024 * 1024 + 1),
+          'Content-Type': 'multipart/form-data; boundary=x',
+        },
+        body: '--x--',
+      })
+    );
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({ error: 'Upload exceeds the size limit' });
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(mutationMock).not.toHaveBeenCalled();
+    expect(extractCouplingForensicsArchiveMock).not.toHaveBeenCalled();
+  });
+
   it('returns hostile-unknown when the viewer does not own the package', async () => {
     queryMock.mockImplementation(async (ref: unknown) => {
       if (ref === apiMock.couplingForensics.listCouplingTraceCandidatesForAuthUser) {
@@ -342,6 +365,59 @@ describe('forensics routes', () => {
     expect(mutationMock.mock.calls[0]?.[1]).toMatchObject({
       packageId: 'creator.package',
       status: 'denied',
+    });
+  });
+
+  it('returns hostile-unknown without attribution when an owned package has no trace candidates', async () => {
+    queryMock.mockImplementation(async (ref: unknown) => {
+      if (ref === apiMock.couplingForensics.listCouplingTraceCandidatesForAuthUser) {
+        return {
+          capabilityEnabled: true,
+          packageOwned: true,
+          truncated: false,
+          candidateLimit: 512,
+          candidates: [],
+        };
+      }
+      throw new Error(`Unexpected query ${String(ref)}`);
+    });
+    mutationMock.mockResolvedValue(undefined);
+
+    const fetchMock = mock(async () => {
+      throw new Error('Coupling service should not be called without trace candidates');
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const formData = new FormData();
+    formData.set('packageId', 'creator.package');
+    formData.set(
+      'file',
+      new File([Uint8Array.from([1, 2, 3])], 'bundle.zip', { type: 'application/zip' })
+    );
+
+    const response = await routes.lookup(
+      new Request('http://localhost:3001/api/forensics/lookup', {
+        method: 'POST',
+        body: formData,
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      packageId: 'creator.package',
+      lookupStatus: 'hostile_unknown',
+      candidateAssetCount: 1,
+      decodedAssetCount: 0,
+      results: [],
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(mutationMock).toHaveBeenCalledTimes(1);
+    expect(mutationMock.mock.calls[0]?.[1]).toMatchObject({
+      packageId: 'creator.package',
+      status: 'hostile_unknown',
+      requestedTokenCount: 0,
+      matchedTokenCount: 0,
     });
   });
 
@@ -403,7 +479,7 @@ describe('forensics routes', () => {
       queryMock.mockImplementation(async (ref: unknown, args: unknown) => {
         if (ref === apiMock.couplingForensics.listOwnedPackageSummariesForAuthUser) {
           expect(args).toEqual({
-            apiSecret: 'convex-secret',
+            apiSecret: TEST_CONVEX_API_TOKEN,
             authUserId: 'creator-user',
           });
           return {
@@ -697,7 +773,7 @@ describe('forensics routes', () => {
       }
       if (ref === apiMock.couplingForensics.lookupTraceMatchesForAuthUser) {
         expect(args).toEqual({
-          apiSecret: 'convex-secret',
+          apiSecret: TEST_CONVEX_API_TOKEN,
           authUserId: 'creator-user',
           packageId: 'creator.package',
           tokenHashes: [expectedTokenHash],
@@ -778,7 +854,7 @@ describe('forensics routes', () => {
   it('rehydrates buyer identity from the encrypted stored license instead of redundant stored buyer columns', async () => {
     const encryptedLicenseKey = await encryptForensicsLicenseKey(
       '11111111-2222-3333-4444-555555555555',
-      'encryption-secret'
+      TEST_ENCRYPTION_KEY
     );
     const expectedTokenHash = sha256Hex('deadbeef');
 

--- a/apps/api/src/routes/forensics.test.ts
+++ b/apps/api/src/routes/forensics.test.ts
@@ -7,6 +7,8 @@ import type { Auth } from '../auth';
 const apiMock = {
   couplingForensics: {
     listOwnedPackageSummariesForAuthUser: 'couplingForensics.listOwnedPackageSummariesForAuthUser',
+    listCouplingTraceCandidatesForAuthUser:
+      'couplingForensics.listCouplingTraceCandidatesForAuthUser',
     lookupTraceMatchesForAuthUser: 'couplingForensics.lookupTraceMatchesForAuthUser',
     resolveBuyerIdentityForAuthUser: 'couplingForensics.resolveBuyerIdentityForAuthUser',
     recordLookupAudit: 'couplingForensics.recordLookupAudit',
@@ -76,6 +78,18 @@ function sha256Hex(text: string): string {
   return createHash('sha256').update(text).digest('hex');
 }
 
+// One recorded buyer for the registered package: assetPath + licenseSubject + the sha256 of the
+// token the seed-iteration decoder is expected to recover.
+function defaultCandidates(tokenHash: string) {
+  return [
+    {
+      assetPath: 'Assets/Character/body.png',
+      licenseSubject: 'license-subject-1',
+      tokenHash,
+    },
+  ];
+}
+
 describe('forensics routes', () => {
   const originalFetch = globalThis.fetch;
   const auth = {
@@ -114,10 +128,22 @@ describe('forensics routes', () => {
     globalThis.fetch = originalFetch;
   });
 
-  it('sends extracted candidate assets to the coupling service before looking up trace matches', async () => {
+  it('attributes a leaked asset to its buyer via seed-iteration candidates', async () => {
     const expectedTokenHash = sha256Hex('deadbeef');
 
     queryMock.mockImplementation(async (ref: unknown, args: unknown) => {
+      if (ref === apiMock.couplingForensics.listCouplingTraceCandidatesForAuthUser) {
+        expect(args).toEqual({
+          apiSecret: 'convex-secret',
+          authUserId: 'creator-user',
+          packageId: 'creator.package',
+        });
+        return {
+          capabilityEnabled: true,
+          packageOwned: true,
+          candidates: defaultCandidates(expectedTokenHash),
+        };
+      }
       if (ref === apiMock.couplingForensics.lookupTraceMatchesForAuthUser) {
         expect(args).toEqual({
           apiSecret: 'convex-secret',
@@ -150,23 +176,23 @@ describe('forensics routes', () => {
     const fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
       const url =
         typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
-      expect(url).toBe('https://coupling.internal/v1/coupling/forensic-score');
+      expect(url).toBe('https://coupling.internal/v1/coupling/attribute');
       expect(init?.method).toBe('POST');
       const headers = new Headers(init?.headers);
       expect(headers.get('authorization')).toBe('Bearer coupling-secret');
       expect(headers.get('content-type')).toBe('application/json');
 
       const requestBody = JSON.parse(String(init?.body)) as {
-        mode: string;
         assets: Array<{ assetPath: string; assetType: string; contentBase64: string }>;
+        candidates: Array<{ assetPath: string; licenseSubject: string; tokenHash: string }>;
       };
-      expect(requestBody.mode).toBe('scan');
       expect(requestBody.assets).toHaveLength(1);
       expect(requestBody.assets[0]).toMatchObject({
         assetPath: 'Assets/Character/body.png',
         assetType: 'png',
       });
       expect(requestBody.assets[0]?.contentBase64.length).toBeGreaterThan(0);
+      expect(requestBody.candidates).toEqual(defaultCandidates(expectedTokenHash));
 
       return new Response(
         JSON.stringify({
@@ -175,10 +201,11 @@ describe('forensics routes', () => {
             {
               assetPath: 'Assets/Character/body.png',
               assetType: 'png',
-              decoderKind: 'png',
-              preclassification: 'decoded',
+              matched: true,
               tokenHex: 'deadbeef',
-              tokenLength: 8,
+              matchedLicenseSubject: 'license-subject-1',
+              wmVersion: 2,
+              attempted: 1,
             },
           ],
         }),
@@ -230,6 +257,91 @@ describe('forensics routes', () => {
       authUserId: 'creator-user',
       packageId: 'creator.package',
       status: 'attributed',
+    });
+  });
+
+  it('returns a 402 when the viewer lacks the coupling traceability capability', async () => {
+    queryMock.mockImplementation(async (ref: unknown) => {
+      if (ref === apiMock.couplingForensics.listCouplingTraceCandidatesForAuthUser) {
+        return { capabilityEnabled: false, packageOwned: false, candidates: [] };
+      }
+      throw new Error(`Unexpected query ${String(ref)}`);
+    });
+    mutationMock.mockResolvedValue(undefined);
+
+    const fetchMock = mock(async () => {
+      throw new Error('Coupling service should not be called without capability');
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const formData = new FormData();
+    formData.set('packageId', 'creator.package');
+    formData.set(
+      'file',
+      new File([Uint8Array.from([1, 2, 3])], 'bundle.zip', { type: 'application/zip' })
+    );
+
+    const response = await routes.lookup(
+      new Request('http://localhost:3001/api/forensics/lookup', {
+        method: 'POST',
+        body: formData,
+      })
+    );
+
+    expect(response.status).toBe(402);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Creator Studio+ is required for coupling traceability',
+      code: 'coupling_traceability_required',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mutationMock).toHaveBeenCalledTimes(1);
+    expect(mutationMock.mock.calls[0]?.[1]).toMatchObject({
+      packageId: 'creator.package',
+      status: 'denied',
+    });
+  });
+
+  it('returns hostile-unknown when the viewer does not own the package', async () => {
+    queryMock.mockImplementation(async (ref: unknown) => {
+      if (ref === apiMock.couplingForensics.listCouplingTraceCandidatesForAuthUser) {
+        return { capabilityEnabled: true, packageOwned: false, candidates: [] };
+      }
+      throw new Error(`Unexpected query ${String(ref)}`);
+    });
+    mutationMock.mockResolvedValue(undefined);
+
+    const fetchMock = mock(async () => {
+      throw new Error('Coupling service should not be called for an unowned package');
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const formData = new FormData();
+    formData.set('packageId', 'creator.package');
+    formData.set(
+      'file',
+      new File([Uint8Array.from([1, 2, 3])], 'bundle.zip', { type: 'application/zip' })
+    );
+
+    const response = await routes.lookup(
+      new Request('http://localhost:3001/api/forensics/lookup', {
+        method: 'POST',
+        body: formData,
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      packageId: 'creator.package',
+      lookupStatus: 'hostile_unknown',
+      candidateAssetCount: 1,
+      decodedAssetCount: 0,
+      results: [],
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mutationMock).toHaveBeenCalledTimes(1);
+    expect(mutationMock.mock.calls[0]?.[1]).toMatchObject({
+      packageId: 'creator.package',
+      status: 'denied',
     });
   });
 
@@ -288,9 +400,18 @@ describe('forensics routes', () => {
     }
   });
 
-  it('returns a tamper-suspected response when candidate assets have no decodable coupling signals', async () => {
-    queryMock.mockImplementation(async () => {
-      throw new Error('Trace lookup should not run without coupling findings');
+  it('returns a tamper-suspected response when no candidate seed decodes the uploaded asset', async () => {
+    const expectedTokenHash = sha256Hex('deadbeef');
+
+    queryMock.mockImplementation(async (ref: unknown) => {
+      if (ref === apiMock.couplingForensics.listCouplingTraceCandidatesForAuthUser) {
+        return {
+          capabilityEnabled: true,
+          packageOwned: true,
+          candidates: defaultCandidates(expectedTokenHash),
+        };
+      }
+      throw new Error(`Trace lookup should not run without recovered tokens (${String(ref)})`);
     });
     mutationMock.mockResolvedValue(undefined);
 
@@ -302,10 +423,8 @@ describe('forensics routes', () => {
             {
               assetPath: 'Assets/Character/body.png',
               assetType: 'png',
-              decoderKind: 'png',
-              preclassification: 'likely-stripped',
-              nativeCode: -10,
-              decodeError: 'quorum not reached',
+              matched: false,
+              attempted: 1,
             },
           ],
         }),
@@ -341,12 +460,12 @@ describe('forensics routes', () => {
       results: [
         {
           assetPath: 'Assets/Character/body.png',
-          layerBClassification: 'trace-likely-stripped',
+          layerBClassification: 'no-signal-found',
           matched: false,
         },
       ],
     });
-    expect(queryMock).not.toHaveBeenCalled();
+    expect(queryMock).toHaveBeenCalledTimes(1);
     expect(mutationMock).toHaveBeenCalledTimes(1);
     expect(mutationMock.mock.calls[0]?.[1]).toMatchObject({
       packageId: 'creator.package',
@@ -354,9 +473,18 @@ describe('forensics routes', () => {
     });
   });
 
-  it('treats empty forensic-score results as candidate assets with no recovered signals', async () => {
-    queryMock.mockImplementation(async () => {
-      throw new Error('Trace lookup should not run without decoded coupling findings');
+  it('treats empty attribution results as candidate assets with no recovered signals', async () => {
+    const expectedTokenHash = sha256Hex('deadbeef');
+
+    queryMock.mockImplementation(async (ref: unknown) => {
+      if (ref === apiMock.couplingForensics.listCouplingTraceCandidatesForAuthUser) {
+        return {
+          capabilityEnabled: true,
+          packageOwned: true,
+          candidates: defaultCandidates(expectedTokenHash),
+        };
+      }
+      throw new Error(`Trace lookup should not run without recovered tokens (${String(ref)})`);
     });
     mutationMock.mockResolvedValue(undefined);
 
@@ -403,7 +531,7 @@ describe('forensics routes', () => {
         },
       ],
     });
-    expect(queryMock).not.toHaveBeenCalled();
+    expect(queryMock).toHaveBeenCalledTimes(1);
     expect(mutationMock).toHaveBeenCalledTimes(1);
     expect(mutationMock.mock.calls[0]?.[1]).toMatchObject({
       packageId: 'creator.package',
@@ -449,9 +577,18 @@ describe('forensics routes', () => {
     });
   });
 
-  it('returns a typed lookup failure when forensic-score returns an object error payload', async () => {
-    queryMock.mockImplementation(async () => {
-      throw new Error('Trace lookup should not run when the coupling service rejects the request');
+  it('returns a typed lookup failure when attribution returns an object error payload', async () => {
+    const expectedTokenHash = sha256Hex('deadbeef');
+
+    queryMock.mockImplementation(async (ref: unknown) => {
+      if (ref === apiMock.couplingForensics.listCouplingTraceCandidatesForAuthUser) {
+        return {
+          capabilityEnabled: true,
+          packageOwned: true,
+          candidates: defaultCandidates(expectedTokenHash),
+        };
+      }
+      throw new Error(`Trace lookup should not run when attribution fails (${String(ref)})`);
     });
     mutationMock.mockResolvedValue(undefined);
 
@@ -489,7 +626,7 @@ describe('forensics routes', () => {
     await expect(response.json()).resolves.toEqual({
       error: 'Coupling forensics lookup failed',
     });
-    expect(queryMock).not.toHaveBeenCalled();
+    expect(queryMock).toHaveBeenCalledTimes(1);
     expect(mutationMock).toHaveBeenCalledTimes(1);
     expect(mutationMock.mock.calls[0]?.[1]).toMatchObject({
       packageId: 'creator.package',
@@ -497,10 +634,17 @@ describe('forensics routes', () => {
     });
   });
 
-  it('returns a hostile-unknown response when decoded coupling signals do not match an authorized trace record', async () => {
+  it('returns a hostile-unknown response when a recovered token does not resolve to a trace record', async () => {
     const expectedTokenHash = sha256Hex('deadbeef');
 
     queryMock.mockImplementation(async (ref: unknown, args: unknown) => {
+      if (ref === apiMock.couplingForensics.listCouplingTraceCandidatesForAuthUser) {
+        return {
+          capabilityEnabled: true,
+          packageOwned: true,
+          candidates: defaultCandidates(expectedTokenHash),
+        };
+      }
       if (ref === apiMock.couplingForensics.lookupTraceMatchesForAuthUser) {
         expect(args).toEqual({
           apiSecret: 'convex-secret',
@@ -528,10 +672,11 @@ describe('forensics routes', () => {
             {
               assetPath: 'Assets/Character/body.png',
               assetType: 'png',
-              decoderKind: 'png',
-              preclassification: 'decoded',
+              matched: true,
               tokenHex: 'deadbeef',
-              tokenLength: 8,
+              matchedLicenseSubject: 'license-subject-1',
+              wmVersion: 2,
+              attempted: 1,
             },
           ],
         }),
@@ -588,6 +733,13 @@ describe('forensics routes', () => {
     const expectedTokenHash = sha256Hex('deadbeef');
 
     queryMock.mockImplementation(async (ref: unknown) => {
+      if (ref === apiMock.couplingForensics.listCouplingTraceCandidatesForAuthUser) {
+        return {
+          capabilityEnabled: true,
+          packageOwned: true,
+          candidates: defaultCandidates(expectedTokenHash),
+        };
+      }
       if (ref === apiMock.couplingForensics.lookupTraceMatchesForAuthUser) {
         return {
           capabilityEnabled: true,
@@ -637,10 +789,11 @@ describe('forensics routes', () => {
             {
               assetPath: 'Assets/Character/body.png',
               assetType: 'png',
-              decoderKind: 'png',
-              preclassification: 'decoded',
+              matched: true,
               tokenHex: 'deadbeef',
-              tokenLength: 8,
+              matchedLicenseSubject: 'license-subject-1',
+              wmVersion: 2,
+              attempted: 1,
             },
           ],
         }),

--- a/apps/api/src/routes/forensics.test.ts
+++ b/apps/api/src/routes/forensics.test.ts
@@ -261,6 +261,8 @@ describe('forensics routes', () => {
     const match = payload.results[0]?.matches[0];
     expect(typeof match?.matchId).toBe('string');
     expect(String(match?.matchId)).toHaveLength(64);
+    expect(typeof match?.buyerMatchId).toBe('string');
+    expect(String(match?.buyerMatchId)).toHaveLength(64);
     expect(match).not.toHaveProperty('licenseSubject');
     expect(match).not.toHaveProperty('correlationId');
     expect(match).not.toHaveProperty('runtimePlaintextSha256');
@@ -666,7 +668,7 @@ describe('forensics routes', () => {
 
   it('keeps proxied dashboard requests on the session auth path when no internal auth user header is present', async () => {
     const previousInternalRpcSecret = process.env.INTERNAL_RPC_SHARED_SECRET;
-    process.env.INTERNAL_RPC_SHARED_SECRET = 'test-internal-secret';
+    process.env.INTERNAL_RPC_SHARED_SECRET = 'test-placeholder-internal-rpc-secret';
 
     try {
       queryMock.mockImplementation(async (ref: unknown, args: unknown) => {
@@ -693,8 +695,9 @@ describe('forensics routes', () => {
         new Request('http://localhost:3001/api/forensics/packages', {
           method: 'GET',
           headers: {
-            'x-internal-service-secret': 'test-internal-secret',
-            cookie: 'yucp.session_token=session-cookie; yucp.session_data=session-data',
+            'x-internal-service-secret': 'test-placeholder-internal-rpc-secret',
+            cookie:
+              'yucp.session_token=test-placeholder-session-cookie; yucp.session_data=test-placeholder-session-data',
           },
         })
       );
@@ -1046,7 +1049,7 @@ describe('forensics routes', () => {
 
   it('rehydrates buyer identity from the encrypted stored license instead of redundant stored buyer columns', async () => {
     const encryptedLicenseKey = await encryptForensicsLicenseKey(
-      '11111111-2222-3333-4444-555555555555',
+      'test-placeholder-forensics-license-key',
       TEST_ENCRYPTION_KEY
     );
     const expectedTokenHash = sha256Hex('deadbeef');

--- a/apps/api/src/routes/forensics.test.ts
+++ b/apps/api/src/routes/forensics.test.ts
@@ -78,13 +78,15 @@ function sha256Hex(text: string): string {
   return createHash('sha256').update(text).digest('hex');
 }
 
+const DEFAULT_LICENSE_SUBJECT = 'f'.repeat(64);
+
 // One recorded buyer for the registered package: assetPath + licenseSubject + the sha256 of the
 // token the seed-iteration decoder is expected to recover.
 function defaultCandidates(tokenHash: string) {
   return [
     {
       assetPath: 'Assets/Character/body.png',
-      licenseSubject: 'license-subject-1',
+      licenseSubject: DEFAULT_LICENSE_SUBJECT,
       tokenHash,
     },
   ];
@@ -153,7 +155,13 @@ describe('forensics routes', () => {
           apiSecret: TEST_CONVEX_API_TOKEN,
           authUserId: 'creator-user',
           packageId: 'creator.package',
-          tokenHashes: [expectedTokenHash],
+          matchedCandidates: [
+            {
+              assetPath: 'Assets/Character/body.png',
+              licenseSubject: DEFAULT_LICENSE_SUBJECT,
+              tokenHash: expectedTokenHash,
+            },
+          ],
         });
         return {
           capabilityEnabled: true,
@@ -161,7 +169,7 @@ describe('forensics routes', () => {
           matches: [
             {
               tokenHash: expectedTokenHash,
-              licenseSubject: 'license-subject-1',
+              licenseSubject: DEFAULT_LICENSE_SUBJECT,
               assetPath: 'Assets/Character/body.png',
               correlationId: 'corr_1',
               createdAt: 1_739_999_999_000,
@@ -207,7 +215,7 @@ describe('forensics routes', () => {
               assetType: 'png',
               matched: true,
               tokenHex: 'deadbeef',
-              matchedLicenseSubject: 'license-subject-1',
+              matchedLicenseSubject: DEFAULT_LICENSE_SUBJECT,
               wmVersion: 2,
               attempted: 1,
             },
@@ -271,7 +279,7 @@ describe('forensics routes', () => {
     expect(match).not.toHaveProperty('buyerProviderUserId');
     expect(match).not.toHaveProperty('buyerSubjectDiscordUserId');
     expect(payload.investigationReport?.topCandidates).toBeUndefined();
-    expect(JSON.stringify(payload)).not.toContain('license-subject-1');
+    expect(JSON.stringify(payload)).not.toContain(DEFAULT_LICENSE_SUBJECT);
     expect(JSON.stringify(payload)).not.toContain('corr_1');
     expect(JSON.stringify(payload)).not.toContain('runtime-sha');
     expect(mutationMock).toHaveBeenCalledTimes(1);
@@ -280,6 +288,121 @@ describe('forensics routes', () => {
       authUserId: 'creator-user',
       packageId: 'creator.package',
       status: 'attributed',
+    });
+  });
+
+  it('looks up only the attribution-matched license subject for a recovered token', async () => {
+    const expectedTokenHash = sha256Hex('deadbeef');
+    const matchedLicenseSubject = 'f'.repeat(64);
+    const otherLicenseSubject = 'e'.repeat(64);
+
+    queryMock.mockImplementation(async (ref: unknown, args: unknown) => {
+      if (ref === apiMock.couplingForensics.listCouplingTraceCandidatesForAuthUser) {
+        return {
+          capabilityEnabled: true,
+          packageOwned: true,
+          candidates: [
+            {
+              assetPath: 'Assets/Character/body.png',
+              licenseSubject: matchedLicenseSubject,
+              tokenHash: expectedTokenHash,
+            },
+            {
+              assetPath: 'Assets/Character/body.png',
+              licenseSubject: otherLicenseSubject,
+              tokenHash: expectedTokenHash,
+            },
+          ],
+        };
+      }
+      if (ref === apiMock.couplingForensics.lookupTraceMatchesForAuthUser) {
+        expect(args).toEqual({
+          apiSecret: TEST_CONVEX_API_TOKEN,
+          authUserId: 'creator-user',
+          packageId: 'creator.package',
+          matchedCandidates: [
+            {
+              assetPath: 'Assets/Character/body.png',
+              licenseSubject: matchedLicenseSubject,
+              tokenHash: expectedTokenHash,
+            },
+          ],
+        });
+        return {
+          capabilityEnabled: true,
+          packageOwned: true,
+          matches: [
+            {
+              tokenHash: expectedTokenHash,
+              licenseSubject: matchedLicenseSubject,
+              assetPath: 'Assets/Character/body.png',
+              correlationId: 'corr_matched',
+              createdAt: 1_739_999_999_000,
+              runtimeArtifactVersion: 'matched-runtime-version',
+              runtimePlaintextSha256: 'runtime-sha',
+            },
+          ],
+          unmatchedTokenHashes: [],
+          truncated: false,
+        };
+      }
+      throw new Error(`Unexpected query ${String(ref)}`);
+    });
+
+    mutationMock.mockResolvedValue(undefined);
+
+    const fetchMock = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          requestId: 'req-subject-match',
+          results: [
+            {
+              assetPath: 'Assets/Character/body.png',
+              assetType: 'png',
+              matched: true,
+              tokenHex: 'deadbeef',
+              matchedLicenseSubject,
+              wmVersion: 2,
+              attempted: 2,
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const formData = new FormData();
+    formData.set('packageId', 'creator.package');
+    formData.set(
+      'file',
+      new File([Uint8Array.from([21, 22, 23])], 'bundle.zip', { type: 'application/zip' })
+    );
+
+    const response = await routes.lookup(
+      new Request('http://localhost:3001/api/forensics/lookup', {
+        method: 'POST',
+        body: formData,
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      lookupStatus: 'attributed',
+      results: [
+        {
+          assetPath: 'Assets/Character/body.png',
+          matched: true,
+          matches: [
+            {
+              runtimeArtifactVersion: 'matched-runtime-version',
+            },
+          ],
+        },
+      ],
     });
   });
 
@@ -972,13 +1095,20 @@ describe('forensics routes', () => {
           apiSecret: TEST_CONVEX_API_TOKEN,
           authUserId: 'creator-user',
           packageId: 'creator.package',
-          tokenHashes: [expectedTokenHash],
+          matchedCandidates: [
+            {
+              assetPath: 'Assets/Character/body.png',
+              licenseSubject: DEFAULT_LICENSE_SUBJECT,
+              tokenHash: expectedTokenHash,
+            },
+          ],
         });
         return {
           capabilityEnabled: true,
           packageOwned: true,
           matches: [],
           unmatchedTokenHashes: [expectedTokenHash],
+          truncated: false,
         };
       }
       throw new Error(`Unexpected query ${String(ref)}`);
@@ -996,7 +1126,7 @@ describe('forensics routes', () => {
               assetType: 'png',
               matched: true,
               tokenHex: 'deadbeef',
-              matchedLicenseSubject: 'license-subject-1',
+              matchedLicenseSubject: DEFAULT_LICENSE_SUBJECT,
               wmVersion: 2,
               attempted: 1,
             },
@@ -1047,6 +1177,81 @@ describe('forensics routes', () => {
     });
   });
 
+  it('fails closed when exact trace match lookup is truncated', async () => {
+    const expectedTokenHash = sha256Hex('deadbeef');
+
+    queryMock.mockImplementation(async (ref: unknown) => {
+      if (ref === apiMock.couplingForensics.listCouplingTraceCandidatesForAuthUser) {
+        return {
+          capabilityEnabled: true,
+          packageOwned: true,
+          candidates: defaultCandidates(expectedTokenHash),
+        };
+      }
+      if (ref === apiMock.couplingForensics.lookupTraceMatchesForAuthUser) {
+        return {
+          capabilityEnabled: true,
+          packageOwned: true,
+          matches: [],
+          unmatchedTokenHashes: [],
+          truncated: true,
+        };
+      }
+      throw new Error(`Unexpected query ${String(ref)}`);
+    });
+
+    mutationMock.mockResolvedValue(undefined);
+
+    const fetchMock = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          requestId: 'req-truncated-match',
+          results: [
+            {
+              assetPath: 'Assets/Character/body.png',
+              assetType: 'png',
+              matched: true,
+              tokenHex: 'deadbeef',
+              matchedLicenseSubject: DEFAULT_LICENSE_SUBJECT,
+              wmVersion: 2,
+              attempted: 1,
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const formData = new FormData();
+    formData.set('packageId', 'creator.package');
+    formData.set(
+      'file',
+      new File([Uint8Array.from([24, 25, 26])], 'bundle.zip', { type: 'application/zip' })
+    );
+
+    const response = await routes.lookup(
+      new Request('http://localhost:3001/api/forensics/lookup', {
+        method: 'POST',
+        body: formData,
+      })
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Trace match limit exceeded; retry with fewer recovered assets',
+      code: 'coupling_trace_match_limit_exceeded',
+    });
+    expect(mutationMock).toHaveBeenCalledTimes(1);
+    expect(mutationMock.mock.calls[0]?.[1]).toMatchObject({
+      packageId: 'creator.package',
+      status: 'error',
+    });
+  });
+
   it('rehydrates buyer identity from the encrypted stored license instead of redundant stored buyer columns', async () => {
     const encryptedLicenseKey = await encryptForensicsLicenseKey(
       'test-placeholder-forensics-license-key',
@@ -1069,7 +1274,7 @@ describe('forensics routes', () => {
           matches: [
             {
               tokenHash: expectedTokenHash,
-              licenseSubject: 'license-subject-1',
+              licenseSubject: DEFAULT_LICENSE_SUBJECT,
               assetPath: 'Assets/Character/body.png',
               correlationId: 'corr_1',
               createdAt: 1_739_999_999_000,
@@ -1113,7 +1318,7 @@ describe('forensics routes', () => {
               assetType: 'png',
               matched: true,
               tokenHex: 'deadbeef',
-              matchedLicenseSubject: 'license-subject-1',
+              matchedLicenseSubject: DEFAULT_LICENSE_SUBJECT,
               wmVersion: 2,
               attempted: 1,
             },

--- a/apps/api/src/routes/forensics.test.ts
+++ b/apps/api/src/routes/forensics.test.ts
@@ -345,6 +345,56 @@ describe('forensics routes', () => {
     });
   });
 
+  it('fails closed when the trace candidate scan is truncated before attribution', async () => {
+    queryMock.mockImplementation(async (ref: unknown) => {
+      if (ref === apiMock.couplingForensics.listCouplingTraceCandidatesForAuthUser) {
+        return {
+          capabilityEnabled: true,
+          packageOwned: true,
+          truncated: true,
+          candidateLimit: 512,
+          candidates: defaultCandidates(sha256Hex('deadbeef')),
+        };
+      }
+      throw new Error(`Unexpected query ${String(ref)}`);
+    });
+    mutationMock.mockResolvedValue(undefined);
+
+    const fetchMock = mock(async () => {
+      throw new Error('Coupling service should not be called with a truncated candidate set');
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const formData = new FormData();
+    formData.set('packageId', 'creator.package');
+    formData.set(
+      'file',
+      new File([Uint8Array.from([1, 2, 3])], 'bundle.zip', { type: 'application/zip' })
+    );
+
+    const response = await routes.lookup(
+      new Request('http://localhost:3001/api/forensics/lookup', {
+        method: 'POST',
+        body: formData,
+      })
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Trace candidate limit exceeded; narrow the package or retry after archival',
+      code: 'coupling_trace_candidate_limit_exceeded',
+      candidateLimit: 512,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mutationMock).toHaveBeenCalledTimes(1);
+    expect(mutationMock.mock.calls[0]?.[1]).toMatchObject({
+      packageId: 'creator.package',
+      status: 'error',
+      requestedTokenCount: 512,
+      matchedTokenCount: 0,
+    });
+  });
+
   it('keeps proxied dashboard requests on the session auth path when no internal auth user header is present', async () => {
     const previousInternalRpcSecret = process.env.INTERNAL_RPC_SHARED_SECRET;
     process.env.INTERNAL_RPC_SHARED_SECRET = 'test-internal-secret';

--- a/apps/api/src/routes/forensics.ts
+++ b/apps/api/src/routes/forensics.ts
@@ -269,7 +269,7 @@ function buildMatchedTraceCandidate(
   const licenseSubject = scoreResult.matchedLicenseSubject?.trim().toLowerCase() || '';
   if (!licenseSubject) {
     throw new CouplingServiceRequestError(
-      `Coupling attribution matched ${scoreResult.assetPath} without a license subject`,
+      'Coupling attribution returned a decoded match without a license subject',
       502
     );
   }

--- a/apps/api/src/routes/forensics.ts
+++ b/apps/api/src/routes/forensics.ts
@@ -339,6 +339,22 @@ function buildLookupMatchId(
     .digest('hex');
 }
 
+function buildLookupBuyerMatchId(
+  config: ForensicsConfig,
+  packageId: string,
+  match: {
+    licenseSubject: string;
+  }
+): string {
+  return createHmac('sha256', config.encryptionSecret)
+    .update('forensics-lookup-buyer-match-v1')
+    .update('\0')
+    .update(packageId)
+    .update('\0')
+    .update(match.licenseSubject)
+    .digest('hex');
+}
+
 export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
   const convex = getConvexClientFromUrl(config.convexUrl);
 
@@ -827,6 +843,7 @@ export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
           matched: matches.length > 0,
           matches: matches.map((match: (typeof matches)[number]) => ({
             matchId: buildLookupMatchId(config, packageId, match),
+            buyerMatchId: buildLookupBuyerMatchId(config, packageId, match),
             assetPath: match.assetPath,
             createdAt: match.createdAt,
             runtimeArtifactVersion: match.runtimeArtifactVersion,

--- a/apps/api/src/routes/forensics.ts
+++ b/apps/api/src/routes/forensics.ts
@@ -96,9 +96,9 @@ function jsonResponse(body: object, status = 200, headers?: Record<string, strin
   return new Response(JSON.stringify(body), {
     status,
     headers: {
+      ...headers,
       'Content-Type': 'application/json',
       'Cache-Control': 'no-store',
-      ...headers,
     },
   });
 }
@@ -274,7 +274,7 @@ function buildMatchedTraceCandidate(
     );
   }
   return {
-    assetPath: scoreResult.assetPath,
+    assetPath: scoreResult.matchedCandidateAssetPath ?? scoreResult.assetPath,
     licenseSubject,
     tokenHash: sha256HexFromBytes(new TextEncoder().encode(scoreResult.tokenHex)),
   };

--- a/apps/api/src/routes/forensics.ts
+++ b/apps/api/src/routes/forensics.ts
@@ -244,22 +244,74 @@ function buildLookupRateLimitKey(viewer: ForensicsViewer, request: Request): str
   return `forensics:lookup:user:${authUserHash}:ip:${clientAddressHash}`;
 }
 
+type MatchedTraceCandidate = {
+  assetPath: string;
+  licenseSubject: string;
+  tokenHash: string;
+};
+
 function normalizeDeclaredPackageIds(values: string[]): string[] {
   return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean))).sort(
     (left, right) => left.localeCompare(right)
   );
 }
 
+function buildTraceCandidateKey(candidate: MatchedTraceCandidate): string {
+  return `${candidate.assetPath}\0${candidate.licenseSubject}\0${candidate.tokenHash}`;
+}
+
+function buildMatchedTraceCandidate(
+  scoreResult: ForensicsScoreResult
+): MatchedTraceCandidate | null {
+  if (!scoreResult.tokenHex) {
+    return null;
+  }
+  const licenseSubject = scoreResult.matchedLicenseSubject?.trim().toLowerCase() || '';
+  if (!licenseSubject) {
+    throw new CouplingServiceRequestError(
+      `Coupling attribution matched ${scoreResult.assetPath} without a license subject`,
+      502
+    );
+  }
+  return {
+    assetPath: scoreResult.assetPath,
+    licenseSubject,
+    tokenHash: sha256HexFromBytes(new TextEncoder().encode(scoreResult.tokenHex)),
+  };
+}
+
+function buildMatchedTraceCandidates(
+  decodedResults: ForensicsScoreResult[]
+): MatchedTraceCandidate[] {
+  const candidates: MatchedTraceCandidate[] = [];
+  const seen = new Set<string>();
+  for (const scoreResult of decodedResults) {
+    const candidate = buildMatchedTraceCandidate(scoreResult);
+    if (!candidate) {
+      continue;
+    }
+    const key = buildTraceCandidateKey(candidate);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    candidates.push(candidate);
+  }
+  return candidates;
+}
+
 function classifyLayerB(
   scoreResult: ForensicsScoreResult,
-  matchedTokenHashes: Set<string>
+  matchedTraceKeys: Set<string>
 ): LayerBClassification {
   if (scoreResult.preclassification === 'decoded') {
-    if (!scoreResult.tokenHex) {
+    const candidate = buildMatchedTraceCandidate(scoreResult);
+    if (!candidate) {
       return 'no-signal-found';
     }
-    const tokenHash = sha256HexFromBytes(new TextEncoder().encode(scoreResult.tokenHex));
-    return matchedTokenHashes.has(tokenHash) ? 'trace-recovered' : 'tamper-suspected';
+    return matchedTraceKeys.has(buildTraceCandidateKey(candidate))
+      ? 'trace-recovered'
+      : 'tamper-suspected';
   }
   if (scoreResult.preclassification === 'likely-stripped') {
     return 'trace-likely-stripped';
@@ -708,7 +760,7 @@ export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
 
       // Seed-iteration attribution: the closed coupling service re-derives each recorded buyer's
       // per-job placement seed and decodes the leaked assets against them. We only hand it candidate
-      // (assetPath, licenseSubject, tokenHash) tuples — the master key and native code stay server-side.
+      // (assetPath, licenseSubject, tokenHash) tuples; the master key and native code stay server-side.
       const scoreResults = await runCouplingAttribution(
         extraction.assets,
         candidateResult.candidates,
@@ -757,15 +809,14 @@ export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
         });
       }
 
-      const tokenHashes = decodedResults
-        .filter((r) => r.tokenHex !== undefined)
-        .map((r) => sha256HexFromBytes(new TextEncoder().encode(r.tokenHex as string)));
+      const matchedCandidates = buildMatchedTraceCandidates(decodedResults);
+      const tokenHashes = matchedCandidates.map((candidate) => candidate.tokenHash);
 
       const lookupResult = await convex.query(api.couplingForensics.lookupTraceMatchesForAuthUser, {
         apiSecret: config.convexApiSecret,
         authUserId: viewer.authUserId,
         packageId,
-        tokenHashes,
+        matchedCandidates,
       });
 
       if (!lookupResult.capabilityEnabled) {
@@ -810,30 +861,47 @@ export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
         });
       }
 
-      const matchesByTokenHash = new Map<string, typeof lookupResult.matches>();
-      for (const match of lookupResult.matches) {
-        const bucket = matchesByTokenHash.get(match.tokenHash) ?? [];
-        bucket.push(match);
-        matchesByTokenHash.set(match.tokenHash, bucket);
+      if (lookupResult.truncated) {
+        await convex.mutation(api.couplingForensics.recordLookupAudit, {
+          apiSecret: config.convexApiSecret,
+          authUserId: viewer.authUserId,
+          packageId,
+          source: viewer.source,
+          status: 'error',
+          requestedTokenCount: matchedCandidates.length,
+          matchedTokenCount: 0,
+          uploadSha256,
+        });
+        return jsonResponse(
+          {
+            error: 'Trace match limit exceeded; retry with fewer recovered assets',
+            code: 'coupling_trace_match_limit_exceeded',
+          },
+          409
+        );
       }
 
-      const matchedTokenHashSet = new Set<string>(
-        lookupResult.matches.map((m: { tokenHash: string }) => m.tokenHash)
+      const matchedTraceKeySet = new Set<string>(
+        lookupResult.matches.map((match: MatchedTraceCandidate) => buildTraceCandidateKey(match))
       );
       const enrichedMatches = await enrichTraceMatches(viewer, lookupResult.matches);
-      const enrichedMatchesByTokenHash = new Map<string, typeof enrichedMatches>();
+      const enrichedMatchesByTraceKey = new Map<string, typeof enrichedMatches>();
       for (const match of enrichedMatches) {
-        const bucket = enrichedMatchesByTokenHash.get(match.tokenHash) ?? [];
+        const matchKey = buildTraceCandidateKey(match);
+        const bucket = enrichedMatchesByTraceKey.get(matchKey) ?? [];
         bucket.push(match);
-        enrichedMatchesByTokenHash.set(match.tokenHash, bucket);
+        enrichedMatchesByTraceKey.set(matchKey, bucket);
       }
 
       const results = scoreResults.map((scoreResult) => {
-        const tokenHash = scoreResult.tokenHex
-          ? sha256HexFromBytes(new TextEncoder().encode(scoreResult.tokenHex))
-          : null;
-        const matches = tokenHash ? (enrichedMatchesByTokenHash.get(tokenHash) ?? []) : [];
-        const layerBClassification = classifyLayerB(scoreResult, matchedTokenHashSet);
+        const candidate =
+          scoreResult.preclassification === 'decoded'
+            ? buildMatchedTraceCandidate(scoreResult)
+            : null;
+        const matches = candidate
+          ? (enrichedMatchesByTraceKey.get(buildTraceCandidateKey(candidate)) ?? [])
+          : [];
+        const layerBClassification = classifyLayerB(scoreResult, matchedTraceKeySet);
         return {
           assetPath: scoreResult.assetPath,
           assetType: scoreResult.assetType,

--- a/apps/api/src/routes/forensics.ts
+++ b/apps/api/src/routes/forensics.ts
@@ -554,6 +554,27 @@ export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
         });
       }
 
+      if (candidateResult.truncated) {
+        await convex.mutation(api.couplingForensics.recordLookupAudit, {
+          apiSecret: config.convexApiSecret,
+          authUserId: viewer.authUserId,
+          packageId,
+          source: viewer.source,
+          status: 'error',
+          requestedTokenCount: candidateResult.candidateLimit,
+          matchedTokenCount: 0,
+          uploadSha256,
+        });
+        return jsonResponse(
+          {
+            error: 'Trace candidate limit exceeded; narrow the package or retry after archival',
+            code: 'coupling_trace_candidate_limit_exceeded',
+            candidateLimit: candidateResult.candidateLimit,
+          },
+          409
+        );
+      }
+
       // Seed-iteration attribution: the closed coupling service re-derives each recorded buyer's
       // per-job placement seed and decodes the leaked assets against them. We only hand it candidate
       // (assetPath, licenseSubject, tokenHash) tuples — the master key and native code stay server-side.

--- a/apps/api/src/routes/forensics.ts
+++ b/apps/api/src/routes/forensics.ts
@@ -11,7 +11,7 @@ import {
   CouplingServiceConfigurationError,
   CouplingServiceRequestError,
   type ForensicsScoreResult,
-  runCouplingForensicsScore,
+  runCouplingAttribution,
 } from '../lib/couplingForensicsService';
 import { rejectCrossSiteRequest } from '../lib/csrf';
 import { logger } from '../lib/logger';
@@ -503,10 +503,68 @@ export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
         });
       }
 
-      const scoreResults = await runCouplingForensicsScore(extraction.assets, {
-        baseUrl: config.couplingServiceBaseUrl,
-        sharedSecret: config.couplingServiceSharedSecret,
-      });
+      const candidateResult = await convex.query(
+        api.couplingForensics.listCouplingTraceCandidatesForAuthUser,
+        {
+          apiSecret: config.convexApiSecret,
+          authUserId: viewer.authUserId,
+          packageId,
+        }
+      );
+
+      if (!candidateResult.capabilityEnabled) {
+        await convex.mutation(api.couplingForensics.recordLookupAudit, {
+          apiSecret: config.convexApiSecret,
+          authUserId: viewer.authUserId,
+          packageId,
+          source: viewer.source,
+          status: 'denied',
+          requestedTokenCount: 0,
+          matchedTokenCount: 0,
+          uploadSha256,
+        });
+        return jsonResponse(
+          {
+            error: 'Creator Studio+ is required for coupling traceability',
+            code: 'coupling_traceability_required',
+          },
+          402
+        );
+      }
+
+      if (!candidateResult.packageOwned) {
+        await convex.mutation(api.couplingForensics.recordLookupAudit, {
+          apiSecret: config.convexApiSecret,
+          authUserId: viewer.authUserId,
+          packageId,
+          source: viewer.source,
+          status: 'denied',
+          requestedTokenCount: 0,
+          matchedTokenCount: 0,
+          uploadSha256,
+        });
+        return jsonResponse({
+          packageId,
+          lookupStatus: 'hostile_unknown' satisfies ForensicsLookupStatus,
+          message: buildLookupMessage('hostile_unknown'),
+          candidateAssetCount: extraction.assets.length,
+          decodedAssetCount: 0,
+          results: [],
+          investigationReport: buildInvestigationReport([], extraction.assets.length),
+        });
+      }
+
+      // Seed-iteration attribution: the closed coupling service re-derives each recorded buyer's
+      // per-job placement seed and decodes the leaked assets against them. We only hand it candidate
+      // (assetPath, licenseSubject, tokenHash) tuples — the master key and native code stay server-side.
+      const scoreResults = await runCouplingAttribution(
+        extraction.assets,
+        candidateResult.candidates,
+        {
+          baseUrl: config.couplingServiceBaseUrl,
+          sharedSecret: config.couplingServiceSharedSecret,
+        }
+      );
 
       const decodedResults = scoreResults.filter(
         (r) => r.preclassification === 'decoded' && r.tokenHex

--- a/apps/api/src/routes/forensics.ts
+++ b/apps/api/src/routes/forensics.ts
@@ -421,6 +421,11 @@ export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
       return jsonResponse({ error: 'Method not allowed' }, 405);
     }
 
+    const declaredContentLength = Number.parseInt(request.headers.get('content-length') ?? '', 10);
+    if (Number.isFinite(declaredContentLength) && declaredContentLength > MAX_UPLOAD_SIZE_BYTES) {
+      return jsonResponse({ error: 'Upload exceeds the size limit' }, 413);
+    }
+
     const workspaceDir = await mkdtemp(path.join(tmpdir(), 'yucp-forensics-'));
     let auditContext: {
       authUserId: string;
@@ -573,6 +578,29 @@ export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
           },
           409
         );
+      }
+
+      if (candidateResult.candidates.length === 0) {
+        const lookupStatus: ForensicsLookupStatus = 'hostile_unknown';
+        await convex.mutation(api.couplingForensics.recordLookupAudit, {
+          apiSecret: config.convexApiSecret,
+          authUserId: viewer.authUserId,
+          packageId,
+          source: viewer.source,
+          status: buildAuditStatus(lookupStatus),
+          requestedTokenCount: 0,
+          matchedTokenCount: 0,
+          uploadSha256,
+        });
+        return jsonResponse({
+          packageId,
+          lookupStatus,
+          message: buildLookupMessage(lookupStatus),
+          candidateAssetCount: extraction.assets.length,
+          decodedAssetCount: 0,
+          results: [],
+          investigationReport: buildInvestigationReport([], extraction.assets.length),
+        });
       }
 
       // Seed-iteration attribution: the closed coupling service re-derives each recorded buyer's

--- a/apps/api/src/routes/forensics.ts
+++ b/apps/api/src/routes/forensics.ts
@@ -590,7 +590,12 @@ export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
       } catch {
         return jsonResponse({ error: 'Invalid multipart form data' }, 400);
       }
-      const packageId = assertPackageId(String(formData.get('packageId') ?? ''));
+      let packageId: string;
+      try {
+        packageId = assertPackageId(String(formData.get('packageId') ?? ''));
+      } catch {
+        return jsonResponse({ error: 'Invalid packageId format' }, 400);
+      }
       const upload = formData.get('file');
       if (!(upload instanceof File)) {
         return jsonResponse({ error: 'Missing upload file' }, 400);

--- a/apps/api/src/routes/forensics.ts
+++ b/apps/api/src/routes/forensics.ts
@@ -578,14 +578,12 @@ export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
       uploadSha256?: string;
     } | null = null;
     try {
-      const replayBody = new ArrayBuffer(boundedRequestBody.byteLength);
-      new Uint8Array(replayBody).set(boundedRequestBody);
       let formData: FormData;
       try {
         formData = await new Request(request.url, {
           method: request.method,
           headers: formDataHeaders,
-          body: replayBody,
+          body: boundedRequestBody.buffer as ArrayBuffer,
         }).formData();
       } catch {
         return jsonResponse({ error: 'Invalid multipart form data' }, 400);

--- a/apps/api/src/routes/forensics.ts
+++ b/apps/api/src/routes/forensics.ts
@@ -27,6 +27,7 @@ import { decryptForensicsLicenseKey } from '../verification/forensicsLicenseKey'
 
 const PACKAGE_ID_RE = /^[a-z0-9\-_./:]{1,128}$/;
 const MAX_UPLOAD_SIZE_BYTES = 100 * 1024 * 1024;
+const MAX_LOOKUP_MULTIPART_OVERHEAD_BYTES = 1024 * 1024;
 const MAX_UPLOAD_FILENAME_LENGTH = 128;
 const FORENSICS_LOOKUP_RATE_LIMIT_MAX_REQUESTS = 30;
 const FORENSICS_LOOKUP_RATE_LIMIT_WINDOW_MS = 60_000;
@@ -212,6 +213,13 @@ function resolveLookupUploadLimit(config: ForensicsConfig): number {
     return Math.floor(configured);
   }
   return MAX_UPLOAD_SIZE_BYTES;
+}
+
+function resolveLookupRequestBodyLimit(maxLookupUploadBytes: number): number {
+  return Math.min(
+    maxLookupUploadBytes + MAX_LOOKUP_MULTIPART_OVERHEAD_BYTES,
+    Number.MAX_SAFE_INTEGER
+  );
 }
 
 function resolveLookupRateLimitMaxRequests(config: ForensicsConfig): number {
@@ -481,9 +489,10 @@ export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
     }
 
     const maxLookupUploadBytes = resolveLookupUploadLimit(config);
+    const maxLookupRequestBodyBytes = resolveLookupRequestBodyLimit(maxLookupUploadBytes);
     let boundedRequestBody: Uint8Array;
     try {
-      boundedRequestBody = await readRequestBytesWithLimit(request, maxLookupUploadBytes);
+      boundedRequestBody = await readRequestBytesWithLimit(request, maxLookupRequestBodyBytes);
     } catch (error) {
       if (error instanceof RequestBodyError && error.status === 413) {
         return jsonResponse({ error: 'Upload exceeds the size limit' }, 413);

--- a/apps/api/src/routes/forensics.ts
+++ b/apps/api/src/routes/forensics.ts
@@ -15,7 +15,11 @@ import {
 } from '../lib/couplingForensicsService';
 import { rejectCrossSiteRequest } from '../lib/csrf';
 import { logger } from '../lib/logger';
-import { RequestBodyError, readJsonObjectBodyWithLimit } from '../lib/requestBody';
+import {
+  RequestBodyError,
+  readJsonObjectBodyWithLimit,
+  readRequestBytesWithLimit,
+} from '../lib/requestBody';
 import { getProviderRuntime } from '../providers/index';
 import { decryptForensicsLicenseKey } from '../verification/forensicsLicenseKey';
 
@@ -32,6 +36,7 @@ export type ForensicsConfig = {
   convexApiSecret: string;
   convexUrl: string;
   encryptionSecret: string;
+  maxLookupUploadBytes?: number;
 };
 
 type ForensicsViewer = {
@@ -188,6 +193,14 @@ async function resolveViewer(
 
 function sha256HexFromBytes(bytes: Uint8Array): string {
   return createHash('sha256').update(bytes).digest('hex');
+}
+
+function resolveLookupUploadLimit(config: ForensicsConfig): number {
+  const configured = config.maxLookupUploadBytes;
+  if (typeof configured === 'number' && Number.isFinite(configured) && configured > 0) {
+    return Math.floor(configured);
+  }
+  return MAX_UPLOAD_SIZE_BYTES;
 }
 
 function normalizeDeclaredPackageIds(values: string[]): string[] {
@@ -421,10 +434,18 @@ export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
       return jsonResponse({ error: 'Method not allowed' }, 405);
     }
 
-    const declaredContentLength = Number.parseInt(request.headers.get('content-length') ?? '', 10);
-    if (Number.isFinite(declaredContentLength) && declaredContentLength > MAX_UPLOAD_SIZE_BYTES) {
-      return jsonResponse({ error: 'Upload exceeds the size limit' }, 413);
+    const maxLookupUploadBytes = resolveLookupUploadLimit(config);
+    let boundedRequestBody: Uint8Array;
+    try {
+      boundedRequestBody = await readRequestBytesWithLimit(request, maxLookupUploadBytes);
+    } catch (error) {
+      if (error instanceof RequestBodyError && error.status === 413) {
+        return jsonResponse({ error: 'Upload exceeds the size limit' }, 413);
+      }
+      throw error;
     }
+    const formDataHeaders = new Headers(request.headers);
+    formDataHeaders.delete('content-length');
 
     const workspaceDir = await mkdtemp(path.join(tmpdir(), 'yucp-forensics-'));
     let auditContext: {
@@ -434,7 +455,13 @@ export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
       uploadSha256?: string;
     } | null = null;
     try {
-      const formData = await request.formData();
+      const replayBody = new ArrayBuffer(boundedRequestBody.byteLength);
+      new Uint8Array(replayBody).set(boundedRequestBody);
+      const formData = await new Request(request.url, {
+        method: request.method,
+        headers: formDataHeaders,
+        body: replayBody,
+      }).formData();
       const packageId = assertPackageId(String(formData.get('packageId') ?? ''));
       const upload = formData.get('file');
       if (!(upload instanceof File)) {
@@ -443,7 +470,7 @@ export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
       if (upload.size <= 0) {
         return jsonResponse({ error: 'Upload is empty' }, 400);
       }
-      if (upload.size > MAX_UPLOAD_SIZE_BYTES) {
+      if (upload.size > maxLookupUploadBytes) {
         return jsonResponse({ error: 'Upload exceeds the size limit' }, 413);
       }
 

--- a/apps/api/src/routes/forensics.ts
+++ b/apps/api/src/routes/forensics.ts
@@ -1,10 +1,11 @@
-import { createHash } from 'node:crypto';
+import { createHash, createHmac } from 'node:crypto';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { getInternalRpcSharedSecret, timingSafeStringEqual } from '@yucp/shared';
 import { api } from '../../../../convex/_generated/api';
 import type { Auth } from '../auth';
+import { getClientAddress } from '../lib/clientAddress';
 import { getConvexClientFromUrl } from '../lib/convex';
 import { extractCouplingForensicsArchive } from '../lib/couplingForensicsArchives';
 import {
@@ -16,17 +17,19 @@ import {
 import { rejectCrossSiteRequest } from '../lib/csrf';
 import { logger } from '../lib/logger';
 import {
-  RequestBodyError,
-  readJsonObjectBodyWithLimit,
-  readRequestBytesWithLimit,
-} from '../lib/requestBody';
+  checkPublicApiRateLimit,
+  getPublicApiRateLimitStore,
+  type PublicApiRateLimitStore,
+} from '../lib/publicApiRateLimit';
+import { RequestBodyError, readRequestBytesWithLimit } from '../lib/requestBody';
 import { getProviderRuntime } from '../providers/index';
 import { decryptForensicsLicenseKey } from '../verification/forensicsLicenseKey';
 
 const PACKAGE_ID_RE = /^[a-z0-9\-_./:]{1,128}$/;
 const MAX_UPLOAD_SIZE_BYTES = 100 * 1024 * 1024;
 const MAX_UPLOAD_FILENAME_LENGTH = 128;
-const FORENSICS_REVEAL_BODY_MAX_BYTES = 4 * 1024;
+const FORENSICS_LOOKUP_RATE_LIMIT_MAX_REQUESTS = 30;
+const FORENSICS_LOOKUP_RATE_LIMIT_WINDOW_MS = 60_000;
 
 export type ForensicsConfig = {
   apiBaseUrl: string;
@@ -37,6 +40,9 @@ export type ForensicsConfig = {
   convexUrl: string;
   encryptionSecret: string;
   maxLookupUploadBytes?: number;
+  lookupRateLimitMaxRequests?: number;
+  lookupRateLimitStore?: PublicApiRateLimitStore;
+  lookupRateLimitWindowMs?: number;
 };
 
 type ForensicsViewer = {
@@ -85,12 +91,13 @@ function buildAuditStatus(
   }
 }
 
-function jsonResponse(body: object, status = 200): Response {
+function jsonResponse(body: object, status = 200, headers?: Record<string, string>): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: {
       'Content-Type': 'application/json',
       'Cache-Control': 'no-store',
+      ...headers,
     },
   });
 }
@@ -195,12 +202,38 @@ function sha256HexFromBytes(bytes: Uint8Array): string {
   return createHash('sha256').update(bytes).digest('hex');
 }
 
+function sha256HexFromString(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
 function resolveLookupUploadLimit(config: ForensicsConfig): number {
   const configured = config.maxLookupUploadBytes;
   if (typeof configured === 'number' && Number.isFinite(configured) && configured > 0) {
     return Math.floor(configured);
   }
   return MAX_UPLOAD_SIZE_BYTES;
+}
+
+function resolveLookupRateLimitMaxRequests(config: ForensicsConfig): number {
+  const configured = config.lookupRateLimitMaxRequests;
+  if (typeof configured === 'number' && Number.isFinite(configured) && configured > 0) {
+    return Math.floor(configured);
+  }
+  return FORENSICS_LOOKUP_RATE_LIMIT_MAX_REQUESTS;
+}
+
+function resolveLookupRateLimitWindowMs(config: ForensicsConfig): number {
+  const configured = config.lookupRateLimitWindowMs;
+  if (typeof configured === 'number' && Number.isFinite(configured) && configured > 0) {
+    return Math.floor(configured);
+  }
+  return FORENSICS_LOOKUP_RATE_LIMIT_WINDOW_MS;
+}
+
+function buildLookupRateLimitKey(viewer: ForensicsViewer, request: Request): string {
+  const authUserHash = sha256HexFromString(viewer.authUserId);
+  const clientAddressHash = sha256HexFromString(getClientAddress(request));
+  return `forensics:lookup:user:${authUserHash}:ip:${clientAddressHash}`;
 }
 
 function normalizeDeclaredPackageIds(values: string[]): string[] {
@@ -233,16 +266,11 @@ type InvestigationReport = {
   unattributedCount: number;
   strippedCount: number;
   noSignalCount: number;
-  topCandidates: Array<{
-    licenseSubject: string;
-    assetCount: number;
-  }>;
 };
 
 function buildInvestigationReport(
   results: Array<{
     layerBClassification: LayerBClassification;
-    matches: Array<{ licenseSubject: string }>;
   }>,
   totalAssets: number
 ): InvestigationReport {
@@ -252,19 +280,11 @@ function buildInvestigationReport(
   let strippedCount = 0;
   let noSignalCount = 0;
 
-  const candidateCounts = new Map<string, number>();
-
   for (const result of results) {
     switch (result.layerBClassification) {
       case 'trace-recovered':
         decodedCount++;
         attributedCount++;
-        for (const match of result.matches) {
-          candidateCounts.set(
-            match.licenseSubject,
-            (candidateCounts.get(match.licenseSubject) ?? 0) + 1
-          );
-        }
         break;
       case 'tamper-suspected':
         decodedCount++;
@@ -279,11 +299,6 @@ function buildInvestigationReport(
     }
   }
 
-  const topCandidates = Array.from(candidateCounts.entries())
-    .sort(([, a], [, b]) => b - a)
-    .slice(0, 10)
-    .map(([licenseSubject, assetCount]) => ({ licenseSubject, assetCount }));
-
   return {
     totalAssets,
     decodedCount,
@@ -291,8 +306,29 @@ function buildInvestigationReport(
     unattributedCount,
     strippedCount,
     noSignalCount,
-    topCandidates,
   };
+}
+
+function buildLookupMatchId(
+  config: ForensicsConfig,
+  packageId: string,
+  match: {
+    licenseSubject: string;
+    tokenHash: string;
+    assetPath: string;
+  }
+): string {
+  return createHmac('sha256', config.encryptionSecret)
+    .update('forensics-lookup-match-v1')
+    .update('\0')
+    .update(packageId)
+    .update('\0')
+    .update(match.licenseSubject)
+    .update('\0')
+    .update(match.tokenHash)
+    .update('\0')
+    .update(match.assetPath)
+    .digest('hex');
 }
 
 export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
@@ -434,6 +470,16 @@ export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
       return jsonResponse({ error: 'Method not allowed' }, 405);
     }
 
+    const rateLimit = await checkPublicApiRateLimit({
+      store: config.lookupRateLimitStore ?? getPublicApiRateLimitStore(),
+      key: buildLookupRateLimitKey(viewer, request),
+      limit: resolveLookupRateLimitMaxRequests(config),
+      windowMs: resolveLookupRateLimitWindowMs(config),
+    });
+    if (!rateLimit.allowed) {
+      return jsonResponse({ error: 'Too many requests' }, 429, rateLimit.headers);
+    }
+
     const maxLookupUploadBytes = resolveLookupUploadLimit(config);
     let boundedRequestBody: Uint8Array;
     try {
@@ -457,11 +503,16 @@ export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
     try {
       const replayBody = new ArrayBuffer(boundedRequestBody.byteLength);
       new Uint8Array(replayBody).set(boundedRequestBody);
-      const formData = await new Request(request.url, {
-        method: request.method,
-        headers: formDataHeaders,
-        body: replayBody,
-      }).formData();
+      let formData: FormData;
+      try {
+        formData = await new Request(request.url, {
+          method: request.method,
+          headers: formDataHeaders,
+          body: replayBody,
+        }).formData();
+      } catch {
+        return jsonResponse({ error: 'Invalid multipart form data' }, 400);
+      }
       const packageId = assertPackageId(String(formData.get('packageId') ?? ''));
       const upload = formData.get('file');
       if (!(upload instanceof File)) {
@@ -766,30 +817,19 @@ export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
           layerBClassification,
           matched: matches.length > 0,
           matches: matches.map((match: (typeof matches)[number]) => ({
-            licenseSubject: match.licenseSubject,
+            matchId: buildLookupMatchId(config, packageId, match),
             assetPath: match.assetPath,
-            correlationId: match.correlationId,
             createdAt: match.createdAt,
             runtimeArtifactVersion: match.runtimeArtifactVersion,
-            runtimePlaintextSha256: match.runtimePlaintextSha256,
-            machineFingerprintHash: match.machineFingerprintHash,
-            projectIdHash: match.projectIdHash,
-            ...(match.grantId !== undefined ? { grantId: match.grantId } : {}),
             ...(match.packFamily !== undefined ? { packFamily: match.packFamily } : {}),
             ...(match.packVersion !== undefined ? { packVersion: match.packVersion } : {}),
             ...(match.provider !== undefined ? { provider: match.provider } : {}),
             ...(match.licenseMasked !== undefined ? { licenseMasked: match.licenseMasked } : {}),
-            ...(match.buyerProviderUserId !== undefined
-              ? { buyerProviderUserId: match.buyerProviderUserId }
-              : {}),
             ...(match.buyerProviderUsername !== undefined
               ? { buyerProviderUsername: match.buyerProviderUsername }
               : {}),
             ...(match.buyerSubjectDisplayName !== undefined
               ? { buyerSubjectDisplayName: match.buyerSubjectDisplayName }
-              : {}),
-            ...(match.buyerSubjectDiscordUserId !== undefined
-              ? { buyerSubjectDiscordUserId: match.buyerSubjectDiscordUserId }
               : {}),
           })),
         };
@@ -863,55 +903,8 @@ export function createForensicsRoutes(auth: Auth, config: ForensicsConfig) {
     }
   }
 
-  async function revealLicense(request: Request): Promise<Response> {
-    const viewer = await resolveViewer(request, auth, config);
-    if (viewer instanceof Response) {
-      return viewer;
-    }
-    if (request.method !== 'POST') {
-      return jsonResponse({ error: 'Method not allowed' }, 405);
-    }
-    try {
-      const body = await readJsonObjectBodyWithLimit(request, FORENSICS_REVEAL_BODY_MAX_BYTES);
-      let packageId: string;
-      try {
-        packageId = assertPackageId(String(body.packageId ?? ''));
-      } catch (error) {
-        return jsonResponse(
-          { error: error instanceof Error ? error.message : 'Invalid packageId format' },
-          400
-        );
-      }
-      const licenseSubject = String(body.licenseSubject ?? '')
-        .trim()
-        .toLowerCase();
-      if (!/^[0-9a-f]{64}$/.test(licenseSubject)) {
-        return jsonResponse({ error: 'Invalid licenseSubject' }, 400);
-      }
-      const result = await convex.mutation(api.couplingForensics.revealCouplingLicenseKey, {
-        apiSecret: config.convexApiSecret,
-        authUserId: viewer.authUserId,
-        packageId,
-        licenseSubject,
-      });
-      if (result.error) {
-        return jsonResponse({ error: 'Forbidden' }, 403);
-      }
-      return jsonResponse({ licenseKey: result.licenseKey });
-    } catch (error) {
-      if (error instanceof RequestBodyError) {
-        return jsonResponse({ error: error.message }, error.status);
-      }
-      logger.error('Failed to reveal coupling license key', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return jsonResponse({ error: 'Failed to reveal license key' }, 500);
-    }
-  }
-
   return {
     listPackages,
     lookup,
-    revealLicense,
   };
 }

--- a/apps/bot/src/commands/forensics.ts
+++ b/apps/bot/src/commands/forensics.ts
@@ -58,7 +58,7 @@ function sanitizeUploadFileName(input: string): string {
 }
 
 function escapeDiscordText(input: string): string {
-  return escapeMarkdown(input.replace(/`/g, "'")).replace(/@/g, '@\u200b');
+  return escapeMarkdown(input.replace(/[\r\n]+/g, ' ').replace(/`/g, "'")).replace(/@/g, '@\u200b');
 }
 
 function formatDiscordInlineCode(input: string): string {

--- a/apps/bot/src/commands/forensics.ts
+++ b/apps/bot/src/commands/forensics.ts
@@ -175,20 +175,24 @@ export async function handleForensicsLookup(
 
     const matchedEntries = payload.results.filter((entry) => entry.matched);
     const uniqueBuyerMatches = new Set<string>();
+    const shownBuyerMatches = new Set<string>();
     const detailLines: string[] = [];
 
-    for (const entry of matchedEntries.slice(0, 5)) {
-      const primaryMatch = entry.matches[0];
-      if (!primaryMatch) {
-        continue;
+    for (const entry of matchedEntries) {
+      for (const match of entry.matches) {
+        const matchIdentity = getForensicsMatchIdentity(match);
+        uniqueBuyerMatches.add(matchIdentity);
+        if (detailLines.length >= 5 || shownBuyerMatches.has(matchIdentity)) {
+          continue;
+        }
+        shownBuyerMatches.add(matchIdentity);
+        detailLines.push(
+          `- \`${entry.assetPath}\` -> \`${formatForensicsMatchLabel(match)}\` (${formatCreatedAt(match.createdAt)})`
+        );
       }
-      uniqueBuyerMatches.add(getForensicsMatchIdentity(primaryMatch));
-      detailLines.push(
-        `- \`${entry.assetPath}\` -> \`${formatForensicsMatchLabel(primaryMatch)}\` (${formatCreatedAt(primaryMatch.createdAt)})`
-      );
     }
 
-    const remainingMatchCount = Math.max(0, matchedEntries.length - detailLines.length);
+    const remainingBuyerCount = Math.max(0, uniqueBuyerMatches.size - shownBuyerMatches.size);
 
     const content = [
       matchedEntries.length > 0
@@ -203,8 +207,8 @@ export async function handleForensicsLookup(
       matchedEntries.length > 0 ? `Matched buyers: ${uniqueBuyerMatches.size}` : payload.message,
       detailLines.length > 0 ? '' : null,
       ...(detailLines.length > 0 ? ['Top matches:', ...detailLines] : []),
-      remainingMatchCount > 0
-        ? `Use the dashboard for the remaining ${remainingMatchCount} matched asset${remainingMatchCount === 1 ? '' : 's'}${dashboardUrl ? `: ${dashboardUrl}` : '.'}`
+      remainingBuyerCount > 0
+        ? `Use the dashboard for the remaining ${remainingBuyerCount} matched buyer${remainingBuyerCount === 1 ? '' : 's'}${dashboardUrl ? `: ${dashboardUrl}` : '.'}`
         : dashboardUrl
           ? `Dashboard: ${dashboardUrl}`
           : null,

--- a/apps/bot/src/commands/forensics.ts
+++ b/apps/bot/src/commands/forensics.ts
@@ -1,13 +1,14 @@
 import { createLogger, getInternalRpcSharedSecret } from '@yucp/shared';
 import type { ConvexHttpClient } from 'convex/browser';
 import type { AutocompleteInteraction, ChatInputCommandInteraction } from 'discord.js';
-import { MessageFlags } from 'discord.js';
+import { escapeMarkdown, MessageFlags } from 'discord.js';
 import { api } from '../../../../convex/_generated/api';
 import { getApiUrls } from '../lib/apiUrls';
 import { E } from '../lib/emojis';
 
 const logger = createLogger(process.env.LOG_LEVEL ?? 'info');
 const MAX_UPLOAD_SIZE_BYTES = 100 * 1024 * 1024;
+const NO_ALLOWED_MENTIONS = { parse: [] } as const;
 
 type ForensicsLookupResponse = {
   packageId: string;
@@ -54,6 +55,14 @@ function sanitizeUploadFileName(input: string): string {
     return 'forensics-upload.bin';
   }
   return trimmed.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+function escapeDiscordText(input: string): string {
+  return escapeMarkdown(input.replace(/`/g, "'")).replace(/@/g, '@\u200b');
+}
+
+function formatDiscordInlineCode(input: string): string {
+  return `\`${escapeDiscordText(input)}\``;
 }
 
 function formatCreatedAt(timestamp: number): string {
@@ -115,6 +124,7 @@ export async function handleForensicsLookup(
   if (attachment.size > MAX_UPLOAD_SIZE_BYTES) {
     await interaction.editReply({
       content: `${E.Library} This upload is larger than the current limit. Use the dashboard upload instead${dashboardUrl ? `: ${dashboardUrl}` : '.'}`,
+      allowedMentions: NO_ALLOWED_MENTIONS,
     });
     return;
   }
@@ -124,6 +134,7 @@ export async function handleForensicsLookup(
   if (!apiBase) {
     await interaction.editReply({
       content: `${E.X_} The API URL is not configured for coupling lookups right now.`,
+      allowedMentions: NO_ALLOWED_MENTIONS,
     });
     return;
   }
@@ -160,6 +171,7 @@ export async function handleForensicsLookup(
     if (response.status === 402 || payload?.code === 'coupling_traceability_required') {
       await interaction.editReply({
         content: `${E.Key} Creator Studio+ is required for coupling traceability.${dashboardUrl ? ` Upgrade or run the lookup from the dashboard: ${dashboardUrl}` : ''}`,
+        allowedMentions: NO_ALLOWED_MENTIONS,
       });
       return;
     }
@@ -169,6 +181,7 @@ export async function handleForensicsLookup(
         payload && typeof payload.error === 'string' ? payload.error : 'Coupling lookup failed.';
       await interaction.editReply({
         content: `${E.X_} ${message}${dashboardUrl ? `\n\nIf this keeps happening, try the dashboard uploader: ${dashboardUrl}` : ''}`,
+        allowedMentions: NO_ALLOWED_MENTIONS,
       });
       return;
     }
@@ -186,8 +199,9 @@ export async function handleForensicsLookup(
           continue;
         }
         shownBuyerMatches.add(matchIdentity);
+        const matchLabel = formatForensicsMatchLabel(match);
         detailLines.push(
-          `- \`${entry.assetPath}\` -> \`${formatForensicsMatchLabel(match)}\` (${formatCreatedAt(match.createdAt)})`
+          `- ${formatDiscordInlineCode(entry.assetPath)} -> ${formatDiscordInlineCode(matchLabel)} (${formatCreatedAt(match.createdAt)})`
         );
       }
     }
@@ -198,8 +212,8 @@ export async function handleForensicsLookup(
       matchedEntries.length > 0
         ? `${E.Checkmark} Coupling lookup complete`
         : `${E.Library} Coupling lookup complete`,
-      `Package: \`${payload.packageId}\``,
-      `File: \`${attachment.name ?? 'upload'}\``,
+      `Package: ${formatDiscordInlineCode(payload.packageId)}`,
+      `File: ${formatDiscordInlineCode(attachment.name ?? 'upload')}`,
       `Status: ${payload.lookupStatus.replace(/_/g, ' ')}`,
       `Candidates scanned: ${payload.candidateAssetCount}`,
       `Decoded assets: ${payload.decodedAssetCount}`,
@@ -216,7 +230,7 @@ export async function handleForensicsLookup(
       .filter((line): line is string => Boolean(line))
       .join('\n');
 
-    await interaction.editReply({ content });
+    await interaction.editReply({ content, allowedMentions: NO_ALLOWED_MENTIONS });
   } catch (error) {
     logger.error('Coupling forensics lookup command failed', {
       error: error instanceof Error ? error.message : String(error),
@@ -226,6 +240,7 @@ export async function handleForensicsLookup(
 
     await interaction.editReply({
       content: `${E.X_} Coupling lookup failed.${dashboardUrl ? ` Try the dashboard uploader instead: ${dashboardUrl}` : ''}`,
+      allowedMentions: NO_ALLOWED_MENTIONS,
     });
   }
 }

--- a/apps/bot/src/commands/forensics.ts
+++ b/apps/bot/src/commands/forensics.ts
@@ -21,13 +21,20 @@ type ForensicsLookupResponse = {
     decoderKind: string;
     tokenLength: number;
     matched: boolean;
-    classification: 'attributed' | 'hostile_unknown';
+    layerBClassification:
+      | 'trace-recovered'
+      | 'tamper-suspected'
+      | 'trace-likely-stripped'
+      | 'no-signal-found';
     matches: Array<{
-      licenseSubject: string;
+      matchId: string;
+      buyerMatchId?: string | null;
       assetPath: string;
-      correlationId: string | null;
       createdAt: number;
       runtimeArtifactVersion?: string | null;
+      licenseMasked?: string | null;
+      buyerProviderUsername?: string | null;
+      buyerSubjectDisplayName?: string | null;
     }>;
   }>;
 };
@@ -55,6 +62,21 @@ function formatCreatedAt(timestamp: number): string {
     month: 'short',
     day: 'numeric',
   });
+}
+
+type ForensicsLookupMatch = ForensicsLookupResponse['results'][number]['matches'][number];
+
+function getForensicsMatchIdentity(match: ForensicsLookupMatch): string {
+  return match.buyerMatchId?.trim() || match.matchId;
+}
+
+function formatForensicsMatchLabel(match: ForensicsLookupMatch): string {
+  const buyerLabel = match.buyerSubjectDisplayName?.trim() || match.buyerProviderUsername?.trim();
+  const licenseLabel = match.licenseMasked?.trim();
+  if (buyerLabel && licenseLabel) {
+    return `${buyerLabel} (${licenseLabel})`;
+  }
+  return buyerLabel || licenseLabel || `match ${getForensicsMatchIdentity(match).slice(0, 12)}`;
 }
 
 export async function handleForensicsPackageAutocomplete(
@@ -152,7 +174,7 @@ export async function handleForensicsLookup(
     }
 
     const matchedEntries = payload.results.filter((entry) => entry.matched);
-    const uniqueLicenseSubjects = new Set<string>();
+    const uniqueBuyerMatches = new Set<string>();
     const detailLines: string[] = [];
 
     for (const entry of matchedEntries.slice(0, 5)) {
@@ -160,9 +182,9 @@ export async function handleForensicsLookup(
       if (!primaryMatch) {
         continue;
       }
-      uniqueLicenseSubjects.add(primaryMatch.licenseSubject);
+      uniqueBuyerMatches.add(getForensicsMatchIdentity(primaryMatch));
       detailLines.push(
-        `- \`${entry.assetPath}\` -> \`${primaryMatch.licenseSubject}\` (${formatCreatedAt(primaryMatch.createdAt)})`
+        `- \`${entry.assetPath}\` -> \`${formatForensicsMatchLabel(primaryMatch)}\` (${formatCreatedAt(primaryMatch.createdAt)})`
       );
     }
 
@@ -178,9 +200,7 @@ export async function handleForensicsLookup(
       `Candidates scanned: ${payload.candidateAssetCount}`,
       `Decoded assets: ${payload.decodedAssetCount}`,
       `Matched assets: ${matchedEntries.length}`,
-      matchedEntries.length > 0
-        ? `Matched licenses: ${uniqueLicenseSubjects.size}`
-        : payload.message,
+      matchedEntries.length > 0 ? `Matched buyers: ${uniqueBuyerMatches.size}` : payload.message,
       detailLines.length > 0 ? '' : null,
       ...(detailLines.length > 0 ? ['Top matches:', ...detailLines] : []),
       remainingMatchCount > 0

--- a/apps/bot/test/commands/forensics.test.ts
+++ b/apps/bot/test/commands/forensics.test.ts
@@ -229,4 +229,109 @@ describe('forensics command', () => {
     expect(reply?.content).toContain('BuyerAccount');
     expect(reply?.content).not.toContain('undefined');
   });
+
+  it('counts all matched buyers and deduplicates top match details', async () => {
+    process.env.API_BASE_URL = 'https://api.example.test';
+    process.env.API_INTERNAL_URL = 'https://api.example.test';
+    process.env.FRONTEND_URL = 'https://web.example.test';
+    process.env.NODE_ENV = 'test';
+
+    const interaction = attachLookupOptions(
+      mockSlashCommand({
+        commandName: 'creator-admin',
+        guildId: 'guild_1',
+        stringOptions: {
+          package_id: 'creator.package',
+        },
+        subcommand: 'lookup',
+        subcommandGroup: 'forensics',
+      }),
+      {
+        contentType: 'application/zip',
+        name: 'upload.zip',
+        size: 128,
+        url: 'https://cdn.example.test/upload.zip',
+      }
+    );
+
+    const fetchMock = mock(async (input: string | URL | Request) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+
+      if (url === 'https://cdn.example.test/upload.zip') {
+        return new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/zip' },
+        });
+      }
+
+      if (url === 'https://api.example.test/api/forensics/lookup') {
+        return new Response(
+          JSON.stringify({
+            packageId: 'creator.package',
+            lookupStatus: 'attributed',
+            message: 'Matched stored coupling traces',
+            candidateAssetCount: 6,
+            decodedAssetCount: 6,
+            results: [
+              ...Array.from({ length: 5 }, (_, index) => ({
+                assetPath: `Assets/Character/duplicate-${index}.png`,
+                assetType: 'png',
+                decoderKind: 'png',
+                tokenLength: 8,
+                layerBClassification: 'trace-recovered',
+                matched: true,
+                matches: [
+                  {
+                    matchId: `${index}`.repeat(64).slice(0, 64),
+                    buyerMatchId: 'b'.repeat(64),
+                    assetPath: `Assets/Character/duplicate-${index}.png`,
+                    createdAt: 1_739_999_999_000 + index,
+                    licenseMasked: 'license-a',
+                    buyerProviderUsername: 'BuyerOne',
+                  },
+                ],
+              })),
+              {
+                assetPath: 'Assets/Character/unique.png',
+                assetType: 'png',
+                decoderKind: 'png',
+                tokenLength: 8,
+                layerBClassification: 'trace-recovered',
+                matched: true,
+                matches: [
+                  {
+                    matchId: 'c'.repeat(64),
+                    buyerMatchId: 'd'.repeat(64),
+                    assetPath: 'Assets/Character/unique.png',
+                    createdAt: 1_740_000_000_000,
+                    licenseMasked: 'license-b',
+                    buyerProviderUsername: 'BuyerTwo',
+                  },
+                ],
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+      }
+
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await handleForensicsLookup(interaction as unknown as ChatInputCommandInteraction, {
+      authUserId: 'auth-user-1',
+      guildId: 'guild_1',
+    });
+
+    const reply = interaction.editReply.mock.calls[0]?.[0];
+    const content = reply?.content ?? '';
+    expect(content).toContain('Matched buyers: 2');
+    expect(content).toContain('BuyerTwo');
+    expect(content.match(/BuyerOne/g)?.length).toBe(1);
+  });
 });

--- a/apps/bot/test/commands/forensics.test.ts
+++ b/apps/bot/test/commands/forensics.test.ts
@@ -99,7 +99,7 @@ describe('forensics command', () => {
       }),
       {
         contentType: 'application/zip',
-        name: 'upload.zip',
+        name: 'upload-<@123>.zip',
         size: 128,
         url: 'https://cdn.example.test/upload.zip',
       }
@@ -181,14 +181,14 @@ describe('forensics command', () => {
       if (url === 'https://api.example.test/api/forensics/lookup') {
         return new Response(
           JSON.stringify({
-            packageId: 'creator.package',
+            packageId: 'creator.package<@123>',
             lookupStatus: 'attributed',
             message: 'Matched stored coupling traces',
             candidateAssetCount: 1,
             decodedAssetCount: 1,
             results: [
               {
-                assetPath: 'Assets/Character/body.png',
+                assetPath: 'Assets/Character/<@123>body.png',
                 assetType: 'png',
                 decoderKind: 'png',
                 tokenLength: 8,
@@ -198,11 +198,11 @@ describe('forensics command', () => {
                   {
                     matchId: 'a'.repeat(64),
                     buyerMatchId: 'b'.repeat(64),
-                    assetPath: 'Assets/Character/body.png',
+                    assetPath: 'Assets/Character/<@123>body.png',
                     createdAt: 1_739_999_999_000,
                     runtimeArtifactVersion: '2026.03.25.153000',
                     licenseMasked: 'jinxxy · ffffffff',
-                    buyerProviderUsername: 'BuyerAccount',
+                    buyerProviderUsername: '<@123> **BuyerAccount** @everyone',
                   },
                 ],
               },
@@ -225,9 +225,14 @@ describe('forensics command', () => {
     });
 
     const reply = interaction.editReply.mock.calls[0]?.[0];
-    expect(reply?.content).toContain('Matched buyers: 1');
-    expect(reply?.content).toContain('BuyerAccount');
-    expect(reply?.content).not.toContain('undefined');
+    const content = reply?.content ?? '';
+    expect(reply?.allowedMentions).toEqual({ parse: [] });
+    expect(content).toContain('Matched buyers: 1');
+    expect(content).toContain('BuyerAccount');
+    expect(content).not.toContain('<@123>');
+    expect(content).not.toContain('@everyone');
+    expect(content).not.toContain('**BuyerAccount**');
+    expect(content).not.toContain('undefined');
   });
 
   it('counts all matched buyers and deduplicates top match details', async () => {

--- a/apps/bot/test/commands/forensics.test.ts
+++ b/apps/bot/test/commands/forensics.test.ts
@@ -142,4 +142,91 @@ describe('forensics command', () => {
     expect(reply?.content).toContain('coupling traceability');
     expect(reply?.content).toContain('https://web.example.test/dashboard/packages?view=forensics');
   });
+
+  it('renders attributed matches with bot-safe buyer fields', async () => {
+    process.env.API_BASE_URL = 'https://api.example.test';
+    process.env.API_INTERNAL_URL = 'https://api.example.test';
+    process.env.FRONTEND_URL = 'https://web.example.test';
+    process.env.NODE_ENV = 'test';
+
+    const interaction = attachLookupOptions(
+      mockSlashCommand({
+        commandName: 'creator-admin',
+        guildId: 'guild_1',
+        stringOptions: {
+          package_id: 'creator.package',
+        },
+        subcommand: 'lookup',
+        subcommandGroup: 'forensics',
+      }),
+      {
+        contentType: 'application/zip',
+        name: 'upload.zip',
+        size: 128,
+        url: 'https://cdn.example.test/upload.zip',
+      }
+    );
+
+    const fetchMock = mock(async (input: string | URL | Request) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+
+      if (url === 'https://cdn.example.test/upload.zip') {
+        return new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/zip' },
+        });
+      }
+
+      if (url === 'https://api.example.test/api/forensics/lookup') {
+        return new Response(
+          JSON.stringify({
+            packageId: 'creator.package',
+            lookupStatus: 'attributed',
+            message: 'Matched stored coupling traces',
+            candidateAssetCount: 1,
+            decodedAssetCount: 1,
+            results: [
+              {
+                assetPath: 'Assets/Character/body.png',
+                assetType: 'png',
+                decoderKind: 'png',
+                tokenLength: 8,
+                layerBClassification: 'trace-recovered',
+                matched: true,
+                matches: [
+                  {
+                    matchId: 'a'.repeat(64),
+                    buyerMatchId: 'b'.repeat(64),
+                    assetPath: 'Assets/Character/body.png',
+                    createdAt: 1_739_999_999_000,
+                    runtimeArtifactVersion: '2026.03.25.153000',
+                    licenseMasked: 'jinxxy · ffffffff',
+                    buyerProviderUsername: 'BuyerAccount',
+                  },
+                ],
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+      }
+
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await handleForensicsLookup(interaction as unknown as ChatInputCommandInteraction, {
+      authUserId: 'auth-user-1',
+      guildId: 'guild_1',
+    });
+
+    const reply = interaction.editReply.mock.calls[0]?.[0];
+    expect(reply?.content).toContain('Matched buyers: 1');
+    expect(reply?.content).toContain('BuyerAccount');
+    expect(reply?.content).not.toContain('undefined');
+  });
 });

--- a/apps/bot/test/commands/forensics.test.ts
+++ b/apps/bot/test/commands/forensics.test.ts
@@ -161,7 +161,7 @@ describe('forensics command', () => {
       }),
       {
         contentType: 'application/zip',
-        name: 'upload.zip',
+        name: 'upload\npwned-file.zip',
         size: 128,
         url: 'https://cdn.example.test/upload.zip',
       }
@@ -181,14 +181,14 @@ describe('forensics command', () => {
       if (url === 'https://api.example.test/api/forensics/lookup') {
         return new Response(
           JSON.stringify({
-            packageId: 'creator.package<@123>',
+            packageId: 'creator.package<@123>\npwned-package',
             lookupStatus: 'attributed',
             message: 'Matched stored coupling traces',
             candidateAssetCount: 1,
             decodedAssetCount: 1,
             results: [
               {
-                assetPath: 'Assets/Character/<@123>body.png',
+                assetPath: 'Assets/Character/<@123>body.png\r\npwned-asset',
                 assetType: 'png',
                 decoderKind: 'png',
                 tokenLength: 8,
@@ -198,11 +198,11 @@ describe('forensics command', () => {
                   {
                     matchId: 'a'.repeat(64),
                     buyerMatchId: 'b'.repeat(64),
-                    assetPath: 'Assets/Character/<@123>body.png',
+                    assetPath: 'Assets/Character/<@123>body.png\r\npwned-asset',
                     createdAt: 1_739_999_999_000,
                     runtimeArtifactVersion: '2026.03.25.153000',
                     licenseMasked: 'jinxxy · ffffffff',
-                    buyerProviderUsername: '<@123> **BuyerAccount** @everyone',
+                    buyerProviderUsername: '<@123> **BuyerAccount**\r\npwned-buyer @everyone',
                   },
                 ],
               },
@@ -232,6 +232,11 @@ describe('forensics command', () => {
     expect(content).not.toContain('<@123>');
     expect(content).not.toContain('@everyone');
     expect(content).not.toContain('**BuyerAccount**');
+    expect(content).not.toContain('\r');
+    expect(content).not.toContain('\npwned-package');
+    expect(content).not.toContain('\npwned-file');
+    expect(content).not.toContain('\npwned-asset');
+    expect(content).not.toContain('\npwned-buyer');
     expect(content).not.toContain('undefined');
   });
 

--- a/apps/web/src/components/dashboard/CouplingForensicsPanel.tsx
+++ b/apps/web/src/components/dashboard/CouplingForensicsPanel.tsx
@@ -13,7 +13,6 @@ import {
   type CouplingForensicsLookupResponse,
   isCouplingTraceabilityRequiredError,
   listCouplingForensicsPackages,
-  revealCouplingLicenseKey,
   runCouplingForensicsLookup,
 } from '@/lib/couplingForensics';
 import { BILLING_CAPABILITY_KEYS } from '../../../../../convex/lib/billingCapabilities';
@@ -66,17 +65,13 @@ function getVerdictKind(
 
 function getBuyerDisplayLabel(match: {
   buyerSubjectDisplayName?: string | null;
-  purchaserEmail?: string | null;
   buyerProviderUsername?: string | null;
-  buyerProviderUserId?: string | null;
-  buyerSubjectDiscordUserId?: string | null;
+  licenseMasked?: string | null;
 }) {
   return (
     match.buyerSubjectDisplayName?.trim() ||
-    match.purchaserEmail?.trim() ||
     match.buyerProviderUsername?.trim() ||
-    match.buyerProviderUserId?.trim() ||
-    match.buyerSubjectDiscordUserId?.trim() ||
+    match.licenseMasked?.trim() ||
     null
   );
 }
@@ -293,29 +288,20 @@ export function CouplingForensicsPanel({ initialPackageId }: { initialPackageId?
     }
   }, [packageOptions, selectedPackageId]);
 
-  // Collect all matches across all matched assets, deduplicated by licenseSubject
+  // Collect all matches across all matched assets, deduplicated by opaque match id.
   const matchedBuyers = useMemo(() => {
     if (!lookupResult) return [];
     const seen = new Set<string>();
     const buyers: Array<{
-      licenseSubject: string;
+      matchId: string;
       createdAt: number;
-      correlationId: string | null;
       runtimeArtifactVersion?: string | null;
-      runtimePlaintextSha256?: string | null;
-      machineFingerprintHash?: string | null;
-      projectIdHash?: string | null;
-      grantId?: string | null;
       packFamily?: string | null;
       packVersion?: string | null;
       provider?: string | null;
       licenseMasked?: string | null;
-      purchaserEmail?: string | null;
-      licenseKey?: string | null;
-      buyerProviderUserId?: string | null;
       buyerProviderUsername?: string | null;
       buyerSubjectDisplayName?: string | null;
-      buyerSubjectDiscordUserId?: string | null;
       buyerDisplayLabel: string;
     }> = [];
     for (const entry of lookupResult.results) {
@@ -323,27 +309,18 @@ export function CouplingForensicsPanel({ initialPackageId }: { initialPackageId?
       for (const match of entry.matches) {
         const buyerDisplayLabel = getBuyerDisplayLabel(match);
         if (!buyerDisplayLabel) continue;
-        if (!seen.has(match.licenseSubject)) {
-          seen.add(match.licenseSubject);
+        if (!seen.has(match.matchId)) {
+          seen.add(match.matchId);
           buyers.push({
-            licenseSubject: match.licenseSubject,
+            matchId: match.matchId,
             createdAt: match.createdAt,
-            correlationId: match.correlationId,
             runtimeArtifactVersion: match.runtimeArtifactVersion,
-            runtimePlaintextSha256: match.runtimePlaintextSha256,
-            machineFingerprintHash: match.machineFingerprintHash,
-            projectIdHash: match.projectIdHash,
-            grantId: match.grantId,
             packFamily: match.packFamily,
             packVersion: match.packVersion,
             provider: match.provider,
             licenseMasked: match.licenseMasked,
-            purchaserEmail: match.purchaserEmail?.trim() || null,
-            licenseKey: match.licenseKey,
-            buyerProviderUserId: match.buyerProviderUserId,
             buyerProviderUsername: match.buyerProviderUsername,
             buyerSubjectDisplayName: match.buyerSubjectDisplayName,
-            buyerSubjectDiscordUserId: match.buyerSubjectDiscordUserId,
             buyerDisplayLabel,
           });
         }
@@ -352,15 +329,12 @@ export function CouplingForensicsPanel({ initialPackageId }: { initialPackageId?
     return buyers.sort((a, b) => b.createdAt - a.createdAt);
   }, [lookupResult]);
 
-  const [revealedKeys, setRevealedKeys] = useState<Record<string, string>>({});
-
   const lookupMutation = useMutation({
     mutationFn: ({ packageId, file }: { packageId: string; file: File }) =>
       runCouplingForensicsLookup({ packageId, file }),
     onMutate: () => {
       setInlineError(null);
       setLookupResult(null);
-      setRevealedKeys({});
     },
     onSuccess: (result) => {
       setLookupResult(result);
@@ -377,31 +351,6 @@ export function CouplingForensicsPanel({ initialPackageId }: { initialPackageId?
         return;
       }
       setInlineError('Scan failed. Please try again with a supported .unitypackage or .zip file.');
-    },
-  });
-
-  const revealMutation = useMutation({
-    mutationFn: ({ licenseSubject }: { licenseSubject: string }) =>
-      revealCouplingLicenseKey({
-        packageId: lookupResult?.packageId ?? selectedPackageId,
-        licenseSubject,
-      }),
-    onSuccess: (result, variables) => {
-      if (result.licenseKey) {
-        setRevealedKeys((prev) => ({
-          ...prev,
-          [variables.licenseSubject]: result.licenseKey as string,
-        }));
-      }
-    },
-    onError: (error) => {
-      if (isDashboardAuthError(error)) {
-        markSessionExpired();
-        return;
-      }
-      toast.error('Could not reveal license key', {
-        description: 'You may not have access, or no key is on file for this license.',
-      });
     },
   });
 
@@ -795,7 +744,7 @@ export function CouplingForensicsPanel({ initialPackageId }: { initialPackageId?
                   />
                   <div className="space-y-3">
                     {matchedBuyers.map((buyer) => (
-                      <div key={buyer.licenseSubject} className="fx-pane space-y-3 p-4">
+                      <div key={buyer.matchId} className="fx-pane space-y-3 p-4">
                         <div className="flex flex-wrap items-center justify-between gap-2">
                           <p className="text-foreground text-sm font-semibold">
                             {buyer.buyerDisplayLabel}
@@ -807,16 +756,10 @@ export function CouplingForensicsPanel({ initialPackageId }: { initialPackageId?
                           ) : null}
                         </div>
                         <dl className="grid grid-cols-1 gap-x-6 gap-y-2.5 sm:grid-cols-2">
-                          {buyer.buyerSubjectDiscordUserId &&
-                          buyer.buyerSubjectDiscordUserId !== buyer.buyerDisplayLabel ? (
-                            <MetaField label="Discord">{buyer.buyerSubjectDiscordUserId}</MetaField>
-                          ) : null}
-
-                          {(buyer.buyerProviderUsername || buyer.buyerProviderUserId) &&
-                          (buyer.buyerProviderUsername ?? buyer.buyerProviderUserId) !==
-                            buyer.buyerDisplayLabel ? (
+                          {buyer.buyerProviderUsername &&
+                          buyer.buyerProviderUsername !== buyer.buyerDisplayLabel ? (
                             <MetaField label="Store account">
-                              {buyer.buyerProviderUsername ?? buyer.buyerProviderUserId}
+                              {buyer.buyerProviderUsername}
                             </MetaField>
                           ) : null}
 
@@ -824,58 +767,15 @@ export function CouplingForensicsPanel({ initialPackageId }: { initialPackageId?
                             {formatBuyerDate(buyer.createdAt)}
                           </MetaField>
 
-                          {buyer.licenseMasked ||
-                          buyer.licenseKey ||
-                          revealedKeys[buyer.licenseSubject] ? (
+                          {buyer.licenseMasked ? (
                             <MetaField label="License" full mono>
-                              {(revealedKeys[buyer.licenseSubject] ?? buyer.licenseKey) ? (
-                                (revealedKeys[buyer.licenseSubject] ?? buyer.licenseKey)
-                              ) : (
-                                <span className="inline-flex flex-wrap items-center gap-2">
-                                  <span>{buyer.licenseMasked}</span>
-                                  <Button
-                                    size="sm"
-                                    variant="primary"
-                                    isPending={
-                                      revealMutation.isPending &&
-                                      revealMutation.variables?.licenseSubject ===
-                                        buyer.licenseSubject
-                                    }
-                                    isDisabled={revealMutation.isPending}
-                                    onPress={() =>
-                                      revealMutation.mutate({
-                                        licenseSubject: buyer.licenseSubject,
-                                      })
-                                    }
-                                  >
-                                    Reveal key
-                                  </Button>
-                                </span>
-                              )}
+                              {buyer.licenseMasked}
                             </MetaField>
                           ) : null}
 
                           {buyer.runtimeArtifactVersion ? (
                             <MetaField label="Package version" mono>
                               {buyer.runtimeArtifactVersion}
-                            </MetaField>
-                          ) : null}
-
-                          {buyer.grantId ? (
-                            <MetaField label="Grant ID" mono>
-                              {buyer.grantId}
-                            </MetaField>
-                          ) : null}
-
-                          {buyer.machineFingerprintHash ? (
-                            <MetaField label="Machine fingerprint (SHA-256)" full mono>
-                              {buyer.machineFingerprintHash}
-                            </MetaField>
-                          ) : null}
-
-                          {buyer.projectIdHash ? (
-                            <MetaField label="Project ID (SHA-256)" full mono>
-                              {buyer.projectIdHash}
                             </MetaField>
                           ) : null}
                         </dl>

--- a/apps/web/src/components/dashboard/CouplingForensicsPanel.tsx
+++ b/apps/web/src/components/dashboard/CouplingForensicsPanel.tsx
@@ -288,12 +288,12 @@ export function CouplingForensicsPanel({ initialPackageId }: { initialPackageId?
     }
   }, [packageOptions, selectedPackageId]);
 
-  // Collect all matches across all matched assets, deduplicated by opaque match id.
+  // Collect all matches across all matched assets, deduplicated by opaque buyer/license id.
   const matchedBuyers = useMemo(() => {
     if (!lookupResult) return [];
     const seen = new Set<string>();
     const buyers: Array<{
-      matchId: string;
+      buyerMatchId: string;
       createdAt: number;
       runtimeArtifactVersion?: string | null;
       packFamily?: string | null;
@@ -309,10 +309,11 @@ export function CouplingForensicsPanel({ initialPackageId }: { initialPackageId?
       for (const match of entry.matches) {
         const buyerDisplayLabel = getBuyerDisplayLabel(match);
         if (!buyerDisplayLabel) continue;
-        if (!seen.has(match.matchId)) {
-          seen.add(match.matchId);
+        const buyerMatchId = match.buyerMatchId?.trim() || match.matchId;
+        if (!seen.has(buyerMatchId)) {
+          seen.add(buyerMatchId);
           buyers.push({
-            matchId: match.matchId,
+            buyerMatchId,
             createdAt: match.createdAt,
             runtimeArtifactVersion: match.runtimeArtifactVersion,
             packFamily: match.packFamily,
@@ -744,7 +745,7 @@ export function CouplingForensicsPanel({ initialPackageId }: { initialPackageId?
                   />
                   <div className="space-y-3">
                     {matchedBuyers.map((buyer) => (
-                      <div key={buyer.matchId} className="fx-pane space-y-3 p-4">
+                      <div key={buyer.buyerMatchId} className="fx-pane space-y-3 p-4">
                         <div className="flex flex-wrap items-center justify-between gap-2">
                           <p className="text-foreground text-sm font-semibold">
                             {buyer.buyerDisplayLabel}

--- a/apps/web/src/lib/couplingForensics.ts
+++ b/apps/web/src/lib/couplingForensics.ts
@@ -8,33 +8,20 @@ export interface CouplingForensicsPackageSummary {
 }
 
 export interface CouplingForensicsMatchSummary {
-  licenseSubject: string;
+  matchId: string;
   assetPath: string;
-  correlationId: string | null;
   createdAt: number;
   runtimeArtifactVersion?: string | null;
-  runtimePlaintextSha256?: string | null;
-  machineFingerprintHash?: string | null;
-  projectIdHash?: string | null;
-  grantId?: string | null;
   packFamily?: string | null;
   packVersion?: string | null;
   /** License store ('gumroad', 'jinxxy', etc.) */
   provider?: string | null;
-  /** Non-secret license identifier (provider + short fingerprint). Full key via reveal. */
+  /** Non-secret license identifier (provider + short fingerprint). */
   licenseMasked?: string | null;
-  /** Buyer's email address from the provider API */
-  purchaserEmail?: string | null;
-  /** Raw license key used to verify the purchase */
-  licenseKey?: string | null;
-  /** Provider-native buyer account identifier */
-  buyerProviderUserId?: string | null;
   /** Provider-native buyer account username, if known */
   buyerProviderUsername?: string | null;
   /** Linked Discord subject display name, if the buyer verified through the bot */
   buyerSubjectDisplayName?: string | null;
-  /** Linked Discord subject id, if the buyer verified through the bot */
-  buyerSubjectDiscordUserId?: string | null;
 }
 
 export interface CouplingForensicsAssetResult {
@@ -71,25 +58,6 @@ export async function runCouplingForensicsLookup(args: { packageId: string; file
   return await apiFetch<CouplingForensicsLookupResponse>('/api/forensics/lookup', {
     method: 'POST',
     body: formData,
-  });
-}
-
-export interface CouplingForensicsRevealResponse {
-  licenseKey?: string | null;
-}
-
-/**
- * Reveals the full provider license key behind a forensics match. Privileged + audit-logged
- * server-side; only call from an explicit user action (e.g. a "Reveal" button).
- */
-export async function revealCouplingLicenseKey(args: {
-  packageId: string;
-  licenseSubject: string;
-}) {
-  return await apiFetch<CouplingForensicsRevealResponse>('/api/forensics/reveal-license', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ packageId: args.packageId, licenseSubject: args.licenseSubject }),
   });
 }
 

--- a/apps/web/src/lib/couplingForensics.ts
+++ b/apps/web/src/lib/couplingForensics.ts
@@ -9,6 +9,7 @@ export interface CouplingForensicsPackageSummary {
 
 export interface CouplingForensicsMatchSummary {
   matchId: string;
+  buyerMatchId?: string | null;
   assetPath: string;
   createdAt: number;
   runtimeArtifactVersion?: string | null;

--- a/apps/web/test/e2e/forensicsHarness.ts
+++ b/apps/web/test/e2e/forensicsHarness.ts
@@ -101,13 +101,23 @@ const couplingServer = Bun.serve({
     }
 
     const payload = (await request.json()) as {
-      assets?: Array<{ assetPath?: string; assetType?: string }>;
+      assets?: Array<{ assetPath?: string; assetType?: string; contentBase64?: string }>;
       candidates?: Array<{ assetPath?: string; licenseSubject?: string; tokenHash?: string }>;
     };
     const assets = Array.isArray(payload.assets) ? payload.assets : [];
     const candidates = Array.isArray(payload.candidates) ? payload.candidates : [];
+    const hasText = (value: unknown) => typeof value === 'string' && value.trim().length > 0;
+    const hasInvalidAsset = assets.some(
+      (asset) => !hasText(asset.assetPath) || !hasText(asset.contentBase64)
+    );
+    const hasInvalidCandidate = candidates.some(
+      (candidate) =>
+        !hasText(candidate.assetPath) ||
+        !hasText(candidate.licenseSubject) ||
+        !hasText(candidate.tokenHash)
+    );
 
-    if (assets.length === 0 || candidates.length === 0) {
+    if (assets.length === 0 || candidates.length === 0 || hasInvalidAsset || hasInvalidCandidate) {
       return Response.json({ error: 'Missing attribution inputs' }, { status: 400 });
     }
 

--- a/apps/web/test/e2e/forensicsHarness.ts
+++ b/apps/web/test/e2e/forensicsHarness.ts
@@ -18,6 +18,8 @@ const refs = {
   getConnectionStatus: 'providerConnections:getConnectionStatus',
   getUserGuilds: 'guildLinks:getUserGuilds',
   listConnectionsForUser: 'providerConnections:listConnectionsForUser',
+  listCouplingTraceCandidatesForAuthUser:
+    'couplingForensics:listCouplingTraceCandidatesForAuthUser',
   listOwnedPackageSummariesForAuthUser: 'couplingForensics:listOwnedPackageSummariesForAuthUser',
   recordLookupAudit: 'couplingForensics:recordLookupAudit',
 } as const;
@@ -90,7 +92,7 @@ const couplingServer = Bun.serve({
   async fetch(request) {
     const url = new URL(request.url);
 
-    if (url.pathname !== '/v1/coupling/forensic-score' || request.method !== 'POST') {
+    if (url.pathname !== '/v1/coupling/attribute' || request.method !== 'POST') {
       return new Response('Not found', { status: 404 });
     }
 
@@ -100,15 +102,21 @@ const couplingServer = Bun.serve({
 
     const payload = (await request.json()) as {
       assets?: Array<{ assetPath?: string; assetType?: string }>;
+      candidates?: Array<{ assetPath?: string; licenseSubject?: string; tokenHash?: string }>;
     };
     const assets = Array.isArray(payload.assets) ? payload.assets : [];
+    const candidates = Array.isArray(payload.candidates) ? payload.candidates : [];
+
+    if (assets.length === 0 || candidates.length === 0) {
+      return Response.json({ error: 'Missing attribution inputs' }, { status: 400 });
+    }
 
     return Response.json({
+      requestId: 'forensics-e2e-attribution',
       results: assets.map((asset) => ({
         assetPath: asset.assetPath ?? '',
         assetType: asset.assetType ?? 'fbx',
-        decoderKind: asset.assetType ?? 'fbx',
-        preclassification: 'no-signal',
+        matched: false,
       })),
     });
   },
@@ -167,6 +175,19 @@ const convex = startFakeConvexServer({
           packageName: 'Novaspil Test Package',
           registeredAt: 1,
           updatedAt: 1,
+        },
+      ],
+    }),
+    [refs.listCouplingTraceCandidatesForAuthUser]: () => ({
+      capabilityEnabled: true,
+      packageOwned: true,
+      truncated: false,
+      candidateLimit: 512,
+      candidates: [
+        {
+          assetPath: 'Assets/Forensics/HarnessFixture.fbx',
+          licenseSubject: 'a'.repeat(64),
+          tokenHash: 'b'.repeat(64),
         },
       ],
     }),

--- a/apps/web/test/unit/dashboard-forensics-route.test.tsx
+++ b/apps/web/test/unit/dashboard-forensics-route.test.tsx
@@ -597,6 +597,7 @@ describe('dashboard forensics route', () => {
           matches: [
             {
               matchId: 'match-buyer-one',
+              buyerMatchId: 'buyer-license-one',
               assetPath: 'Assets/Character/body.png',
               createdAt: 1_744_317_600_000,
               runtimeArtifactVersion: 'sha256-b8c6ba93829b',
@@ -637,7 +638,83 @@ describe('dashboard forensics route', () => {
     expect(screen.getByText('BuyerAccount')).toBeInTheDocument();
     expect(screen.getByText('jinxxy:abcd1234')).toBeInTheDocument();
     expect(screen.queryByText('customer-123')).not.toBeInTheDocument();
-    expect(screen.queryByText('11111111-2222-3333-4444-555555555555')).not.toBeInTheDocument();
+    expect(screen.queryByText('test-placeholder-forensics-license-key')).not.toBeInTheDocument();
+  });
+
+  it('deduplicates buyer cards across multiple asset matches for the same buyer', async () => {
+    runCouplingForensicsLookupMock.mockResolvedValue({
+      packageId: 'pkg.creator.bundle',
+      lookupStatus: 'attributed',
+      message: 'Authorized matches found',
+      candidateAssetCount: 2,
+      decodedAssetCount: 2,
+      results: [
+        {
+          assetPath: 'Assets/Character/body.png',
+          assetType: 'png',
+          decoderKind: 'png',
+          tokenLength: 64,
+          matched: true,
+          matches: [
+            {
+              matchId: 'match-body',
+              buyerMatchId: 'buyer-license-one',
+              assetPath: 'Assets/Character/body.png',
+              createdAt: 1_744_317_600_000,
+              runtimeArtifactVersion: 'sha256-b8c6ba93829b',
+              provider: 'jinxxy',
+              buyerSubjectDisplayName: 'Buyer One',
+              licenseMasked: 'jinxxy:abcd1234',
+            },
+          ],
+        },
+        {
+          assetPath: 'Assets/Character/head.png',
+          assetType: 'png',
+          decoderKind: 'png',
+          tokenLength: 64,
+          matched: true,
+          matches: [
+            {
+              matchId: 'match-head',
+              buyerMatchId: 'buyer-license-one',
+              assetPath: 'Assets/Character/head.png',
+              createdAt: 1_744_317_700_000,
+              runtimeArtifactVersion: 'sha256-b8c6ba93829b',
+              provider: 'jinxxy',
+              buyerSubjectDisplayName: 'Buyer One',
+              licenseMasked: 'jinxxy:abcd1234',
+            },
+          ],
+        },
+      ],
+    });
+
+    const Component = CouplingForensicsPanel;
+    if (!Component) {
+      throw new Error('Forensics route component is not defined');
+    }
+
+    render(<Component />, { wrapper: createWrapper() });
+
+    await waitFor(() =>
+      expect(document.getElementById('forensics-file')).toBeInstanceOf(HTMLInputElement)
+    );
+    const fileInput = document.getElementById('forensics-file');
+    if (!(fileInput instanceof HTMLInputElement)) {
+      throw new Error('Forensics file input was not rendered');
+    }
+
+    const upload = new File(['archive'], 'leak.zip', { type: 'application/zip' });
+    fireEvent.change(fileInput, { target: { files: [upload] } });
+
+    await waitFor(() => expect(screen.getByText('leak.zip')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /find buyer/i }));
+
+    await waitFor(() => expect(screen.getByText('Buyer identified')).toBeInTheDocument());
+
+    expect(screen.queryByText('2 buyers identified')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Buyer One')).toHaveLength(1);
   });
 
   it('renders the human package name instead of a raw package id in the selector', async () => {

--- a/apps/web/test/unit/dashboard-forensics-route.test.tsx
+++ b/apps/web/test/unit/dashboard-forensics-route.test.tsx
@@ -535,14 +535,10 @@ describe('dashboard forensics route', () => {
           matched: true,
           matches: [
             {
-              licenseSubject: '3dea218ee2aca2785da88513407c1a78cecc034f6cd2c25d98251a2fbb5717df',
+              matchId: 'match-unresolved',
+              assetPath: 'Assets/Character/body.png',
               createdAt: 1_744_317_600_000,
-              correlationId: 'corr_1',
               runtimeArtifactVersion: 'sha256-b8c6ba93829b',
-              machineFingerprintHash:
-                'e89ae2ec8249eb9f4c1ee28da1b231ade5d54736435bd0f2fa3f9ff54a8d973e',
-              projectIdHash: 'ff42f1be72b7dd37c9eabe011ca258127c3f76cc9c5d44711afa9a3c99af4a5c',
-              grantId: 'b3ea2d7c-00a1-43d2-b41c-28bf59f3fb2d',
               provider: 'jinxxy',
             },
           ],
@@ -600,15 +596,14 @@ describe('dashboard forensics route', () => {
           matched: true,
           matches: [
             {
-              licenseSubject: '3dea218ee2aca2785da88513407c1a78cecc034f6cd2c25d98251a2fbb5717df',
+              matchId: 'match-buyer-one',
+              assetPath: 'Assets/Character/body.png',
               createdAt: 1_744_317_600_000,
-              correlationId: 'corr_1',
               runtimeArtifactVersion: 'sha256-b8c6ba93829b',
               provider: 'jinxxy',
-              buyerProviderUserId: 'customer-123',
+              buyerProviderUsername: 'BuyerAccount',
               buyerSubjectDisplayName: 'Buyer One',
-              buyerSubjectDiscordUserId: 'discord-buyer-1',
-              licenseKey: '11111111-2222-3333-4444-555555555555',
+              licenseMasked: 'jinxxy:abcd1234',
             },
           ],
         },
@@ -639,9 +634,10 @@ describe('dashboard forensics route', () => {
     await waitFor(() => expect(screen.getByText('Buyer identified')).toBeInTheDocument());
 
     expect(screen.getByText('Buyer One')).toBeInTheDocument();
-    expect(screen.getByText('discord-buyer-1')).toBeInTheDocument();
-    expect(screen.getByText('customer-123')).toBeInTheDocument();
-    expect(screen.getByText('11111111-2222-3333-4444-555555555555')).toBeInTheDocument();
+    expect(screen.getByText('BuyerAccount')).toBeInTheDocument();
+    expect(screen.getByText('jinxxy:abcd1234')).toBeInTheDocument();
+    expect(screen.queryByText('customer-123')).not.toBeInTheDocument();
+    expect(screen.queryByText('11111111-2222-3333-4444-555555555555')).not.toBeInTheDocument();
   });
 
   it('renders the human package name instead of a raw package id in the selector', async () => {

--- a/apps/web/test/unit/dashboard-packages-route.test.tsx
+++ b/apps/web/test/unit/dashboard-packages-route.test.tsx
@@ -590,7 +590,6 @@ vi.mock('@/lib/packages', () => ({
 vi.mock('@/lib/couplingForensics', () => ({
   isCouplingTraceabilityRequiredError: vi.fn(() => false),
   listCouplingForensicsPackages: vi.fn(),
-  revealCouplingLicenseKey: vi.fn(),
   runCouplingForensicsLookup: vi.fn(),
 }));
 

--- a/convex/couplingForensics.realtest.ts
+++ b/convex/couplingForensics.realtest.ts
@@ -517,6 +517,110 @@ describe('coupling forensics license subject resolution', () => {
     ]);
   });
 
+  it('reports truncation when duplicate-heavy raw trace rows exceed the scan limit', async () => {
+    const t = makeTestConvex();
+    const now = Date.now();
+    const authUserId = 'creator-candidates-raw-scan-bound-auth';
+    const packageId = 'pkg.creator.candidates.raw-scan-bound';
+    const candidateLimit = 512;
+    const rawScanLimit = candidateLimit * 4;
+    const duplicateLicenseSubject = 'a'.repeat(64);
+    const duplicateTokenHash = '1'.repeat(64);
+    const laterLicenseSubject = 'b'.repeat(64);
+    const laterTokenHash = 'f'.repeat(64);
+
+    await seedCertificateBillingCatalog(t, {
+      productId: 'plan-coupling-traceability',
+      capabilityKeys: ['coupling_traceability'],
+      capabilityKey: 'coupling_traceability',
+      featureFlags: { coupling_traceability: true },
+      benefitMetadata: { coupling_traceability: true },
+    });
+    const creatorProfileId = await seedCreatorProfile(t, {
+      authUserId,
+      ownerDiscordUserId: 'discord-candidates-raw-scan-bound-creator',
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('creator_billing_entitlements', {
+        workspaceKey: buildCreatorProfileWorkspaceKey(creatorProfileId),
+        authUserId,
+        creatorProfileId,
+        planKey: 'creator-suite-plus',
+        productId: 'plan-coupling-traceability',
+        status: 'active',
+        allowEnrollment: true,
+        allowSigning: true,
+        deviceCap: 5,
+        auditRetentionDays: 30,
+        supportTier: 'standard',
+        currentPeriodEnd: now + 86_400_000,
+        graceUntil: now + 3 * 86_400_000,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await ctx.db.insert('package_registry', {
+        packageId,
+        packageName: 'Creator Bundle',
+        publisherId: 'publisher-candidates-raw-scan-bound',
+        yucpUserId: authUserId,
+        status: 'active',
+        registeredAt: now,
+        updatedAt: now,
+      });
+
+      for (let index = 0; index < rawScanLimit + 1; index += 1) {
+        await ctx.db.insert('coupling_trace_records', {
+          authUserId,
+          packageId,
+          licenseSubject: duplicateLicenseSubject,
+          assetPath: 'Assets/Character/body.png',
+          tokenHash: duplicateTokenHash,
+          tokenLength: 64,
+          machineFingerprintHash: 'c'.repeat(64),
+          projectIdHash: 'd'.repeat(64),
+          runtimeArtifactVersion: 'sha256-b8c6ba93829b',
+          runtimePlaintextSha256: 'e'.repeat(64),
+          correlationId: `corr-candidates-raw-scan-bound-${index}`,
+          createdAt: now + index,
+          provider: 'jinxxy',
+        });
+      }
+
+      await ctx.db.insert('coupling_trace_records', {
+        authUserId,
+        packageId,
+        licenseSubject: laterLicenseSubject,
+        assetPath: 'Assets/Character/face.png',
+        tokenHash: laterTokenHash,
+        tokenLength: 64,
+        machineFingerprintHash: 'c'.repeat(64),
+        projectIdHash: 'd'.repeat(64),
+        runtimeArtifactVersion: 'sha256-b8c6ba93829b',
+        runtimePlaintextSha256: 'e'.repeat(64),
+        correlationId: 'corr-candidates-raw-scan-bound-later',
+        createdAt: now + rawScanLimit + 1,
+        provider: 'jinxxy',
+      });
+    });
+
+    const result = await t.query(api.couplingForensics.listCouplingTraceCandidatesForAuthUser, {
+      apiSecret: 'test-secret',
+      authUserId,
+      packageId,
+    });
+
+    expect(result.candidateLimit).toBe(candidateLimit);
+    expect(result.truncated).toBe(true);
+    expect(result.candidates).toEqual([
+      {
+        assetPath: 'Assets/Character/body.png',
+        licenseSubject: duplicateLicenseSubject,
+        tokenHash: duplicateTokenHash,
+      },
+    ]);
+  });
+
   it('returns no trace candidates without the traceability capability', async () => {
     const t = makeTestConvex();
     const now = Date.now();

--- a/convex/couplingForensics.realtest.ts
+++ b/convex/couplingForensics.realtest.ts
@@ -140,4 +140,217 @@ describe('coupling forensics license subject resolution', () => {
     expect(result.matches[0]).not.toHaveProperty('licenseKey');
     expect(result.matches[0]).not.toHaveProperty('purchaserEmail');
   });
+
+  it('lists deduped trace candidates for the package owner with the traceability capability', async () => {
+    const t = makeTestConvex();
+    const now = Date.now();
+    const authUserId = 'creator-candidates-auth';
+    const packageId = 'pkg.creator.candidates';
+    const subjectA = 'a'.repeat(64);
+    const subjectB = 'b'.repeat(64);
+    const tokenHashA = '1'.repeat(64);
+    const tokenHashB = '2'.repeat(64);
+
+    await seedCertificateBillingCatalog(t, {
+      productId: 'plan-coupling-traceability',
+      capabilityKeys: ['coupling_traceability'],
+      capabilityKey: 'coupling_traceability',
+      featureFlags: { coupling_traceability: true },
+      benefitMetadata: { coupling_traceability: true },
+    });
+    const creatorProfileId = await seedCreatorProfile(t, {
+      authUserId,
+      ownerDiscordUserId: 'discord-candidates-creator',
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('creator_billing_entitlements', {
+        workspaceKey: buildCreatorProfileWorkspaceKey(creatorProfileId),
+        authUserId,
+        creatorProfileId,
+        planKey: 'creator-suite-plus',
+        productId: 'plan-coupling-traceability',
+        status: 'active',
+        allowEnrollment: true,
+        allowSigning: true,
+        deviceCap: 5,
+        auditRetentionDays: 30,
+        supportTier: 'standard',
+        currentPeriodEnd: now + 86_400_000,
+        graceUntil: now + 3 * 86_400_000,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await ctx.db.insert('package_registry', {
+        packageId,
+        packageName: 'Creator Bundle',
+        publisherId: 'publisher-candidates',
+        yucpUserId: authUserId,
+        status: 'active',
+        registeredAt: now,
+        updatedAt: now,
+      });
+
+      const baseRecord = {
+        authUserId,
+        packageId,
+        tokenLength: 64,
+        machineFingerprintHash: 'c'.repeat(64),
+        projectIdHash: 'd'.repeat(64),
+        runtimeArtifactVersion: 'sha256-b8c6ba93829b',
+        runtimePlaintextSha256: 'e'.repeat(64),
+        createdAt: now,
+        provider: 'jinxxy',
+      };
+      // Two identical (assetPath, licenseSubject, tokenHash) rows must dedupe to one candidate.
+      await ctx.db.insert('coupling_trace_records', {
+        ...baseRecord,
+        licenseSubject: subjectA,
+        assetPath: 'Assets/Character/body.png',
+        tokenHash: tokenHashA,
+        correlationId: 'corr-candidates-1',
+      });
+      await ctx.db.insert('coupling_trace_records', {
+        ...baseRecord,
+        licenseSubject: subjectA,
+        assetPath: 'Assets/Character/body.png',
+        tokenHash: tokenHashA,
+        correlationId: 'corr-candidates-2',
+      });
+      await ctx.db.insert('coupling_trace_records', {
+        ...baseRecord,
+        licenseSubject: subjectB,
+        assetPath: 'Assets/Character/face.png',
+        tokenHash: tokenHashB,
+        correlationId: 'corr-candidates-3',
+      });
+    });
+
+    const result = await t.query(api.couplingForensics.listCouplingTraceCandidatesForAuthUser, {
+      apiSecret: 'test-secret',
+      authUserId,
+      packageId,
+    });
+
+    expect(result.capabilityEnabled).toBe(true);
+    expect(result.packageOwned).toBe(true);
+    expect(result.candidates).toHaveLength(2);
+    expect(result.candidates).toContainEqual({
+      assetPath: 'Assets/Character/body.png',
+      licenseSubject: subjectA,
+      tokenHash: tokenHashA,
+    });
+    expect(result.candidates).toContainEqual({
+      assetPath: 'Assets/Character/face.png',
+      licenseSubject: subjectB,
+      tokenHash: tokenHashB,
+    });
+  });
+
+  it('returns no trace candidates without the traceability capability', async () => {
+    const t = makeTestConvex();
+    const now = Date.now();
+    const authUserId = 'creator-nocap-auth';
+    const packageId = 'pkg.creator.nocap';
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('package_registry', {
+        packageId,
+        packageName: 'Creator Bundle',
+        publisherId: 'publisher-nocap',
+        yucpUserId: authUserId,
+        status: 'active',
+        registeredAt: now,
+        updatedAt: now,
+      });
+      await ctx.db.insert('coupling_trace_records', {
+        authUserId,
+        packageId,
+        licenseSubject: 'b'.repeat(64),
+        assetPath: 'Assets/Character/body.png',
+        tokenHash: '1'.repeat(64),
+        tokenLength: 64,
+        machineFingerprintHash: 'c'.repeat(64),
+        projectIdHash: 'd'.repeat(64),
+        runtimeArtifactVersion: 'sha256-b8c6ba93829b',
+        runtimePlaintextSha256: 'e'.repeat(64),
+        correlationId: 'corr-nocap-1',
+        createdAt: now,
+        provider: 'jinxxy',
+      });
+    });
+
+    const result = await t.query(api.couplingForensics.listCouplingTraceCandidatesForAuthUser, {
+      apiSecret: 'test-secret',
+      authUserId,
+      packageId,
+    });
+
+    expect(result).toEqual({
+      capabilityEnabled: false,
+      packageOwned: false,
+      candidates: [],
+    });
+  });
+
+  it('returns packageOwned false for a capable viewer who does not own the package', async () => {
+    const t = makeTestConvex();
+    const now = Date.now();
+    const authUserId = 'creator-nonowner-auth';
+    const packageId = 'pkg.creator.nonowner';
+
+    await seedCertificateBillingCatalog(t, {
+      productId: 'plan-coupling-traceability',
+      capabilityKeys: ['coupling_traceability'],
+      capabilityKey: 'coupling_traceability',
+      featureFlags: { coupling_traceability: true },
+      benefitMetadata: { coupling_traceability: true },
+    });
+    const creatorProfileId = await seedCreatorProfile(t, {
+      authUserId,
+      ownerDiscordUserId: 'discord-nonowner-creator',
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('creator_billing_entitlements', {
+        workspaceKey: buildCreatorProfileWorkspaceKey(creatorProfileId),
+        authUserId,
+        creatorProfileId,
+        planKey: 'creator-suite-plus',
+        productId: 'plan-coupling-traceability',
+        status: 'active',
+        allowEnrollment: true,
+        allowSigning: true,
+        deviceCap: 5,
+        auditRetentionDays: 30,
+        supportTier: 'standard',
+        currentPeriodEnd: now + 86_400_000,
+        graceUntil: now + 3 * 86_400_000,
+        createdAt: now,
+        updatedAt: now,
+      });
+      // Package belongs to a different creator.
+      await ctx.db.insert('package_registry', {
+        packageId,
+        packageName: 'Someone Else Bundle',
+        publisherId: 'publisher-other',
+        yucpUserId: 'a-different-creator',
+        status: 'active',
+        registeredAt: now,
+        updatedAt: now,
+      });
+    });
+
+    const result = await t.query(api.couplingForensics.listCouplingTraceCandidatesForAuthUser, {
+      apiSecret: 'test-secret',
+      authUserId,
+      packageId,
+    });
+
+    expect(result).toEqual({
+      capabilityEnabled: true,
+      packageOwned: false,
+      candidates: [],
+    });
+  });
 });

--- a/convex/couplingForensics.realtest.ts
+++ b/convex/couplingForensics.realtest.ts
@@ -114,7 +114,7 @@ describe('coupling forensics license subject resolution', () => {
         authUserId,
         packageId,
         provider: 'jinxxy',
-        licenseKey: '11111111-2222-3333-4444-555555555555',
+        licenseKey: 'test-placeholder-forensics-license-key',
         purchaserEmail: 'buyer@example.com',
         providerUserId: 'customer-123',
         externalOrderId: 'order-123',
@@ -139,6 +139,92 @@ describe('coupling forensics license subject resolution', () => {
     });
     expect(result.matches[0]).not.toHaveProperty('licenseKey');
     expect(result.matches[0]).not.toHaveProperty('purchaserEmail');
+  });
+
+  it('bounds trace match lookup per token hash and returns the newest rows first', async () => {
+    const t = makeTestConvex();
+    const now = Date.now();
+    const authUserId = 'creator-forensics-bounded-auth';
+    const packageId = 'pkg.creator.bounded';
+    const tokenHash = 'c'.repeat(64);
+    const matchLimit = 64;
+
+    await seedCertificateBillingCatalog(t, {
+      productId: 'plan-coupling-traceability',
+      capabilityKeys: ['coupling_traceability'],
+      capabilityKey: 'coupling_traceability',
+      featureFlags: {
+        coupling_traceability: true,
+      },
+      benefitMetadata: {
+        coupling_traceability: true,
+      },
+    });
+
+    const creatorProfileId = await seedCreatorProfile(t, {
+      authUserId,
+      ownerDiscordUserId: 'discord-creator-forensics-bounded',
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('creator_billing_entitlements', {
+        workspaceKey: buildCreatorProfileWorkspaceKey(creatorProfileId),
+        authUserId,
+        creatorProfileId,
+        planKey: 'creator-suite-plus',
+        productId: 'plan-coupling-traceability',
+        status: 'active',
+        allowEnrollment: true,
+        allowSigning: true,
+        deviceCap: 5,
+        auditRetentionDays: 30,
+        supportTier: 'standard',
+        currentPeriodEnd: now + 86_400_000,
+        graceUntil: now + 3 * 86_400_000,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      await ctx.db.insert('package_registry', {
+        packageId,
+        packageName: 'Bounded Creator Bundle',
+        publisherId: 'publisher-forensics-bounded',
+        yucpUserId: authUserId,
+        status: 'active',
+        registeredAt: now,
+        updatedAt: now,
+      });
+
+      for (let index = 0; index < matchLimit + 1; index += 1) {
+        await ctx.db.insert('coupling_trace_records', {
+          authUserId,
+          packageId,
+          licenseSubject: index.toString(16).padStart(64, '0'),
+          assetPath: `Assets/Character/part-${index}.png`,
+          tokenHash,
+          tokenLength: 64,
+          machineFingerprintHash: 'c'.repeat(64),
+          projectIdHash: 'd'.repeat(64),
+          runtimeArtifactVersion: 'sha256-b8c6ba93829b',
+          runtimePlaintextSha256: 'e'.repeat(64),
+          correlationId: `corr-forensics-bounded-${index}`,
+          createdAt: now + index,
+          provider: 'jinxxy',
+        });
+      }
+    });
+
+    const result = await t.query(api.couplingForensics.lookupTraceMatchesForAuthUser, {
+      apiSecret: 'test-secret',
+      authUserId,
+      packageId,
+      tokenHashes: [tokenHash],
+    });
+
+    expect(result.matches).toHaveLength(matchLimit);
+    expect(result.matches[0]?.assetPath).toBe(`Assets/Character/part-${matchLimit}.png`);
+    expect(result.matches.at(-1)?.assetPath).toBe('Assets/Character/part-1.png');
+    expect(result.unmatchedTokenHashes).toEqual([]);
   });
 
   it('lists deduped trace candidates for the package owner with the traceability capability', async () => {

--- a/convex/couplingForensics.realtest.ts
+++ b/convex/couplingForensics.realtest.ts
@@ -247,6 +247,83 @@ describe('coupling forensics license subject resolution', () => {
     });
   });
 
+  it('bounds trace candidates and reports truncation instead of returning an unbounded package scan', async () => {
+    const t = makeTestConvex();
+    const now = Date.now();
+    const authUserId = 'creator-candidates-bounded-auth';
+    const packageId = 'pkg.creator.candidates.bounded';
+    const candidateLimit = 512;
+
+    await seedCertificateBillingCatalog(t, {
+      productId: 'plan-coupling-traceability',
+      capabilityKeys: ['coupling_traceability'],
+      capabilityKey: 'coupling_traceability',
+      featureFlags: { coupling_traceability: true },
+      benefitMetadata: { coupling_traceability: true },
+    });
+    const creatorProfileId = await seedCreatorProfile(t, {
+      authUserId,
+      ownerDiscordUserId: 'discord-candidates-bounded-creator',
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('creator_billing_entitlements', {
+        workspaceKey: buildCreatorProfileWorkspaceKey(creatorProfileId),
+        authUserId,
+        creatorProfileId,
+        planKey: 'creator-suite-plus',
+        productId: 'plan-coupling-traceability',
+        status: 'active',
+        allowEnrollment: true,
+        allowSigning: true,
+        deviceCap: 5,
+        auditRetentionDays: 30,
+        supportTier: 'standard',
+        currentPeriodEnd: now + 86_400_000,
+        graceUntil: now + 3 * 86_400_000,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await ctx.db.insert('package_registry', {
+        packageId,
+        packageName: 'Creator Bundle',
+        publisherId: 'publisher-candidates-bounded',
+        yucpUserId: authUserId,
+        status: 'active',
+        registeredAt: now,
+        updatedAt: now,
+      });
+
+      for (let index = 0; index < candidateLimit + 1; index += 1) {
+        await ctx.db.insert('coupling_trace_records', {
+          authUserId,
+          packageId,
+          licenseSubject: index.toString(16).padStart(64, '0'),
+          assetPath: `Assets/Character/body-${index}.png`,
+          tokenHash: (index + 1).toString(16).padStart(64, '0'),
+          tokenLength: 64,
+          machineFingerprintHash: 'c'.repeat(64),
+          projectIdHash: 'd'.repeat(64),
+          runtimeArtifactVersion: 'sha256-b8c6ba93829b',
+          runtimePlaintextSha256: 'e'.repeat(64),
+          correlationId: `corr-candidates-bounded-${index}`,
+          createdAt: now + index,
+          provider: 'jinxxy',
+        });
+      }
+    });
+
+    const result = await t.query(api.couplingForensics.listCouplingTraceCandidatesForAuthUser, {
+      apiSecret: 'test-secret',
+      authUserId,
+      packageId,
+    });
+
+    expect(result.candidateLimit).toBe(candidateLimit);
+    expect(result.truncated).toBe(true);
+    expect(result.candidates).toHaveLength(candidateLimit);
+  });
+
   it('returns no trace candidates without the traceability capability', async () => {
     const t = makeTestConvex();
     const now = Date.now();
@@ -289,6 +366,8 @@ describe('coupling forensics license subject resolution', () => {
     expect(result).toEqual({
       capabilityEnabled: false,
       packageOwned: false,
+      truncated: false,
+      candidateLimit: 512,
       candidates: [],
     });
   });
@@ -350,6 +429,8 @@ describe('coupling forensics license subject resolution', () => {
     expect(result).toEqual({
       capabilityEnabled: true,
       packageOwned: false,
+      truncated: false,
+      candidateLimit: 512,
       candidates: [],
     });
   });

--- a/convex/couplingForensics.realtest.ts
+++ b/convex/couplingForensics.realtest.ts
@@ -409,6 +409,53 @@ describe('coupling forensics license subject resolution', () => {
     expect(result.unmatchedTokenHashes).toEqual([]);
   });
 
+  it('reports truncation when one token has more matches than the per-token fanout cap', async () => {
+    const t = makeTestConvex();
+    const now = Date.now();
+    const authUserId = 'creator-forensics-token-cap-auth';
+    const packageId = 'pkg.creator.token-cap';
+    const tokenHash = 'f'.repeat(64);
+
+    await seedTraceablePackage(t, {
+      authUserId,
+      packageId,
+      now,
+      ownerDiscordUserId: 'discord-creator-forensics-token-cap',
+      packageName: 'Token Cap Creator Bundle',
+    });
+
+    await t.run(async (ctx) => {
+      for (let rowIndex = 0; rowIndex < 65; rowIndex += 1) {
+        await ctx.db.insert('coupling_trace_records', {
+          authUserId,
+          packageId,
+          licenseSubject: rowIndex.toString(16).padEnd(64, '0'),
+          assetPath: `Assets/Character/token-cap-${rowIndex}.png`,
+          tokenHash,
+          tokenLength: 64,
+          machineFingerprintHash: 'c'.repeat(64),
+          projectIdHash: 'd'.repeat(64),
+          runtimeArtifactVersion: 'sha256-b8c6ba93829b',
+          runtimePlaintextSha256: 'e'.repeat(64),
+          correlationId: `corr-forensics-token-cap-${rowIndex}`,
+          createdAt: now + rowIndex,
+          provider: 'jinxxy',
+        });
+      }
+    });
+
+    const result = await t.query(api.couplingForensics.lookupTraceMatchesForAuthUser, {
+      apiSecret: 'test-secret',
+      authUserId,
+      packageId,
+      tokenHashes: [tokenHash],
+    });
+
+    expect(result.matches).toHaveLength(64);
+    expect(result.truncated).toBe(true);
+    expect(result.unmatchedTokenHashes).toEqual([]);
+  });
+
   it('lists deduped trace candidates for the package owner with the traceability capability', async () => {
     const t = makeTestConvex();
     const now = Date.now();

--- a/convex/couplingForensics.realtest.ts
+++ b/convex/couplingForensics.realtest.ts
@@ -409,6 +409,114 @@ describe('coupling forensics license subject resolution', () => {
     ]);
   });
 
+  it('continues scanning past duplicate raw trace rows to include later unique candidates', async () => {
+    const t = makeTestConvex();
+    const now = Date.now();
+    const authUserId = 'creator-candidates-duplicate-page-auth';
+    const packageId = 'pkg.creator.candidates.duplicate-page';
+    const candidateLimit = 512;
+    const duplicateLicenseSubject = 'a'.repeat(64);
+    const duplicateTokenHash = '1'.repeat(64);
+    const laterLicenseSubject = 'b'.repeat(64);
+    const laterTokenHash = 'f'.repeat(64);
+
+    await seedCertificateBillingCatalog(t, {
+      productId: 'plan-coupling-traceability',
+      capabilityKeys: ['coupling_traceability'],
+      capabilityKey: 'coupling_traceability',
+      featureFlags: { coupling_traceability: true },
+      benefitMetadata: { coupling_traceability: true },
+    });
+    const creatorProfileId = await seedCreatorProfile(t, {
+      authUserId,
+      ownerDiscordUserId: 'discord-candidates-duplicate-page-creator',
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('creator_billing_entitlements', {
+        workspaceKey: buildCreatorProfileWorkspaceKey(creatorProfileId),
+        authUserId,
+        creatorProfileId,
+        planKey: 'creator-suite-plus',
+        productId: 'plan-coupling-traceability',
+        status: 'active',
+        allowEnrollment: true,
+        allowSigning: true,
+        deviceCap: 5,
+        auditRetentionDays: 30,
+        supportTier: 'standard',
+        currentPeriodEnd: now + 86_400_000,
+        graceUntil: now + 3 * 86_400_000,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await ctx.db.insert('package_registry', {
+        packageId,
+        packageName: 'Creator Bundle',
+        publisherId: 'publisher-candidates-duplicate-page',
+        yucpUserId: authUserId,
+        status: 'active',
+        registeredAt: now,
+        updatedAt: now,
+      });
+
+      for (let index = 0; index < candidateLimit + 1; index += 1) {
+        await ctx.db.insert('coupling_trace_records', {
+          authUserId,
+          packageId,
+          licenseSubject: duplicateLicenseSubject,
+          assetPath: 'Assets/Character/body.png',
+          tokenHash: duplicateTokenHash,
+          tokenLength: 64,
+          machineFingerprintHash: 'c'.repeat(64),
+          projectIdHash: 'd'.repeat(64),
+          runtimeArtifactVersion: 'sha256-b8c6ba93829b',
+          runtimePlaintextSha256: 'e'.repeat(64),
+          correlationId: `corr-candidates-duplicate-page-${index}`,
+          createdAt: now + index,
+          provider: 'jinxxy',
+        });
+      }
+
+      await ctx.db.insert('coupling_trace_records', {
+        authUserId,
+        packageId,
+        licenseSubject: laterLicenseSubject,
+        assetPath: 'Assets/Character/face.png',
+        tokenHash: laterTokenHash,
+        tokenLength: 64,
+        machineFingerprintHash: 'c'.repeat(64),
+        projectIdHash: 'd'.repeat(64),
+        runtimeArtifactVersion: 'sha256-b8c6ba93829b',
+        runtimePlaintextSha256: 'e'.repeat(64),
+        correlationId: 'corr-candidates-duplicate-page-later',
+        createdAt: now + candidateLimit + 1,
+        provider: 'jinxxy',
+      });
+    });
+
+    const result = await t.query(api.couplingForensics.listCouplingTraceCandidatesForAuthUser, {
+      apiSecret: 'test-secret',
+      authUserId,
+      packageId,
+    });
+
+    expect(result.candidateLimit).toBe(candidateLimit);
+    expect(result.truncated).toBe(false);
+    expect(result.candidates).toEqual([
+      {
+        assetPath: 'Assets/Character/body.png',
+        licenseSubject: duplicateLicenseSubject,
+        tokenHash: duplicateTokenHash,
+      },
+      {
+        assetPath: 'Assets/Character/face.png',
+        licenseSubject: laterLicenseSubject,
+        tokenHash: laterTokenHash,
+      },
+    ]);
+  });
+
   it('returns no trace candidates without the traceability capability', async () => {
     const t = makeTestConvex();
     const now = Date.now();

--- a/convex/couplingForensics.realtest.ts
+++ b/convex/couplingForensics.realtest.ts
@@ -324,6 +324,91 @@ describe('coupling forensics license subject resolution', () => {
     expect(result.candidates).toHaveLength(candidateLimit);
   });
 
+  it('does not report truncation when duplicate raw trace rows dedupe under the candidate limit', async () => {
+    const t = makeTestConvex();
+    const now = Date.now();
+    const authUserId = 'creator-candidates-duplicate-bound-auth';
+    const packageId = 'pkg.creator.candidates.duplicate-bound';
+    const candidateLimit = 512;
+    const licenseSubject = 'a'.repeat(64);
+    const tokenHash = '1'.repeat(64);
+
+    await seedCertificateBillingCatalog(t, {
+      productId: 'plan-coupling-traceability',
+      capabilityKeys: ['coupling_traceability'],
+      capabilityKey: 'coupling_traceability',
+      featureFlags: { coupling_traceability: true },
+      benefitMetadata: { coupling_traceability: true },
+    });
+    const creatorProfileId = await seedCreatorProfile(t, {
+      authUserId,
+      ownerDiscordUserId: 'discord-candidates-duplicate-bound-creator',
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('creator_billing_entitlements', {
+        workspaceKey: buildCreatorProfileWorkspaceKey(creatorProfileId),
+        authUserId,
+        creatorProfileId,
+        planKey: 'creator-suite-plus',
+        productId: 'plan-coupling-traceability',
+        status: 'active',
+        allowEnrollment: true,
+        allowSigning: true,
+        deviceCap: 5,
+        auditRetentionDays: 30,
+        supportTier: 'standard',
+        currentPeriodEnd: now + 86_400_000,
+        graceUntil: now + 3 * 86_400_000,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await ctx.db.insert('package_registry', {
+        packageId,
+        packageName: 'Creator Bundle',
+        publisherId: 'publisher-candidates-duplicate-bound',
+        yucpUserId: authUserId,
+        status: 'active',
+        registeredAt: now,
+        updatedAt: now,
+      });
+
+      for (let index = 0; index < candidateLimit + 1; index += 1) {
+        await ctx.db.insert('coupling_trace_records', {
+          authUserId,
+          packageId,
+          licenseSubject,
+          assetPath: 'Assets/Character/body.png',
+          tokenHash,
+          tokenLength: 64,
+          machineFingerprintHash: 'c'.repeat(64),
+          projectIdHash: 'd'.repeat(64),
+          runtimeArtifactVersion: 'sha256-b8c6ba93829b',
+          runtimePlaintextSha256: 'e'.repeat(64),
+          correlationId: `corr-candidates-duplicate-bound-${index}`,
+          createdAt: now + index,
+          provider: 'jinxxy',
+        });
+      }
+    });
+
+    const result = await t.query(api.couplingForensics.listCouplingTraceCandidatesForAuthUser, {
+      apiSecret: 'test-secret',
+      authUserId,
+      packageId,
+    });
+
+    expect(result.candidateLimit).toBe(candidateLimit);
+    expect(result.truncated).toBe(false);
+    expect(result.candidates).toEqual([
+      {
+        assetPath: 'Assets/Character/body.png',
+        licenseSubject,
+        tokenHash,
+      },
+    ]);
+  });
+
   it('returns no trace candidates without the traceability capability', async () => {
     const t = makeTestConvex();
     const now = Date.now();

--- a/convex/couplingForensics.realtest.ts
+++ b/convex/couplingForensics.realtest.ts
@@ -8,6 +8,64 @@ import {
   seedSubject,
 } from './testHelpers';
 
+async function seedTraceablePackage(
+  t: ReturnType<typeof makeTestConvex>,
+  args: {
+    authUserId: string;
+    packageId: string;
+    now: number;
+    ownerDiscordUserId?: string;
+    packageName?: string;
+  }
+) {
+  await seedCertificateBillingCatalog(t, {
+    productId: 'plan-coupling-traceability',
+    capabilityKeys: ['coupling_traceability'],
+    capabilityKey: 'coupling_traceability',
+    featureFlags: {
+      coupling_traceability: true,
+    },
+    benefitMetadata: {
+      coupling_traceability: true,
+    },
+  });
+
+  const creatorProfileId = await seedCreatorProfile(t, {
+    authUserId: args.authUserId,
+    ownerDiscordUserId: args.ownerDiscordUserId ?? `${args.authUserId}-discord`,
+  });
+
+  await t.run(async (ctx) => {
+    await ctx.db.insert('creator_billing_entitlements', {
+      workspaceKey: buildCreatorProfileWorkspaceKey(creatorProfileId),
+      authUserId: args.authUserId,
+      creatorProfileId,
+      planKey: 'creator-suite-plus',
+      productId: 'plan-coupling-traceability',
+      status: 'active',
+      allowEnrollment: true,
+      allowSigning: true,
+      deviceCap: 5,
+      auditRetentionDays: 30,
+      supportTier: 'standard',
+      currentPeriodEnd: args.now + 86_400_000,
+      graceUntil: args.now + 3 * 86_400_000,
+      createdAt: args.now,
+      updatedAt: args.now,
+    });
+
+    await ctx.db.insert('package_registry', {
+      packageId: args.packageId,
+      packageName: args.packageName ?? 'Traceable Creator Bundle',
+      publisherId: `${args.packageId}.publisher`,
+      yucpUserId: args.authUserId,
+      status: 'active',
+      registeredAt: args.now,
+      updatedAt: args.now,
+    });
+  });
+}
+
 describe('coupling forensics license subject resolution', () => {
   beforeEach(() => {
     process.env.CONVEX_API_SECRET = 'test-secret';
@@ -224,6 +282,130 @@ describe('coupling forensics license subject resolution', () => {
     expect(result.matches).toHaveLength(matchLimit);
     expect(result.matches[0]?.assetPath).toBe(`Assets/Character/part-${matchLimit}.png`);
     expect(result.matches.at(-1)?.assetPath).toBe('Assets/Character/part-1.png');
+    expect(result.unmatchedTokenHashes).toEqual([]);
+  });
+
+  it('filters trace match lookups to the exact attribution candidate', async () => {
+    const t = makeTestConvex();
+    const now = Date.now();
+    const authUserId = 'creator-forensics-exact-auth';
+    const packageId = 'pkg.creator.exact';
+    const tokenHash = 'd'.repeat(64);
+    const matchedSubject = '1'.repeat(64);
+    const otherSubject = '2'.repeat(64);
+
+    await seedTraceablePackage(t, {
+      authUserId,
+      packageId,
+      now,
+      ownerDiscordUserId: 'discord-creator-forensics-exact',
+      packageName: 'Exact Match Creator Bundle',
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('coupling_trace_records', {
+        authUserId,
+        packageId,
+        licenseSubject: otherSubject,
+        assetPath: 'Assets/Character/body.png',
+        tokenHash,
+        tokenLength: 64,
+        machineFingerprintHash: 'c'.repeat(64),
+        projectIdHash: 'd'.repeat(64),
+        runtimeArtifactVersion: 'other-runtime-version',
+        runtimePlaintextSha256: 'e'.repeat(64),
+        correlationId: 'corr-forensics-exact-other',
+        createdAt: now + 1,
+        provider: 'jinxxy',
+      });
+      await ctx.db.insert('coupling_trace_records', {
+        authUserId,
+        packageId,
+        licenseSubject: matchedSubject,
+        assetPath: 'Assets/Character/body.png',
+        tokenHash,
+        tokenLength: 64,
+        machineFingerprintHash: 'c'.repeat(64),
+        projectIdHash: 'd'.repeat(64),
+        runtimeArtifactVersion: 'matched-runtime-version',
+        runtimePlaintextSha256: 'e'.repeat(64),
+        correlationId: 'corr-forensics-exact-matched',
+        createdAt: now,
+        provider: 'jinxxy',
+      });
+    });
+
+    const result = await t.query(api.couplingForensics.lookupTraceMatchesForAuthUser, {
+      apiSecret: 'test-secret',
+      authUserId,
+      packageId,
+      matchedCandidates: [
+        {
+          assetPath: 'Assets/Character/body.png',
+          licenseSubject: matchedSubject,
+          tokenHash,
+        },
+      ],
+    });
+
+    expect(result.truncated).toBe(false);
+    expect(result.unmatchedTokenHashes).toEqual([]);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0]).toMatchObject({
+      licenseSubject: matchedSubject,
+      runtimeArtifactVersion: 'matched-runtime-version',
+    });
+  });
+
+  it('reports truncation when token-hash fanout exhausts the total match budget', async () => {
+    const t = makeTestConvex();
+    const now = Date.now();
+    const authUserId = 'creator-forensics-fanout-auth';
+    const packageId = 'pkg.creator.fanout';
+    const tokenHashes = Array.from({ length: 9 }, (_, index) =>
+      (index + 1).toString(16).repeat(64).slice(0, 64)
+    );
+
+    await seedTraceablePackage(t, {
+      authUserId,
+      packageId,
+      now,
+      ownerDiscordUserId: 'discord-creator-forensics-fanout',
+      packageName: 'Fanout Creator Bundle',
+    });
+
+    await t.run(async (ctx) => {
+      for (const [tokenIndex, tokenHash] of tokenHashes.entries()) {
+        const rowCount = tokenIndex < 8 ? 64 : 1;
+        for (let rowIndex = 0; rowIndex < rowCount; rowIndex += 1) {
+          await ctx.db.insert('coupling_trace_records', {
+            authUserId,
+            packageId,
+            licenseSubject: `${tokenIndex.toString(16)}${rowIndex.toString(16)}`.padEnd(64, '0'),
+            assetPath: `Assets/Character/token-${tokenIndex}-part-${rowIndex}.png`,
+            tokenHash,
+            tokenLength: 64,
+            machineFingerprintHash: 'c'.repeat(64),
+            projectIdHash: 'd'.repeat(64),
+            runtimeArtifactVersion: 'sha256-b8c6ba93829b',
+            runtimePlaintextSha256: 'e'.repeat(64),
+            correlationId: `corr-forensics-fanout-${tokenIndex}-${rowIndex}`,
+            createdAt: now + tokenIndex * 100 + rowIndex,
+            provider: 'jinxxy',
+          });
+        }
+      }
+    });
+
+    const result = await t.query(api.couplingForensics.lookupTraceMatchesForAuthUser, {
+      apiSecret: 'test-secret',
+      authUserId,
+      packageId,
+      tokenHashes,
+    });
+
+    expect(result.matches).toHaveLength(512);
+    expect(result.truncated).toBe(true);
     expect(result.unmatchedTokenHashes).toEqual([]);
   });
 

--- a/convex/couplingForensics.ts
+++ b/convex/couplingForensics.ts
@@ -37,6 +37,43 @@ function normalizeTokenHashes(tokenHashes: string[]): string[] {
   return normalized;
 }
 
+type TraceMatchCandidate = {
+  assetPath: string;
+  licenseSubject: string;
+  tokenHash: string;
+};
+
+function normalizeTraceMatchCandidates(candidates: TraceMatchCandidate[]): TraceMatchCandidate[] {
+  if (candidates.length > COUPLING_TRACE_CANDIDATE_LIMIT) {
+    throw new ConvexError('Too many coupling trace match candidates');
+  }
+
+  const normalized: TraceMatchCandidate[] = [];
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    const assetPath = candidate.assetPath.trim();
+    const licenseSubject = candidate.licenseSubject.trim().toLowerCase();
+    const tokenHash = candidate.tokenHash.trim().toLowerCase();
+    if (!assetPath) {
+      throw new ConvexError('Invalid match candidate assetPath');
+    }
+    if (!TOKEN_HASH_RE.test(licenseSubject)) {
+      throw new ConvexError('Invalid match candidate licenseSubject');
+    }
+    if (!TOKEN_HASH_RE.test(tokenHash)) {
+      throw new ConvexError('Invalid match candidate tokenHash');
+    }
+
+    const key = `${assetPath}\0${licenseSubject}\0${tokenHash}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    normalized.push({ assetPath, licenseSubject, tokenHash });
+  }
+  return normalized;
+}
+
 function isArchivedPackage(
   registration: Pick<Doc<'package_registry'>, 'status'> | null | undefined
 ): boolean {
@@ -235,7 +272,16 @@ export const lookupTraceMatchesForAuthUser = query({
     apiSecret: v.string(),
     authUserId: v.string(),
     packageId: v.string(),
-    tokenHashes: v.array(v.string()),
+    tokenHashes: v.optional(v.array(v.string())),
+    matchedCandidates: v.optional(
+      v.array(
+        v.object({
+          assetPath: v.string(),
+          licenseSubject: v.string(),
+          tokenHash: v.string(),
+        })
+      )
+    ),
   },
   returns: v.object({
     capabilityEnabled: v.boolean(),
@@ -265,11 +311,19 @@ export const lookupTraceMatchesForAuthUser = query({
       })
     ),
     unmatchedTokenHashes: v.array(v.string()),
+    truncated: v.boolean(),
   }),
   handler: async (ctx, args) => {
     requireApiSecret(args.apiSecret);
     assertPackageId(args.packageId);
-    const tokenHashes = normalizeTokenHashes(args.tokenHashes);
+    const matchedCandidates = normalizeTraceMatchCandidates(args.matchedCandidates ?? []);
+    const tokenHashes =
+      args.tokenHashes !== undefined
+        ? normalizeTokenHashes(args.tokenHashes)
+        : Array.from(new Set(matchedCandidates.map((candidate) => candidate.tokenHash)));
+    if (tokenHashes.length === 0 && matchedCandidates.length === 0) {
+      throw new ConvexError('At least one coupling trace match candidate is required');
+    }
 
     const capabilityEnabled = await ctx.runQuery(
       internal.certificateBilling.hasCapabilityForAuthUser,
@@ -284,6 +338,7 @@ export const lookupTraceMatchesForAuthUser = query({
         packageOwned: false,
         matches: [],
         unmatchedTokenHashes: tokenHashes,
+        truncated: false,
       };
     }
 
@@ -300,6 +355,7 @@ export const lookupTraceMatchesForAuthUser = query({
         packageOwned: false,
         matches: [],
         unmatchedTokenHashes: tokenHashes,
+        truncated: false,
       };
     }
 
@@ -387,53 +443,91 @@ export const lookupTraceMatchesForAuthUser = query({
       return pending;
     };
 
-    for (const tokenHash of tokenHashes) {
-      const remainingMatchBudget = COUPLING_TRACE_MATCH_TOTAL_LIMIT - matches.length;
-      if (remainingMatchBudget <= 0) {
-        break;
+    const unmatchedTokenHashSet = new Set<string>();
+    let truncated = false;
+
+    const appendTraceMatch = async (row: Doc<'coupling_trace_records'>) => {
+      matchedTokenHashes.add(row.tokenHash);
+
+      const identity = await resolveIdentityForSubject(row.licenseSubject);
+
+      matches.push({
+        tokenHash: row.tokenHash,
+        licenseSubject: row.licenseSubject,
+        assetPath: row.assetPath,
+        correlationId: row.correlationId,
+        createdAt: row.createdAt,
+        runtimeArtifactVersion: row.runtimeArtifactVersion,
+        runtimePlaintextSha256: row.runtimePlaintextSha256,
+        machineFingerprintHash: row.machineFingerprintHash,
+        projectIdHash: row.projectIdHash,
+        grantId: row.grantId,
+        packFamily: row.packFamily,
+        packVersion: row.packVersion,
+        provider: identity?.provider ?? row.provider,
+        licenseMasked: buildLicenseMaskedLabel(identity?.provider ?? row.provider, row.licenseSubject),
+        licenseKeyEncrypted: identity?.licenseKeyEncrypted,
+        providerProductId: identity?.providerProductId,
+        buyerProviderUserId: identity?.buyerProviderUserId,
+        buyerProviderUsername: identity?.buyerProviderUsername,
+        buyerSubjectDisplayName: identity?.buyerSubjectDisplayName,
+        buyerSubjectDiscordUserId: identity?.buyerSubjectDiscordUserId,
+      });
+    };
+
+    if (matchedCandidates.length > 0) {
+      for (const candidate of matchedCandidates) {
+        if (matches.length >= COUPLING_TRACE_MATCH_TOTAL_LIMIT) {
+          truncated = true;
+          break;
+        }
+        const row = await ctx.db
+          .query('coupling_trace_records')
+          .withIndex('by_auth_package_token_subject_asset_created', (q) =>
+            q
+              .eq('authUserId', args.authUserId)
+              .eq('packageId', args.packageId)
+              .eq('tokenHash', candidate.tokenHash)
+              .eq('licenseSubject', candidate.licenseSubject)
+              .eq('assetPath', candidate.assetPath)
+          )
+          .order('desc')
+          .first();
+
+        if (!row) {
+          unmatchedTokenHashSet.add(candidate.tokenHash);
+          continue;
+        }
+
+        await appendTraceMatch(row);
       }
-      const matchLimit = Math.min(COUPLING_TRACE_MATCHES_PER_TOKEN_LIMIT, remainingMatchBudget);
-      const rows = await ctx.db
-        .query('coupling_trace_records')
-        .withIndex('by_auth_package_token_created', (q) =>
-          q
-            .eq('authUserId', args.authUserId)
-            .eq('packageId', args.packageId)
-            .eq('tokenHash', tokenHash)
-        )
-        .order('desc')
-        .take(matchLimit);
+    } else {
+      for (const tokenHash of tokenHashes) {
+        const remainingMatchBudget = COUPLING_TRACE_MATCH_TOTAL_LIMIT - matches.length;
+        if (remainingMatchBudget <= 0) {
+          truncated = true;
+          break;
+        }
+        const matchLimit = Math.min(COUPLING_TRACE_MATCHES_PER_TOKEN_LIMIT, remainingMatchBudget);
+        const rows = await ctx.db
+          .query('coupling_trace_records')
+          .withIndex('by_auth_package_token_created', (q) =>
+            q
+              .eq('authUserId', args.authUserId)
+              .eq('packageId', args.packageId)
+              .eq('tokenHash', tokenHash)
+          )
+          .order('desc')
+          .take(matchLimit);
 
-      for (const row of rows) {
-        matchedTokenHashes.add(tokenHash);
+        if (rows.length === 0) {
+          unmatchedTokenHashSet.add(tokenHash);
+          continue;
+        }
 
-        const identity = await resolveIdentityForSubject(row.licenseSubject);
-
-        matches.push({
-          tokenHash,
-          licenseSubject: row.licenseSubject,
-          assetPath: row.assetPath,
-          correlationId: row.correlationId,
-          createdAt: row.createdAt,
-          runtimeArtifactVersion: row.runtimeArtifactVersion,
-          runtimePlaintextSha256: row.runtimePlaintextSha256,
-          machineFingerprintHash: row.machineFingerprintHash,
-          projectIdHash: row.projectIdHash,
-          grantId: row.grantId,
-          packFamily: row.packFamily,
-          packVersion: row.packVersion,
-          provider: identity?.provider ?? row.provider,
-          licenseMasked: buildLicenseMaskedLabel(
-            identity?.provider ?? row.provider,
-            row.licenseSubject
-          ),
-          licenseKeyEncrypted: identity?.licenseKeyEncrypted,
-          providerProductId: identity?.providerProductId,
-          buyerProviderUserId: identity?.buyerProviderUserId,
-          buyerProviderUsername: identity?.buyerProviderUsername,
-          buyerSubjectDisplayName: identity?.buyerSubjectDisplayName,
-          buyerSubjectDiscordUserId: identity?.buyerSubjectDiscordUserId,
-        });
+        for (const row of rows) {
+          await appendTraceMatch(row);
+        }
       }
     }
 
@@ -441,7 +535,10 @@ export const lookupTraceMatchesForAuthUser = query({
       capabilityEnabled: true,
       packageOwned: true,
       matches,
-      unmatchedTokenHashes: tokenHashes.filter((tokenHash) => !matchedTokenHashes.has(tokenHash)),
+      unmatchedTokenHashes: Array.from(unmatchedTokenHashSet).filter(
+        (tokenHash) => !matchedTokenHashes.has(tokenHash)
+      ),
+      truncated,
     };
   },
 });

--- a/convex/couplingForensics.ts
+++ b/convex/couplingForensics.ts
@@ -9,6 +9,8 @@ import { decryptForPurpose } from './lib/vrchat/crypto';
 
 const PACKAGE_ID_RE = /^[a-z0-9\-_./:]{1,128}$/;
 const TOKEN_HASH_RE = /^[0-9a-f]{64}$/;
+const COUPLING_TRACE_CANDIDATE_LIMIT = 512;
+const COUPLING_TRACE_ROW_SCAN_LIMIT = COUPLING_TRACE_CANDIDATE_LIMIT + 1;
 
 function assertPackageId(packageId: string): void {
   if (!PACKAGE_ID_RE.test(packageId)) {
@@ -609,6 +611,8 @@ export const listCouplingTraceCandidatesForAuthUser = query({
   returns: v.object({
     capabilityEnabled: v.boolean(),
     packageOwned: v.boolean(),
+    truncated: v.boolean(),
+    candidateLimit: v.number(),
     candidates: v.array(
       v.object({
         assetPath: v.string(),
@@ -629,7 +633,13 @@ export const listCouplingTraceCandidatesForAuthUser = query({
       }
     );
     if (!capabilityEnabled) {
-      return { capabilityEnabled: false, packageOwned: false, candidates: [] };
+      return {
+        capabilityEnabled: false,
+        packageOwned: false,
+        truncated: false,
+        candidateLimit: COUPLING_TRACE_CANDIDATE_LIMIT,
+        candidates: [],
+      };
     }
 
     const registration = await ctx.runQuery(internal.packageRegistry.getRegistration, {
@@ -640,21 +650,28 @@ export const listCouplingTraceCandidatesForAuthUser = query({
       registration.yucpUserId !== args.authUserId ||
       isArchivedPackage(registration)
     ) {
-      return { capabilityEnabled: true, packageOwned: false, candidates: [] };
+      return {
+        capabilityEnabled: true,
+        packageOwned: false,
+        truncated: false,
+        candidateLimit: COUPLING_TRACE_CANDIDATE_LIMIT,
+        candidates: [],
+      };
     }
 
     const rows = await ctx.db
       .query('coupling_trace_records')
       .withIndex('by_package_token', (q) => q.eq('packageId', args.packageId))
-      .collect();
+      .take(COUPLING_TRACE_ROW_SCAN_LIMIT);
+    const truncated = rows.length > COUPLING_TRACE_CANDIDATE_LIMIT;
 
     const seen = new Set<string>();
     const candidates: Array<{ assetPath: string; licenseSubject: string; tokenHash: string }> = [];
-    for (const row of rows) {
+    for (const row of rows.slice(0, COUPLING_TRACE_CANDIDATE_LIMIT)) {
       if (row.authUserId !== args.authUserId) {
         continue;
       }
-      const key = `${row.assetPath} ${row.licenseSubject} ${row.tokenHash}`;
+      const key = JSON.stringify([row.assetPath, row.licenseSubject, row.tokenHash]);
       if (seen.has(key)) {
         continue;
       }
@@ -666,6 +683,12 @@ export const listCouplingTraceCandidatesForAuthUser = query({
       });
     }
 
-    return { capabilityEnabled: true, packageOwned: true, candidates };
+    return {
+      capabilityEnabled: true,
+      packageOwned: true,
+      truncated,
+      candidateLimit: COUPLING_TRACE_CANDIDATE_LIMIT,
+      candidates,
+    };
   },
 });

--- a/convex/couplingForensics.ts
+++ b/convex/couplingForensics.ts
@@ -10,7 +10,7 @@ import { decryptForPurpose } from './lib/vrchat/crypto';
 const PACKAGE_ID_RE = /^[a-z0-9\-_./:]{1,128}$/;
 const TOKEN_HASH_RE = /^[0-9a-f]{64}$/;
 const COUPLING_TRACE_CANDIDATE_LIMIT = 512;
-const COUPLING_TRACE_ROW_SCAN_LIMIT = COUPLING_TRACE_CANDIDATE_LIMIT + 1;
+const COUPLING_TRACE_ROW_PAGE_SIZE = 512;
 
 function assertPackageId(packageId: string): void {
   if (!PACKAGE_ID_RE.test(packageId)) {
@@ -659,32 +659,39 @@ export const listCouplingTraceCandidatesForAuthUser = query({
       };
     }
 
-    const rows = await ctx.db
-      .query('coupling_trace_records')
-      .withIndex('by_package_token', (q) => q.eq('packageId', args.packageId))
-      .take(COUPLING_TRACE_ROW_SCAN_LIMIT);
-
     const seen = new Set<string>();
     const candidates: Array<{ assetPath: string; licenseSubject: string; tokenHash: string }> = [];
     let truncated = false;
-    for (const row of rows) {
-      if (row.authUserId !== args.authUserId) {
-        continue;
+    let cursor: string | null = null;
+    let isDone = false;
+    while (!isDone && !truncated) {
+      const page = await ctx.db
+        .query('coupling_trace_records')
+        .withIndex('by_package_token', (q) => q.eq('packageId', args.packageId))
+        .paginate({ cursor, numItems: COUPLING_TRACE_ROW_PAGE_SIZE });
+
+      for (const row of page.page) {
+        if (row.authUserId !== args.authUserId) {
+          continue;
+        }
+        const key = JSON.stringify([row.assetPath, row.licenseSubject, row.tokenHash]);
+        if (seen.has(key)) {
+          continue;
+        }
+        if (candidates.length >= COUPLING_TRACE_CANDIDATE_LIMIT) {
+          truncated = true;
+          break;
+        }
+        seen.add(key);
+        candidates.push({
+          assetPath: row.assetPath,
+          licenseSubject: row.licenseSubject,
+          tokenHash: row.tokenHash,
+        });
       }
-      const key = JSON.stringify([row.assetPath, row.licenseSubject, row.tokenHash]);
-      if (seen.has(key)) {
-        continue;
-      }
-      if (candidates.length >= COUPLING_TRACE_CANDIDATE_LIMIT) {
-        truncated = true;
-        break;
-      }
-      seen.add(key);
-      candidates.push({
-        assetPath: row.assetPath,
-        licenseSubject: row.licenseSubject,
-        tokenHash: row.tokenHash,
-      });
+
+      cursor = page.continueCursor;
+      isDone = page.isDone;
     }
 
     return {

--- a/convex/couplingForensics.ts
+++ b/convex/couplingForensics.ts
@@ -11,6 +11,7 @@ const PACKAGE_ID_RE = /^[a-z0-9\-_./:]{1,128}$/;
 const TOKEN_HASH_RE = /^[0-9a-f]{64}$/;
 const COUPLING_TRACE_CANDIDATE_LIMIT = 512;
 const COUPLING_TRACE_ROW_PAGE_SIZE = 512;
+const COUPLING_TRACE_ROW_SCAN_LIMIT = COUPLING_TRACE_CANDIDATE_LIMIT * 4;
 
 function assertPackageId(packageId: string): void {
   if (!PACKAGE_ID_RE.test(packageId)) {
@@ -664,11 +665,19 @@ export const listCouplingTraceCandidatesForAuthUser = query({
     let truncated = false;
     let cursor: string | null = null;
     let isDone = false;
-    while (!isDone && !truncated) {
+    let rowsScanned = 0;
+    while (!isDone && !truncated && rowsScanned < COUPLING_TRACE_ROW_SCAN_LIMIT) {
       const page = await ctx.db
         .query('coupling_trace_records')
         .withIndex('by_package_token', (q) => q.eq('packageId', args.packageId))
-        .paginate({ cursor, numItems: COUPLING_TRACE_ROW_PAGE_SIZE });
+        .paginate({
+          cursor,
+          numItems: Math.min(
+            COUPLING_TRACE_ROW_PAGE_SIZE,
+            COUPLING_TRACE_ROW_SCAN_LIMIT - rowsScanned
+          ),
+        });
+      rowsScanned += page.page.length;
 
       for (const row of page.page) {
         if (row.authUserId !== args.authUserId) {
@@ -692,6 +701,9 @@ export const listCouplingTraceCandidatesForAuthUser = query({
 
       cursor = page.continueCursor;
       isDone = page.isDone;
+      if (!isDone && rowsScanned >= COUPLING_TRACE_ROW_SCAN_LIMIT) {
+        truncated = true;
+      }
     }
 
     return {

--- a/convex/couplingForensics.ts
+++ b/convex/couplingForensics.ts
@@ -45,10 +45,7 @@ function isArchivedPackage(
  * stable fingerprint of the license subject (SHA-256 of the key). Identifies *which* license
  * without revealing it — the full key is only available via the audit-logged reveal action.
  */
-function buildLicenseMaskedLabel(
-  provider: string | undefined,
-  licenseSubject: string
-): string {
+function buildLicenseMaskedLabel(provider: string | undefined, licenseSubject: string): string {
   const fingerprint = licenseSubject.slice(0, 10);
   return provider ? `${provider} · ${fingerprint}` : fingerprint;
 }
@@ -594,5 +591,81 @@ export const recordLookupAudit = mutation({
       correlationId: `${args.source}:${args.packageId}:${Date.now()}`,
       createdAt: Date.now(),
     });
+  },
+});
+
+/**
+ * Returns the per-(asset, buyer) candidate set the forensic attribution resolver needs to re-derive
+ * placement seeds for a leaked asset: {assetPath, licenseSubject, tokenHash} for every trace of the
+ * package. Same gates as lookupTraceMatchesForAuthUser (api secret + couplingTraceability capability
+ * + package ownership). The closed coupling service derives a seed per candidate and decodes.
+ */
+export const listCouplingTraceCandidatesForAuthUser = query({
+  args: {
+    apiSecret: v.string(),
+    authUserId: v.string(),
+    packageId: v.string(),
+  },
+  returns: v.object({
+    capabilityEnabled: v.boolean(),
+    packageOwned: v.boolean(),
+    candidates: v.array(
+      v.object({
+        assetPath: v.string(),
+        licenseSubject: v.string(),
+        tokenHash: v.string(),
+      })
+    ),
+  }),
+  handler: async (ctx, args) => {
+    requireApiSecret(args.apiSecret);
+    assertPackageId(args.packageId);
+
+    const capabilityEnabled = await ctx.runQuery(
+      internal.certificateBilling.hasCapabilityForAuthUser,
+      {
+        authUserId: args.authUserId,
+        capabilityKey: BILLING_CAPABILITY_KEYS.couplingTraceability,
+      }
+    );
+    if (!capabilityEnabled) {
+      return { capabilityEnabled: false, packageOwned: false, candidates: [] };
+    }
+
+    const registration = await ctx.runQuery(internal.packageRegistry.getRegistration, {
+      packageId: args.packageId,
+    });
+    if (
+      !registration ||
+      registration.yucpUserId !== args.authUserId ||
+      isArchivedPackage(registration)
+    ) {
+      return { capabilityEnabled: true, packageOwned: false, candidates: [] };
+    }
+
+    const rows = await ctx.db
+      .query('coupling_trace_records')
+      .withIndex('by_package_token', (q) => q.eq('packageId', args.packageId))
+      .collect();
+
+    const seen = new Set<string>();
+    const candidates: Array<{ assetPath: string; licenseSubject: string; tokenHash: string }> = [];
+    for (const row of rows) {
+      if (row.authUserId !== args.authUserId) {
+        continue;
+      }
+      const key = `${row.assetPath} ${row.licenseSubject} ${row.tokenHash}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      candidates.push({
+        assetPath: row.assetPath,
+        licenseSubject: row.licenseSubject,
+        tokenHash: row.tokenHash,
+      });
+    }
+
+    return { capabilityEnabled: true, packageOwned: true, candidates };
   },
 });

--- a/convex/couplingForensics.ts
+++ b/convex/couplingForensics.ts
@@ -10,6 +10,8 @@ import { decryptForPurpose } from './lib/vrchat/crypto';
 const PACKAGE_ID_RE = /^[a-z0-9\-_./:]{1,128}$/;
 const TOKEN_HASH_RE = /^[0-9a-f]{64}$/;
 const COUPLING_TRACE_CANDIDATE_LIMIT = 512;
+const COUPLING_TRACE_MATCHES_PER_TOKEN_LIMIT = 64;
+const COUPLING_TRACE_MATCH_TOTAL_LIMIT = 512;
 const COUPLING_TRACE_ROW_PAGE_SIZE = 512;
 const COUPLING_TRACE_ROW_SCAN_LIMIT = COUPLING_TRACE_CANDIDATE_LIMIT * 4;
 
@@ -388,18 +390,23 @@ export const lookupTraceMatchesForAuthUser = query({
     };
 
     for (const tokenHash of tokenHashes) {
+      const remainingMatchBudget = COUPLING_TRACE_MATCH_TOTAL_LIMIT - matches.length;
+      if (remainingMatchBudget <= 0) {
+        break;
+      }
+      const matchLimit = Math.min(COUPLING_TRACE_MATCHES_PER_TOKEN_LIMIT, remainingMatchBudget);
       const rows = await ctx.db
         .query('coupling_trace_records')
-        .withIndex('by_package_token', (q) =>
-          q.eq('packageId', args.packageId).eq('tokenHash', tokenHash)
+        .withIndex('by_auth_package_token_created', (q) =>
+          q
+            .eq('authUserId', args.authUserId)
+            .eq('packageId', args.packageId)
+            .eq('tokenHash', tokenHash)
         )
-        .collect();
+        .order('desc')
+        .take(matchLimit);
 
-      const scopedRows = rows
-        .filter((row) => row.authUserId === args.authUserId)
-        .sort((left, right) => right.createdAt - left.createdAt);
-
-      for (const row of scopedRows) {
+      for (const row of rows) {
         matchedTokenHashes.add(tokenHash);
 
         const identity = await resolveIdentityForSubject(row.licenseSubject);

--- a/convex/couplingForensics.ts
+++ b/convex/couplingForensics.ts
@@ -508,7 +508,10 @@ export const lookupTraceMatchesForAuthUser = query({
           truncated = true;
           break;
         }
-        const matchLimit = Math.min(COUPLING_TRACE_MATCHES_PER_TOKEN_LIMIT, remainingMatchBudget);
+        const matchDisplayLimit = Math.min(
+          COUPLING_TRACE_MATCHES_PER_TOKEN_LIMIT,
+          remainingMatchBudget
+        );
         const rows = await ctx.db
           .query('coupling_trace_records')
           .withIndex('by_auth_package_token_created', (q) =>
@@ -518,15 +521,23 @@ export const lookupTraceMatchesForAuthUser = query({
               .eq('tokenHash', tokenHash)
           )
           .order('desc')
-          .take(matchLimit);
+          .take(matchDisplayLimit + 1);
 
         if (rows.length === 0) {
           unmatchedTokenHashSet.add(tokenHash);
           continue;
         }
 
-        for (const row of rows) {
+        if (rows.length > matchDisplayLimit) {
+          truncated = true;
+        }
+
+        for (const row of rows.slice(0, matchDisplayLimit)) {
           await appendTraceMatch(row);
+        }
+
+        if (truncated) {
+          break;
         }
       }
     }

--- a/convex/couplingForensics.ts
+++ b/convex/couplingForensics.ts
@@ -4,8 +4,6 @@ import type { Doc } from './_generated/dataModel';
 import { mutation, type QueryCtx, query } from './_generated/server';
 import { requireApiSecret } from './lib/apiAuth';
 import { BILLING_CAPABILITY_KEYS } from './lib/billingCapabilities';
-import { PII_PURPOSES } from './lib/credentialKeys';
-import { decryptForPurpose } from './lib/vrchat/crypto';
 
 const PACKAGE_ID_RE = /^[a-z0-9\-_./:]{1,128}$/;
 const TOKEN_HASH_RE = /^[0-9a-f]{64}$/;
@@ -48,7 +46,7 @@ function isArchivedPackage(
 /**
  * Non-secret license identifier for the forensics list view: the provider plus a short,
  * stable fingerprint of the license subject (SHA-256 of the key). Identifies *which* license
- * without revealing it — the full key is only available via the audit-logged reveal action.
+ * without revealing it.
  */
 function buildLicenseMaskedLabel(provider: string | undefined, licenseSubject: string): string {
   const fingerprint = licenseSubject.slice(0, 10);
@@ -445,98 +443,6 @@ export const lookupTraceMatchesForAuthUser = query({
       matches,
       unmatchedTokenHashes: tokenHashes.filter((tokenHash) => !matchedTokenHashes.has(tokenHash)),
     };
-  },
-});
-
-/**
- * Reveals the full provider license key behind a coupling forensics match. Privileged:
- * requires the owning creator, the coupling-traceability capability, and a real coupling
- * trace for that license subject on the package. Every reveal writes an audit_events row.
- */
-export const revealCouplingLicenseKey = mutation({
-  args: {
-    apiSecret: v.string(),
-    authUserId: v.string(),
-    packageId: v.string(),
-    licenseSubject: v.string(),
-  },
-  returns: v.object({
-    licenseKey: v.optional(v.string()),
-    error: v.optional(v.string()),
-  }),
-  handler: async (ctx, args) => {
-    requireApiSecret(args.apiSecret);
-    assertPackageId(args.packageId);
-    if (!TOKEN_HASH_RE.test(args.licenseSubject)) {
-      throw new ConvexError('Invalid licenseSubject');
-    }
-
-    const capabilityEnabled = await ctx.runQuery(
-      internal.certificateBilling.hasCapabilityForAuthUser,
-      {
-        authUserId: args.authUserId,
-        capabilityKey: BILLING_CAPABILITY_KEYS.couplingTraceability,
-      }
-    );
-    if (!capabilityEnabled) {
-      return { error: 'Coupling traceability is not enabled for this account' };
-    }
-
-    const registration = await ctx.runQuery(internal.packageRegistry.getRegistration, {
-      packageId: args.packageId,
-    });
-    if (
-      !registration ||
-      registration.yucpUserId !== args.authUserId ||
-      isArchivedPackage(registration)
-    ) {
-      return { error: 'Package not found or not owned by this account' };
-    }
-
-    // Require a real coupling trace tying this license subject to the owner's package.
-    const trace = await ctx.db
-      .query('coupling_trace_records')
-      .withIndex('by_package_token', (q) => q.eq('packageId', args.packageId))
-      .filter((q) => q.eq(q.field('licenseSubject'), args.licenseSubject))
-      .first();
-    if (!trace || trace.authUserId !== args.authUserId) {
-      return { error: 'No coupling trace for that license on this package' };
-    }
-
-    const link = await ctx.db
-      .query('license_subject_links')
-      .withIndex('by_auth_user_subject', (q) =>
-        q.eq('authUserId', args.authUserId).eq('licenseSubject', args.licenseSubject)
-      )
-      .first();
-    if (!link?.licenseKeyEncrypted) {
-      return { error: 'No license key on file for this license' };
-    }
-
-    const secret = process.env.ENCRYPTION_SECRET;
-    if (!secret) {
-      throw new ConvexError('ENCRYPTION_SECRET is required to reveal license keys');
-    }
-    const licenseKey = await decryptForPurpose(
-      link.licenseKeyEncrypted,
-      secret,
-      PII_PURPOSES.forensicsLicenseKey
-    );
-
-    await ctx.db.insert('audit_events', {
-      authUserId: args.authUserId,
-      eventType: 'coupling.license_key.revealed',
-      actorType: 'system',
-      metadata: {
-        packageId: args.packageId,
-        licenseSubject: args.licenseSubject,
-        provider: link.provider,
-      },
-      correlationId: `coupling-reveal:${args.authUserId}:${args.licenseSubject}:${Date.now()}`,
-      createdAt: Date.now(),
-    });
-
-    return { licenseKey };
   },
 });
 

--- a/convex/couplingForensics.ts
+++ b/convex/couplingForensics.ts
@@ -663,17 +663,21 @@ export const listCouplingTraceCandidatesForAuthUser = query({
       .query('coupling_trace_records')
       .withIndex('by_package_token', (q) => q.eq('packageId', args.packageId))
       .take(COUPLING_TRACE_ROW_SCAN_LIMIT);
-    const truncated = rows.length > COUPLING_TRACE_CANDIDATE_LIMIT;
 
     const seen = new Set<string>();
     const candidates: Array<{ assetPath: string; licenseSubject: string; tokenHash: string }> = [];
-    for (const row of rows.slice(0, COUPLING_TRACE_CANDIDATE_LIMIT)) {
+    let truncated = false;
+    for (const row of rows) {
       if (row.authUserId !== args.authUserId) {
         continue;
       }
       const key = JSON.stringify([row.assetPath, row.licenseSubject, row.tokenHash]);
       if (seen.has(key)) {
         continue;
+      }
+      if (candidates.length >= COUPLING_TRACE_CANDIDATE_LIMIT) {
+        truncated = true;
+        break;
       }
       seen.add(key);
       candidates.push({

--- a/convex/couplingJobAndReveal.realtest.ts
+++ b/convex/couplingJobAndReveal.realtest.ts
@@ -1,6 +1,7 @@
 import { setPinnedYucpRootsForTests } from '@yucp/shared/yucpTrust';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { api, internal } from './_generated/api';
+import * as couplingForensics from './couplingForensics';
 import { buildCreatorProfileWorkspaceKey } from './lib/certificateBillingConfig';
 import { PII_PURPOSES } from './lib/credentialKeys';
 import { encryptPii } from './lib/piiCrypto';
@@ -27,7 +28,7 @@ async function sha256Hex(input: string): Promise<string> {
   return Buffer.from(new Uint8Array(digest)).toString('hex');
 }
 
-describe('coupling job + license reveal', () => {
+describe('coupling job + license redaction', () => {
   let rootPrivateKey = '';
   let originalFetch: typeof fetch;
   let originalCouplingServiceBaseUrl: string | undefined;
@@ -465,7 +466,7 @@ describe('coupling job + license reveal', () => {
     expect(result.files?.map((file) => file.seedHex)).toEqual(['4'.repeat(64)]);
   });
 
-  // ── Reveal ────────────────────────────────────────────────────────────────
+  // ── License redaction ─────────────────────────────────────────────────────
 
   async function seedCouplingTraceability(t: ReturnType<typeof makeTestConvex>) {
     const now = Date.now();
@@ -555,62 +556,7 @@ describe('coupling job + license reveal', () => {
     expect(result.matches[0]).not.toHaveProperty('licenseKey');
   });
 
-  it('reveals the full license key for the owner and writes an audit event', async () => {
-    const t = makeTestConvex();
-    await seedCouplingTraceability(t);
-    await seedPackageRegistration(t);
-    await seedTraceAndLink(t, 'LICENSE-KEY-12345');
-
-    const result = await t.mutation(api.couplingForensics.revealCouplingLicenseKey, {
-      apiSecret: 'test-secret',
-      authUserId: creatorAuthUserId,
-      packageId,
-      licenseSubject,
-    });
-
-    expect(result.error).toBeUndefined();
-    expect(result.licenseKey).toBe('LICENSE-KEY-12345');
-
-    const audits = await t.run(async (ctx) =>
-      ctx.db
-        .query('audit_events')
-        .filter((q) => q.eq(q.field('eventType'), 'coupling.license_key.revealed'))
-        .collect()
-    );
-    expect(audits).toHaveLength(1);
-    expect(audits[0].authUserId).toBe(creatorAuthUserId);
-  });
-
-  it('refuses to reveal without the coupling-traceability capability', async () => {
-    const t = makeTestConvex();
-    await seedPackageRegistration(t);
-    await seedTraceAndLink(t, 'LICENSE-KEY-12345');
-
-    const result = await t.mutation(api.couplingForensics.revealCouplingLicenseKey, {
-      apiSecret: 'test-secret',
-      authUserId: creatorAuthUserId,
-      packageId,
-      licenseSubject,
-    });
-
-    expect(result.licenseKey).toBeUndefined();
-    expect(result.error).toBeTruthy();
-  });
-
-  it('refuses to reveal for a non-owner', async () => {
-    const t = makeTestConvex();
-    await seedCouplingTraceability(t);
-    await seedPackageRegistration(t);
-    await seedTraceAndLink(t, 'LICENSE-KEY-12345');
-
-    const result = await t.mutation(api.couplingForensics.revealCouplingLicenseKey, {
-      apiSecret: 'test-secret',
-      authUserId: 'someone-else',
-      packageId,
-      licenseSubject,
-    });
-
-    expect(result.licenseKey).toBeUndefined();
-    expect(result.error).toBeTruthy();
+  it('does not export a plaintext license key reveal mutation', () => {
+    expect('revealCouplingLicenseKey' in couplingForensics).toBe(false);
   });
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2591,6 +2591,7 @@ const coupling_trace_records = defineTable({
 })
   .index('by_auth_user_created', ['authUserId', 'createdAt'])
   .index('by_package_token', ['packageId', 'tokenHash'])
+  .index('by_auth_package_token_created', ['authUserId', 'packageId', 'tokenHash', 'createdAt'])
   .index('by_correlation', ['correlationId'])
   .index('by_grant_id', ['grantId']);
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2592,6 +2592,14 @@ const coupling_trace_records = defineTable({
   .index('by_auth_user_created', ['authUserId', 'createdAt'])
   .index('by_package_token', ['packageId', 'tokenHash'])
   .index('by_auth_package_token_created', ['authUserId', 'packageId', 'tokenHash', 'createdAt'])
+  .index('by_auth_package_token_subject_asset_created', [
+    'authUserId',
+    'packageId',
+    'tokenHash',
+    'licenseSubject',
+    'assetPath',
+    'createdAt',
+  ])
   .index('by_correlation', ['correlationId'])
   .index('by_grant_id', ['grantId']);
 


### PR DESCRIPTION
## Summary
- Route forensics uploads through coupling-service attribution using Convex trace candidates.
- Add Convex candidate listing and lookup audit support with capability and ownership gates.
- Extend API and Convex tests for attributed, denied, no-candidate, and audit paths.

## Verification
- `bun test apps/api/src/routes/forensics.test.ts apps/api/src/routes/forensics.startup.test.ts`
- `bun x vitest run --config convex/vitest.config.ts convex/couplingForensics.realtest.ts`
- `bun audit`
- `bun run lint`
- `bun run typecheck`
- `bun run test:external-integrations`
- `bun run test:ci`
- `bun run test:convex`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Candidate-first forensics lookup now uses coupling attribution with configurable attribution timeout and budgeted match retrieval that can return truncated results.
  * Added coupling trace candidate listing with capability/ownership gating and deduplication, including truncation reporting.
* **Bug Fixes**
  * Added configurable request/upload-size bounding and stricter multipart validation; improved rate limiting with 429 + headers.
  * Hardened coupling-service networking (safer base URL rules, error redirects) and added response size limits with consistent error handling.
* **UI Updates**
  * Removed license/key reveal functionality; updated forensics and bot views to display safer, redacted match/buyer fields.
* **Tests**
  * Refreshed and expanded backend, integration, e2e harness, and safe-logging coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->