### PR TITLE
fix(discord): bound account-link network requests

### DIFF
--- a/apps/api/src/providers/discord/buyerLink.test.ts
+++ b/apps/api/src/providers/discord/buyerLink.test.ts
@@ -33,6 +33,7 @@ mock.module('../../lib/encrypt', () => ({
 const { createDiscordBuyerLinkPlugin } = await import('./buyerLink');
 
 const originalFetch = globalThis.fetch;
+const originalSetTimeout = globalThis.setTimeout;
 
 let queryImpl: (ref: unknown, args?: unknown) => Promise<unknown>;
 let mutationImpl: (ref: unknown, args?: unknown) => Promise<unknown>;
@@ -62,6 +63,7 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  globalThis.setTimeout = originalSetTimeout;
 });
 
 describe('discord buyer link plugin', () => {
@@ -159,6 +161,129 @@ describe('discord buyer link plugin', () => {
       apiMock.creatorProfiles.getCreatorProfile,
       expect.objectContaining({
         authUserId: 'buyer_auth_user_B',
+      })
+    );
+  });
+
+  it('honors Discord Retry-After before retrying guild member fetches', async () => {
+    const retryDelays: number[] = [];
+    globalThis.setTimeout = mock(
+      (callback: Parameters<typeof setTimeout>[0], timeout?: number, ...args: unknown[]) => {
+        retryDelays.push(Number(timeout));
+        if (typeof callback === 'function') {
+          callback(...args);
+        }
+        return 0 as never;
+      }
+    ) as unknown as typeof setTimeout;
+
+    let guildMemberFetchCount = 0;
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe(
+        'https://discord.com/api/v10/users/@me/guilds/source-guild-1/member'
+      );
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+
+      guildMemberFetchCount += 1;
+      if (guildMemberFetchCount === 1) {
+        return Response.json(
+          { message: 'You are being rate limited.', retry_after: 7 },
+          { status: 429, headers: { 'Retry-After': '7' } }
+        );
+      }
+
+      return Response.json({ roles: ['required-role-1'] });
+    }) as unknown as typeof fetch;
+
+    queryMock.mockImplementation(async (ref, args) => {
+      switch (ref) {
+        case apiMock.creatorProfiles.getCreatorProfile:
+          expect(args).toMatchObject({
+            apiSecret: 'api-secret',
+            authUserId: 'creator_auth_user_A',
+          });
+          return {
+            _id: 'creator-profile-1',
+            authUserId: 'creator_auth_user_A',
+            policy: {
+              enableDiscordRoleFromOtherServers: true,
+              allowedSourceGuildIds: ['source-guild-1'],
+            },
+          };
+        case apiMock.role_rules.getDiscordRoleRulesByTenant:
+          expect(args).toMatchObject({
+            apiSecret: 'api-secret',
+            authUserId: 'creator_auth_user_A',
+            sourceGuildIds: ['source-guild-1'],
+          });
+          return [
+            {
+              sourceGuildId: 'source-guild-1',
+              requiredRoleId: 'required-role-1',
+              productId: 'discord-product-1',
+            },
+          ];
+        default:
+          throw new Error(`Unhandled query ref ${String(ref)}`);
+      }
+    });
+    mutationMock.mockImplementation(async (ref, args) => {
+      switch (ref) {
+        case apiMock.identitySync.storeDiscordToken:
+          expect(args).toMatchObject({
+            apiSecret: 'api-secret',
+            externalAccountId: 'external-account-1',
+          });
+          return null;
+        case apiMock.entitlements.grantEntitlement:
+          expect(args).toMatchObject({
+            apiSecret: 'api-secret',
+            authUserId: 'creator_auth_user_A',
+            subjectId: 'subject-1',
+            productId: 'discord-product-1',
+            evidence: {
+              provider: 'discord',
+              sourceReference: 'discord-product-1',
+            },
+          });
+          return null;
+        default:
+          throw new Error(`Unhandled mutation ref ${String(ref)}`);
+      }
+    });
+
+    const plugin = createDiscordBuyerLinkPlugin();
+    if (!plugin.afterLink) {
+      throw new Error('Expected afterLink to be defined for Discord');
+    }
+
+    await plugin.afterLink(
+      {
+        authUserId: 'buyer_auth_user_B',
+        creatorAuthUserId: 'creator_auth_user_A',
+        sessionId: 'verification-session-1' as never,
+        sessionMode: 'discord_role',
+        verificationMethod: 'account_link',
+        discordUserId: 'discord-user-123',
+        accessToken: 'discord-access-token',
+        expiresAt: 123,
+        grantedScopes: ['identify', 'guilds', 'guilds.members.read'],
+        identity: {
+          providerUserId: 'discord-user-123',
+          username: 'discord-buyer',
+        },
+        subjectId: 'subject-1' as never,
+        externalAccountId: 'external-account-1' as never,
+      },
+      makeCtx()
+    );
+
+    expect(retryDelays).toEqual([7000]);
+    expect(guildMemberFetchCount).toBe(2);
+    expect(mutationMock).toHaveBeenCalledWith(
+      apiMock.entitlements.grantEntitlement,
+      expect.objectContaining({
+        productId: 'discord-product-1',
       })
     );
   });

--- a/apps/api/src/providers/discord/buyerLink.test.ts
+++ b/apps/api/src/providers/discord/buyerLink.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import type { ConvexServerClient } from '../../lib/convex';
 
 const apiMock = {
@@ -32,6 +32,8 @@ mock.module('../../lib/encrypt', () => ({
 
 const { createDiscordBuyerLinkPlugin } = await import('./buyerLink');
 
+const originalFetch = globalThis.fetch;
+
 let queryImpl: (ref: unknown, args?: unknown) => Promise<unknown>;
 let mutationImpl: (ref: unknown, args?: unknown) => Promise<unknown>;
 const queryMock = mock((ref: unknown, args?: unknown) => queryImpl(ref, args));
@@ -58,7 +60,31 @@ beforeEach(() => {
   mutationImpl = async () => null;
 });
 
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
 describe('discord buyer link plugin', () => {
+  it('bounds the Discord identity fetch with an abort signal', async () => {
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe('https://discord.com/api/v10/users/@me');
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      return Response.json({
+        id: 'discord-user-123',
+        username: 'discord-buyer',
+        avatar: 'avatar-hash',
+      });
+    }) as unknown as typeof fetch;
+
+    const plugin = createDiscordBuyerLinkPlugin();
+    const identity = await plugin.fetchIdentity('discord-access-token', makeCtx());
+
+    expect(identity).toMatchObject({
+      providerUserId: 'discord-user-123',
+      username: 'discord-buyer',
+    });
+  });
+
   it('uses the creator auth user for Discord role tenant lookups after buyer canonicalization', async () => {
     queryMock.mockImplementation(async (ref, args) => {
       switch (ref) {

--- a/apps/api/src/providers/discord/buyerLink.ts
+++ b/apps/api/src/providers/discord/buyerLink.ts
@@ -4,6 +4,8 @@ import type { BuyerLinkPlugin } from '../types';
 
 const DISCORD_API_BASE = 'https://discord.com/api/v10';
 const DISCORD_TOKEN_PURPOSE = 'discord-oauth-access-token';
+const DISCORD_API_TIMEOUT_MS = 10_000;
+const DISCORD_RETRY_AFTER_MAX_MS = 5_000;
 
 interface DiscordUserResponse {
   id?: string;
@@ -21,6 +23,7 @@ async function fetchDiscordIdentity(accessToken: string) {
   // https://discord.com/developers/docs/resources/user#get-current-user
   const response = await fetch(`${DISCORD_API_BASE}/users/@me`, {
     headers: { Authorization: `Bearer ${accessToken}` },
+    signal: AbortSignal.timeout(DISCORD_API_TIMEOUT_MS),
   });
   if (!response.ok) {
     throw new Error('Failed to fetch Discord user');
@@ -50,15 +53,20 @@ async function fetchGuildMember(
   // https://discord.com/developers/docs/resources/user#get-current-user-guild-member
   let response = await fetch(`${DISCORD_API_BASE}/users/@me/guilds/${guildId}/member`, {
     headers: { Authorization: `Bearer ${accessToken}` },
+    signal: AbortSignal.timeout(DISCORD_API_TIMEOUT_MS),
   });
 
   if (response.status === 429) {
     const retryAfter = Number.parseFloat(response.headers.get('Retry-After') ?? '5');
     await new Promise((resolve) =>
-      setTimeout(resolve, Number.isFinite(retryAfter) ? retryAfter * 1000 : 5000)
+      setTimeout(
+        resolve,
+        Math.min(Number.isFinite(retryAfter) ? retryAfter * 1000 : 5000, DISCORD_RETRY_AFTER_MAX_MS)
+      )
     );
     response = await fetch(`${DISCORD_API_BASE}/users/@me/guilds/${guildId}/member`, {
       headers: { Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(DISCORD_API_TIMEOUT_MS),
     });
   }
 

--- a/apps/api/src/providers/discord/buyerLink.ts
+++ b/apps/api/src/providers/discord/buyerLink.ts
@@ -71,7 +71,8 @@ async function fetchGuildMember(
 ): Promise<DiscordGuildMemberResponse> {
   // Discord Get Current User Guild Member docs:
   // https://discord.com/developers/docs/resources/user#get-current-user-guild-member
-  let response = await fetch(`${DISCORD_API_BASE}/users/@me/guilds/${guildId}/member`, {
+  const guildMemberUrl = `${DISCORD_API_BASE}/users/@me/guilds/${encodeURIComponent(guildId)}/member`;
+  let response = await fetch(guildMemberUrl, {
     headers: { Authorization: `Bearer ${accessToken}` },
     signal: AbortSignal.timeout(DISCORD_API_TIMEOUT_MS),
   });
@@ -85,7 +86,7 @@ async function fetchGuildMember(
     }
 
     await new Promise((resolve) => setTimeout(resolve, retryAfterMs));
-    response = await fetch(`${DISCORD_API_BASE}/users/@me/guilds/${guildId}/member`, {
+    response = await fetch(guildMemberUrl, {
       headers: { Authorization: `Bearer ${accessToken}` },
       signal: AbortSignal.timeout(DISCORD_API_TIMEOUT_MS),
     });

--- a/apps/api/src/providers/discord/buyerLink.ts
+++ b/apps/api/src/providers/discord/buyerLink.ts
@@ -5,7 +5,8 @@ import type { BuyerLinkPlugin } from '../types';
 const DISCORD_API_BASE = 'https://discord.com/api/v10';
 const DISCORD_TOKEN_PURPOSE = 'discord-oauth-access-token';
 const DISCORD_API_TIMEOUT_MS = 10_000;
-const DISCORD_RETRY_AFTER_MAX_MS = 5_000;
+const DISCORD_RETRY_AFTER_FALLBACK_MS = 5_000;
+const DISCORD_RATE_LIMIT_RETRY_BUDGET_MS = 10_000;
 
 interface DiscordUserResponse {
   id?: string;
@@ -16,6 +17,25 @@ interface DiscordUserResponse {
 
 interface DiscordGuildMemberResponse {
   roles?: string[];
+}
+
+async function readDiscordRetryAfterMs(response: Response): Promise<number> {
+  const retryAfterHeader = Number.parseFloat(response.headers.get('Retry-After') ?? '');
+  if (Number.isFinite(retryAfterHeader) && retryAfterHeader >= 0) {
+    return retryAfterHeader * 1000;
+  }
+
+  try {
+    const data = (await response.clone().json()) as { retry_after?: unknown };
+    const retryAfter = Number.parseFloat(String(data.retry_after ?? ''));
+    if (Number.isFinite(retryAfter) && retryAfter >= 0) {
+      return retryAfter * 1000;
+    }
+  } catch {
+    return DISCORD_RETRY_AFTER_FALLBACK_MS;
+  }
+
+  return DISCORD_RETRY_AFTER_FALLBACK_MS;
 }
 
 async function fetchDiscordIdentity(accessToken: string) {
@@ -57,13 +77,14 @@ async function fetchGuildMember(
   });
 
   if (response.status === 429) {
-    const retryAfter = Number.parseFloat(response.headers.get('Retry-After') ?? '5');
-    await new Promise((resolve) =>
-      setTimeout(
-        resolve,
-        Math.min(Number.isFinite(retryAfter) ? retryAfter * 1000 : 5000, DISCORD_RETRY_AFTER_MAX_MS)
-      )
-    );
+    // Discord rate limit docs:
+    // https://discord.com/developers/docs/topics/rate-limits#exceeding-a-rate-limit
+    const retryAfterMs = await readDiscordRetryAfterMs(response);
+    if (retryAfterMs > DISCORD_RATE_LIMIT_RETRY_BUDGET_MS) {
+      throw new Error('Discord is rate limited. Please try again shortly.');
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, retryAfterMs));
     response = await fetch(`${DISCORD_API_BASE}/users/@me/guilds/${guildId}/member`, {
       headers: { Authorization: `Bearer ${accessToken}` },
       signal: AbortSignal.timeout(DISCORD_API_TIMEOUT_MS),

--- a/apps/api/src/routes/connect.guildChannels.test.ts
+++ b/apps/api/src/routes/connect.guildChannels.test.ts
@@ -763,7 +763,7 @@ describe('discord role setup routes', () => {
     const session = JSON.parse(sessionEntry.value) as {
       guilds?: Array<{ id: string; name: string }>;
     };
-    session.guilds = [{ id: 'source-guild-1', name: 'Source Guild' }];
+    session.guilds = [{ id: '1169053833922629653', name: 'Source Guild' }];
     testStore.set(`discord_role_setup:${token}`, { value: JSON.stringify(session) });
 
     const saveRes = await routes.saveDiscordRoleSelection(
@@ -774,7 +774,7 @@ describe('discord role setup routes', () => {
           Cookie: `yucp_discord_role_setup=${token}`,
         },
         body: JSON.stringify({
-          sourceGuildId: 'source-guild-1',
+          sourceGuildId: '1169053833922629653',
           sourceGuildName: 'Source Guild',
           sourceRoleId: '123456789012345678',
         }),
@@ -802,12 +802,56 @@ describe('discord role setup routes', () => {
     };
     expect(resultBody).toEqual({
       completed: true,
-      sourceGuildId: 'source-guild-1',
+      sourceGuildId: '1169053833922629653',
       sourceGuildName: 'Source Guild',
       sourceRoleId: '123456789012345678',
       sourceRoleIds: ['123456789012345678'],
       requiredRoleMatchMode: 'any',
     });
+  });
+
+  it('rejects malformed Discord source guild IDs before saving role selections', async () => {
+    const createRes = await routes.createDiscordRoleSession(
+      new Request('http://localhost:3001/api/setup/discord-role-session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          authUserId: 'creator-auth-user',
+          guildId: 'guild-123',
+          adminDiscordUserId: 'discord-admin-123',
+          apiSecret: 'test-convex-secret',
+        }),
+      })
+    );
+    const { token } = (await createRes.json()) as { token: string };
+    const sessionEntry = testStore.get(`discord_role_setup:${token}`);
+    if (!sessionEntry) {
+      throw new Error('Discord role setup session was not stored');
+    }
+    const session = JSON.parse(sessionEntry.value) as {
+      guilds?: Array<{ id: string; name: string }>;
+    };
+    session.guilds = [{ id: '../member', name: 'Injected Guild' }];
+    testStore.set(`discord_role_setup:${token}`, { value: JSON.stringify(session) });
+
+    const saveRes = await routes.saveDiscordRoleSelection(
+      new Request('http://localhost:3001/api/setup/discord-role-save', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `yucp_discord_role_setup=${token}`,
+        },
+        body: JSON.stringify({
+          sourceGuildId: '../member',
+          sourceGuildName: 'Injected Guild',
+          sourceRoleId: '123456789012345678',
+        }),
+      })
+    );
+
+    expect(saveRes.status).toBe(400);
+    const body = (await saveRes.json()) as { error: string };
+    expect(body.error).toContain('Invalid source guild ID');
   });
 });
 

--- a/apps/api/src/routes/connect.guildChannels.test.ts
+++ b/apps/api/src/routes/connect.guildChannels.test.ts
@@ -58,6 +58,8 @@ const apiMock = {
  * mock.module causing the stateStore singleton to diverge across module instances.
  */
 const testStore = new Map<string, { value: string; expiresAt?: number }>();
+const DUMMY_DISCORD_SOURCE_GUILD_ID = '100000000000000001';
+const DUMMY_DISCORD_SOURCE_ROLE_ID = '100000000000000002';
 
 mock.module('../../../../convex/_generated/api', () => ({
   api: apiMock,
@@ -763,7 +765,7 @@ describe('discord role setup routes', () => {
     const session = JSON.parse(sessionEntry.value) as {
       guilds?: Array<{ id: string; name: string }>;
     };
-    session.guilds = [{ id: '1169053833922629653', name: 'Source Guild' }];
+    session.guilds = [{ id: DUMMY_DISCORD_SOURCE_GUILD_ID, name: 'Source Guild' }];
     testStore.set(`discord_role_setup:${token}`, { value: JSON.stringify(session) });
 
     const saveRes = await routes.saveDiscordRoleSelection(
@@ -774,9 +776,9 @@ describe('discord role setup routes', () => {
           Cookie: `yucp_discord_role_setup=${token}`,
         },
         body: JSON.stringify({
-          sourceGuildId: '1169053833922629653',
+          sourceGuildId: DUMMY_DISCORD_SOURCE_GUILD_ID,
           sourceGuildName: 'Source Guild',
-          sourceRoleId: '123456789012345678',
+          sourceRoleId: DUMMY_DISCORD_SOURCE_ROLE_ID,
         }),
       })
     );
@@ -802,10 +804,10 @@ describe('discord role setup routes', () => {
     };
     expect(resultBody).toEqual({
       completed: true,
-      sourceGuildId: '1169053833922629653',
+      sourceGuildId: DUMMY_DISCORD_SOURCE_GUILD_ID,
       sourceGuildName: 'Source Guild',
-      sourceRoleId: '123456789012345678',
-      sourceRoleIds: ['123456789012345678'],
+      sourceRoleId: DUMMY_DISCORD_SOURCE_ROLE_ID,
+      sourceRoleIds: [DUMMY_DISCORD_SOURCE_ROLE_ID],
       requiredRoleMatchMode: 'any',
     });
   });
@@ -844,7 +846,7 @@ describe('discord role setup routes', () => {
         body: JSON.stringify({
           sourceGuildId: '../member',
           sourceGuildName: 'Injected Guild',
-          sourceRoleId: '123456789012345678',
+          sourceRoleId: DUMMY_DISCORD_SOURCE_ROLE_ID,
         }),
       })
     );

--- a/apps/api/src/routes/connectDiscordRoleRoutes.ts
+++ b/apps/api/src/routes/connectDiscordRoleRoutes.ts
@@ -6,6 +6,9 @@ import type { ConnectConfig } from '../providers/types';
 const DISCORD_ROLE_SETUP_PREFIX = 'discord_role_setup:';
 const DISCORD_ROLE_OAUTH_STATE_PREFIX = 'discord_role_oauth:';
 const DISCORD_ROLE_SETUP_TTL_MS = 30 * 60 * 1000; // 30 minutes
+// Discord Snowflake docs:
+// https://discord.com/developers/docs/reference#snowflakes
+const DISCORD_SNOWFLAKE_ID_PATTERN = /^\d{17,20}$/;
 
 interface DiscordRoleSetupSession {
   authUserId: string;
@@ -349,6 +352,12 @@ export function createConnectDiscordRoleRoutes(options: ConnectDiscordRoleRoutes
     if (!sourceGuildId) {
       return Response.json({ error: 'sourceGuildId is required' }, { status: 400 });
     }
+    if (!DISCORD_SNOWFLAKE_ID_PATTERN.test(sourceGuildId)) {
+      return Response.json(
+        { error: 'Invalid source guild ID. Must be a Discord snowflake.' },
+        { status: 400 }
+      );
+    }
     if (bodyRecord.sourceRoleIds !== undefined && !sourceRoleIds) {
       return Response.json({ error: 'sourceRoleIds must be an array of strings' }, { status: 400 });
     }
@@ -369,9 +378,8 @@ export function createConnectDiscordRoleRoutes(options: ConnectDiscordRoleRoutes
         { status: 400 }
       );
     }
-    const validId = /^\d{17,20}$/;
     for (const id of roleIds) {
-      if (!validId.test(id)) {
+      if (!DISCORD_SNOWFLAKE_ID_PATTERN.test(id)) {
         return Response.json(
           { error: `Invalid role ID: ${id}. Must be 17–20 digits.` },
           { status: 400 }

--- a/apps/api/src/routes/connectDiscordRoleRoutes.ts
+++ b/apps/api/src/routes/connectDiscordRoleRoutes.ts
@@ -1,4 +1,4 @@
-import type { StructuredLogger } from '@yucp/shared';
+import { isDiscordSnowflakeId, type StructuredLogger } from '@yucp/shared';
 import { buildCookie, DISCORD_ROLE_SETUP_COOKIE, getCookieValue } from '../lib/browserSessions';
 import { getStateStore } from '../lib/stateStore';
 import type { ConnectConfig } from '../providers/types';
@@ -6,9 +6,6 @@ import type { ConnectConfig } from '../providers/types';
 const DISCORD_ROLE_SETUP_PREFIX = 'discord_role_setup:';
 const DISCORD_ROLE_OAUTH_STATE_PREFIX = 'discord_role_oauth:';
 const DISCORD_ROLE_SETUP_TTL_MS = 30 * 60 * 1000; // 30 minutes
-// Discord Snowflake docs:
-// https://discord.com/developers/docs/reference#snowflakes
-const DISCORD_SNOWFLAKE_ID_PATTERN = /^\d{17,20}$/;
 
 interface DiscordRoleSetupSession {
   authUserId: string;
@@ -352,7 +349,7 @@ export function createConnectDiscordRoleRoutes(options: ConnectDiscordRoleRoutes
     if (!sourceGuildId) {
       return Response.json({ error: 'sourceGuildId is required' }, { status: 400 });
     }
-    if (!DISCORD_SNOWFLAKE_ID_PATTERN.test(sourceGuildId)) {
+    if (!isDiscordSnowflakeId(sourceGuildId)) {
       return Response.json(
         { error: 'Invalid source guild ID. Must be a Discord snowflake.' },
         { status: 400 }
@@ -379,7 +376,7 @@ export function createConnectDiscordRoleRoutes(options: ConnectDiscordRoleRoutes
       );
     }
     for (const id of roleIds) {
-      if (!DISCORD_SNOWFLAKE_ID_PATTERN.test(id)) {
+      if (!isDiscordSnowflakeId(id)) {
         return Response.json(
           { error: `Invalid role ID: ${id}. Must be 17–20 digits.` },
           { status: 400 }

--- a/apps/api/src/verification/sessionManager.accountLink.test.ts
+++ b/apps/api/src/verification/sessionManager.accountLink.test.ts
@@ -545,6 +545,7 @@ describe('VerificationSessionManager account-link callback', () => {
     globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
       expect(String(input)).toBe('https://discord.com/api/oauth2/token');
       expect(init?.method).toBe('POST');
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
 
       const params = new URLSearchParams(String(init?.body ?? ''));
       expect(params.get('grant_type')).toBe('authorization_code');

--- a/apps/api/src/verification/sessionManager.ts
+++ b/apps/api/src/verification/sessionManager.ts
@@ -36,6 +36,8 @@ import {
 } from './verificationSessionPrimitives';
 import { createVrchatVerificationRouteHandlers } from './verificationVrchatRoutes';
 
+const OAUTH_TOKEN_EXCHANGE_TIMEOUT_MS = 10_000;
+
 export { getVerificationConfig, type VerificationConfig } from './verificationConfig';
 export {
   computeCodeChallenge,
@@ -562,6 +564,9 @@ export function createVerificationSessionManager(
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: tokenParams.toString(),
+        // Discord OAuth2 token exchange docs:
+        // https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-exchange-example
+        signal: AbortSignal.timeout(OAUTH_TOKEN_EXCHANGE_TIMEOUT_MS),
       });
 
       if (!tokenRes.ok) {

--- a/apps/bot/src/services/roleSync.ts
+++ b/apps/bot/src/services/roleSync.ts
@@ -1781,10 +1781,12 @@ export class RoleSyncService {
         );
 
         // Check guild membership using the user's OAuth token
-        const memberRes = await fetch(
-          `https://discord.com/api/v10/users/@me/guilds/${sourceGuildId}/member`,
-          { headers: { Authorization: `Bearer ${accessToken}` } }
-        );
+        const sourceGuildMemberUrl = `https://discord.com/api/v10/users/@me/guilds/${encodeURIComponent(
+          sourceGuildId
+        )}/member`;
+        const memberRes = await fetch(sourceGuildMemberUrl, {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
 
         if (memberRes.status === 429) {
           const retryAfter = memberRes.headers.get('Retry-After');

--- a/apps/bot/src/services/roleSync.ts
+++ b/apps/bot/src/services/roleSync.ts
@@ -34,6 +34,8 @@ import {
 import { buildVerifyPromptMessage, getEnabledProviders } from '../lib/verifyPrompt';
 import { buildVerifyPromptAccessPreview } from '../lib/verifyPromptAccess';
 
+const DISCORD_GUILD_MEMBER_FETCH_TIMEOUT_MS = 10_000;
+
 type BotConvexClient = {
   // biome-ignore lint/suspicious/noExplicitAny: Convex calls are dynamically dispatched in the bot runtime.
   query: (functionReference: unknown, args?: unknown) => Promise<any>;
@@ -1780,12 +1782,14 @@ export class RoleSyncService {
           this.encryptionSecret
         );
 
-        // Check guild membership using the user's OAuth token
+        // Discord Get Current User Guild Member docs:
+        // https://discord.com/developers/docs/resources/user#get-current-user-guild-member
         const sourceGuildMemberUrl = `https://discord.com/api/v10/users/@me/guilds/${encodeURIComponent(
           sourceGuildId
         )}/member`;
         const memberRes = await fetch(sourceGuildMemberUrl, {
           headers: { Authorization: `Bearer ${accessToken}` },
+          signal: AbortSignal.timeout(DISCORD_GUILD_MEMBER_FETCH_TIMEOUT_MS),
         });
 
         if (memberRes.status === 429) {

--- a/apps/bot/src/services/roleSync.ts
+++ b/apps/bot/src/services/roleSync.ts
@@ -35,6 +35,8 @@ import { buildVerifyPromptMessage, getEnabledProviders } from '../lib/verifyProm
 import { buildVerifyPromptAccessPreview } from '../lib/verifyPromptAccess';
 
 const DISCORD_GUILD_MEMBER_FETCH_TIMEOUT_MS = 10_000;
+const DISCORD_GUILD_MEMBER_RATE_LIMIT_FALLBACK_MS = 5_000;
+const DISCORD_GUILD_MEMBER_RATE_LIMIT_RETRY_BUDGET_MS = 10_000;
 
 type BotConvexClient = {
   // biome-ignore lint/suspicious/noExplicitAny: Convex calls are dynamically dispatched in the bot runtime.
@@ -44,6 +46,14 @@ type BotConvexClient = {
   // biome-ignore lint/suspicious/noExplicitAny: Convex calls are dynamically dispatched in the bot runtime.
   action: (functionReference: unknown, args?: unknown) => Promise<any>;
 };
+
+function readDiscordRetryAfterMs(retryAfterHeader: string | null): number {
+  const retryAfterSeconds = Number.parseFloat(retryAfterHeader ?? '');
+  if (!Number.isFinite(retryAfterSeconds) || retryAfterSeconds <= 0) {
+    return DISCORD_GUILD_MEMBER_RATE_LIMIT_FALLBACK_MS;
+  }
+  return retryAfterSeconds * 1000;
+}
 
 // ============================================================================
 // TYPES (defined locally to avoid Convex import issues)
@@ -1793,8 +1803,13 @@ export class RoleSyncService {
         });
 
         if (memberRes.status === 429) {
-          const retryAfter = memberRes.headers.get('Retry-After');
-          const waitMs = retryAfter ? Number.parseInt(retryAfter, 10) * 1000 : 5000;
+          // Discord rate limit docs:
+          // https://discord.com/developers/docs/topics/rate-limits#exceeding-a-rate-limit
+          const waitMs = readDiscordRetryAfterMs(memberRes.headers.get('Retry-After'));
+          if (waitMs > DISCORD_GUILD_MEMBER_RATE_LIMIT_RETRY_BUDGET_MS) {
+            skipped++;
+            continue;
+          }
           await new Promise((r) => setTimeout(r, waitMs));
           continue; // Skip this user for now, will be retried
         }

--- a/apps/bot/test/lib/roleSync.test.ts
+++ b/apps/bot/test/lib/roleSync.test.ts
@@ -96,7 +96,10 @@ mock.module('../../../../convex/_generated/api', () => ({
 import type { Client } from 'discord.js';
 import { type OutboxJob, RoleSyncService } from '../../src/services/roleSync';
 
-function createService(discordClientOverrides?: Partial<Client>) {
+function createService(
+  discordClientOverrides?: Partial<Client>,
+  optionsOverrides?: { encryptionSecret?: string }
+) {
   return new RoleSyncService({
     convexUrl: 'https://convex.example.test',
     apiSecret: 'test-secret',
@@ -109,6 +112,7 @@ function createService(discordClientOverrides?: Partial<Client>) {
       ...discordClientOverrides,
     } as unknown as Client,
     pollIntervalMs: 5_000,
+    encryptionSecret: optionsOverrides?.encryptionSecret,
   });
 }
 
@@ -517,6 +521,59 @@ describe('role sync service regressions', () => {
     expect(addRoleToMemberMock.mock.calls as unknown as Array<[string, string, string]>).toEqual([
       ['guild-123', 'user-123', 'role-advanced'],
     ]);
+  });
+
+  it('bounds proactive Discord guild member fetches with an abort signal', async () => {
+    const originalFetch = globalThis.fetch;
+    const service = createService(undefined, { encryptionSecret: 'test-encryption-key' });
+    const decryptTokenMock = mock(async () => 'placeholder-discord-oauth-value');
+    (
+      service as unknown as {
+        decryptToken: (ciphertextB64: string, secret: string) => Promise<string>;
+      }
+    ).decryptToken = decryptTokenMock;
+
+    let observedSignal: AbortSignal | undefined;
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      observedSignal = init?.signal ?? undefined;
+      return Response.json({ roles: ['234567890123456789'] });
+    }) as unknown as typeof fetch;
+
+    try {
+      await (
+        service as unknown as {
+          proactiveDiscordRoleCheck: (
+            authUserId: string,
+            productId: string,
+            accounts: Array<{
+              externalAccountId: string;
+              providerUserId: string;
+              discordAccessTokenEncrypted: string;
+              discordTokenExpiresAt?: number;
+            }>
+          ) => Promise<void>;
+        }
+      ).proactiveDiscordRoleCheck(
+        'auth-user-123',
+        'discord_role:123456789012345678:234567890123456789',
+        [
+          {
+            externalAccountId: 'external-account-123',
+            providerUserId: 'discord-user-123',
+            discordAccessTokenEncrypted: 'placeholder-encrypted-oauth-value',
+            discordTokenExpiresAt: Date.now() + 60_000,
+          },
+        ]
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(observedSignal).toBeInstanceOf(AbortSignal);
+    expect(decryptTokenMock).toHaveBeenCalledWith(
+      'placeholder-encrypted-oauth-value',
+      'test-encryption-key'
+    );
   });
 
   it('keeps product-wide role rules for guilds without tier-scoped overrides', async () => {

--- a/apps/bot/test/lib/roleSync.test.ts
+++ b/apps/bot/test/lib/roleSync.test.ts
@@ -96,6 +96,9 @@ mock.module('../../../../convex/_generated/api', () => ({
 import type { Client } from 'discord.js';
 import { type OutboxJob, RoleSyncService } from '../../src/services/roleSync';
 
+const DUMMY_DISCORD_SOURCE_GUILD_ID = '100000000000000001';
+const DUMMY_DISCORD_REQUIRED_ROLE_ID = '100000000000000002';
+
 function createService(
   discordClientOverrides?: Partial<Client>,
   optionsOverrides?: { encryptionSecret?: string }
@@ -536,7 +539,7 @@ describe('role sync service regressions', () => {
     let observedSignal: AbortSignal | undefined;
     globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
       observedSignal = init?.signal ?? undefined;
-      return Response.json({ roles: ['234567890123456789'] });
+      return Response.json({ roles: [DUMMY_DISCORD_REQUIRED_ROLE_ID] });
     }) as unknown as typeof fetch;
 
     try {
@@ -555,7 +558,7 @@ describe('role sync service regressions', () => {
         }
       ).proactiveDiscordRoleCheck(
         'auth-user-123',
-        'discord_role:123456789012345678:234567890123456789',
+        `discord_role:${DUMMY_DISCORD_SOURCE_GUILD_ID}:${DUMMY_DISCORD_REQUIRED_ROLE_ID}`,
         [
           {
             externalAccountId: 'external-account-123',
@@ -574,6 +577,67 @@ describe('role sync service regressions', () => {
       'placeholder-encrypted-oauth-value',
       'test-encryption-key'
     );
+  });
+
+  it('skips over-budget proactive Discord 429 backoff without sleeping', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalSetTimeout = globalThis.setTimeout;
+    const service = createService(undefined, { encryptionSecret: 'test-encryption-key' });
+    (
+      service as unknown as {
+        decryptToken: (ciphertextB64: string, secret: string) => Promise<string>;
+      }
+    ).decryptToken = mock(async () => 'placeholder-discord-oauth-value');
+
+    const retryDelays: number[] = [];
+    globalThis.setTimeout = mock(
+      (callback: Parameters<typeof setTimeout>[0], timeout?: number, ...args: unknown[]) => {
+        retryDelays.push(Number(timeout));
+        if (typeof callback === 'function') {
+          callback(...args);
+        }
+        return 0 as never;
+      }
+    ) as unknown as typeof setTimeout;
+    globalThis.fetch = mock(async () => {
+      return Response.json(
+        { message: 'You are being rate limited.' },
+        { status: 429, headers: { 'Retry-After': '20' } }
+      );
+    }) as unknown as typeof fetch;
+
+    try {
+      await (
+        service as unknown as {
+          proactiveDiscordRoleCheck: (
+            authUserId: string,
+            productId: string,
+            accounts: Array<{
+              externalAccountId: string;
+              providerUserId: string;
+              discordAccessTokenEncrypted: string;
+              discordTokenExpiresAt?: number;
+            }>
+          ) => Promise<void>;
+        }
+      ).proactiveDiscordRoleCheck(
+        'auth-user-123',
+        `discord_role:${DUMMY_DISCORD_SOURCE_GUILD_ID}:${DUMMY_DISCORD_REQUIRED_ROLE_ID}`,
+        [
+          {
+            externalAccountId: 'external-account-123',
+            providerUserId: 'discord-user-123',
+            discordAccessTokenEncrypted: 'placeholder-encrypted-oauth-value',
+            discordTokenExpiresAt: Date.now() + 60_000,
+          },
+        ]
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.setTimeout = originalSetTimeout;
+    }
+
+    expect(retryDelays).toEqual([]);
   });
 
   it('keeps product-wide role rules for guilds without tier-scoped overrides', async () => {

--- a/convex/lib/roleRules/discord.ts
+++ b/convex/lib/roleRules/discord.ts
@@ -6,22 +6,13 @@
  */
 
 import type { GenericMutationCtx } from 'convex/server';
+import { assertDiscordSnowflakeId } from '@yucp/shared';
 import type { DataModel, Id } from '../../_generated/dataModel';
 import { enqueueVerifyPromptRefreshJob } from '../verifyPrompt';
 import { requireApiSecret } from './queries';
 import { normalizeWritableVerifiedRoleIds } from './roleIds';
 
 type MutationCtx = GenericMutationCtx<DataModel>;
-
-// Discord Snowflake docs:
-// https://discord.com/developers/docs/reference#snowflakes
-const DISCORD_SNOWFLAKE_ID_PATTERN = /^\d{17,20}$/;
-
-function assertDiscordSnowflakeId(value: string, label: string) {
-  if (!DISCORD_SNOWFLAKE_ID_PATTERN.test(value)) {
-    throw new Error(`Invalid Discord ${label} ID`);
-  }
-}
 
 export function buildDiscordRoleKey(
   sourceGuildId: string,

--- a/convex/lib/roleRules/discord.ts
+++ b/convex/lib/roleRules/discord.ts
@@ -6,13 +6,20 @@
  */
 
 import type { GenericMutationCtx } from 'convex/server';
-import { assertDiscordSnowflakeId } from '@yucp/shared';
+import { ConvexError } from 'convex/values';
+import { isDiscordSnowflakeId } from '@yucp/shared';
 import type { DataModel, Id } from '../../_generated/dataModel';
 import { enqueueVerifyPromptRefreshJob } from '../verifyPrompt';
 import { requireApiSecret } from './queries';
 import { normalizeWritableVerifiedRoleIds } from './roleIds';
 
 type MutationCtx = GenericMutationCtx<DataModel>;
+
+function assertDiscordSnowflakeId(value: string, label: string) {
+  if (!isDiscordSnowflakeId(value)) {
+    throw new ConvexError(`Invalid Discord ${label} ID`);
+  }
+}
 
 export function buildDiscordRoleKey(
   sourceGuildId: string,

--- a/convex/lib/roleRules/discord.ts
+++ b/convex/lib/roleRules/discord.ts
@@ -13,6 +13,16 @@ import { normalizeWritableVerifiedRoleIds } from './roleIds';
 
 type MutationCtx = GenericMutationCtx<DataModel>;
 
+// Discord Snowflake docs:
+// https://discord.com/developers/docs/reference#snowflakes
+const DISCORD_SNOWFLAKE_ID_PATTERN = /^\d{17,20}$/;
+
+function assertDiscordSnowflakeId(value: string, label: string) {
+  if (!DISCORD_SNOWFLAKE_ID_PATTERN.test(value)) {
+    throw new Error(`Invalid Discord ${label} ID`);
+  }
+}
+
 export function buildDiscordRoleKey(
   sourceGuildId: string,
   requiredRoleIds: string[],
@@ -54,6 +64,10 @@ export async function addProductFromDiscordRoleImpl(
   const reqIds = args.requiredRoleIds ?? (args.requiredRoleId ? [args.requiredRoleId] : []);
   if (reqIds.length === 0) {
     throw new Error('At least one required role is needed');
+  }
+  assertDiscordSnowflakeId(args.sourceGuildId, 'source guild');
+  for (const requiredRoleId of reqIds) {
+    assertDiscordSnowflakeId(requiredRoleId, 'required role');
   }
 
   const productId = buildDiscordRoleKey(args.sourceGuildId, reqIds, args.requiredRoleMatchMode);

--- a/convex/roleRules.realtest.ts
+++ b/convex/roleRules.realtest.ts
@@ -10,6 +10,7 @@
  */
 
 import { beforeEach, describe, expect, it } from 'vitest';
+import { ConvexError } from 'convex/values';
 import { api } from './_generated/api';
 import type { Doc } from './_generated/dataModel';
 import { getByProductInternal } from './role_rules';
@@ -337,8 +338,9 @@ describe('role rules CRUD and isolation', () => {
     });
     const before = await getRoleRuleCounts(t);
 
-    await expect(
-      t.mutation(api.role_rules.addProductFromDiscordRole, {
+    let caught: unknown;
+    try {
+      await t.mutation(api.role_rules.addProductFromDiscordRole, {
         apiSecret: 'test-secret',
         authUserId: 'auth-creator-invalid-discord-source',
         sourceGuildId: '../member',
@@ -346,8 +348,13 @@ describe('role rules CRUD and isolation', () => {
         guildId: 'guild-invalid-discord-source',
         guildLinkId,
         verifiedRoleId: 'target-role-invalid-discord-source',
-      })
-    ).rejects.toThrow('Invalid Discord source guild ID');
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(ConvexError);
+    expect((caught as Error).message).toContain('Invalid Discord source guild ID');
 
     expect(await getRoleRuleCounts(t)).toEqual(before);
   });

--- a/convex/roleRules.realtest.ts
+++ b/convex/roleRules.realtest.ts
@@ -311,8 +311,8 @@ describe('role rules CRUD and isolation', () => {
     await t.mutation(api.role_rules.addProductFromDiscordRole, {
       apiSecret: 'test-secret',
       authUserId: 'auth-creator-refresh-discord',
-      sourceGuildId: 'source-guild-refresh',
-      requiredRoleId: 'source-role-refresh',
+      sourceGuildId: '1169053833922629653',
+      requiredRoleId: '1169056856354852927',
       guildId: 'guild-refresh-discord',
       guildLinkId,
       verifiedRoleId: 'target-role-refresh',
@@ -323,6 +323,30 @@ describe('role rules CRUD and isolation', () => {
 
     expect(jobTypes).toContain('retroactive_rule_sync');
     expect(jobTypes).toContain('verify_prompt_refresh');
+  });
+
+  it('rejects discord cross-server rules with malformed source guild IDs', async () => {
+    const t = makeTestConvex();
+
+    const guildLinkId = await seedGuildLink(t, {
+      authUserId: 'auth-creator-invalid-discord-source',
+      discordGuildId: 'guild-invalid-discord-source',
+    });
+    const before = await getRoleRuleCounts(t);
+
+    await expect(
+      t.mutation(api.role_rules.addProductFromDiscordRole, {
+        apiSecret: 'test-secret',
+        authUserId: 'auth-creator-invalid-discord-source',
+        sourceGuildId: '../member',
+        requiredRoleId: '1169056856354852927',
+        guildId: 'guild-invalid-discord-source',
+        guildLinkId,
+        verifiedRoleId: 'target-role-invalid-discord-source',
+      })
+    ).rejects.toThrow('Invalid Discord source guild ID');
+
+    expect(await getRoleRuleCounts(t)).toEqual(before);
   });
 
   it('given wrong apiSecret, when creating rule, then throws', async () => {
@@ -436,8 +460,8 @@ describe('role rules CRUD and isolation', () => {
       t.mutation(api.role_rules.addProductFromDiscordRole, {
         apiSecret: 'test-secret',
         authUserId: 'auth-creator-role-limit-discord',
-        sourceGuildId: 'source-guild-role-limit-discord',
-        requiredRoleId: 'source-role-role-limit-discord',
+        sourceGuildId: '1169053833922629653',
+        requiredRoleId: '1169056856354852927',
         guildId: 'guild-role-limit-discord',
         guildLinkId,
         verifiedRoleIds: Array.from({ length: 11 }, (_, index) => `role-limit-discord-${index}`),

--- a/convex/roleRules.realtest.ts
+++ b/convex/roleRules.realtest.ts
@@ -15,6 +15,9 @@ import type { Doc } from './_generated/dataModel';
 import { getByProductInternal } from './role_rules';
 import { makeTestConvex, seedGuildLink } from './testHelpers';
 
+const DUMMY_DISCORD_SOURCE_GUILD_ID = '100000000000000001';
+const DUMMY_DISCORD_REQUIRED_ROLE_ID = '100000000000000002';
+
 async function getRoleRuleCounts(t: ReturnType<typeof makeTestConvex>) {
   return t.run(async (ctx) => ({
     roleRules: (await ctx.db.query('role_rules').collect()).length,
@@ -311,8 +314,8 @@ describe('role rules CRUD and isolation', () => {
     await t.mutation(api.role_rules.addProductFromDiscordRole, {
       apiSecret: 'test-secret',
       authUserId: 'auth-creator-refresh-discord',
-      sourceGuildId: '1169053833922629653',
-      requiredRoleId: '1169056856354852927',
+      sourceGuildId: DUMMY_DISCORD_SOURCE_GUILD_ID,
+      requiredRoleId: DUMMY_DISCORD_REQUIRED_ROLE_ID,
       guildId: 'guild-refresh-discord',
       guildLinkId,
       verifiedRoleId: 'target-role-refresh',
@@ -339,7 +342,7 @@ describe('role rules CRUD and isolation', () => {
         apiSecret: 'test-secret',
         authUserId: 'auth-creator-invalid-discord-source',
         sourceGuildId: '../member',
-        requiredRoleId: '1169056856354852927',
+        requiredRoleId: DUMMY_DISCORD_REQUIRED_ROLE_ID,
         guildId: 'guild-invalid-discord-source',
         guildLinkId,
         verifiedRoleId: 'target-role-invalid-discord-source',
@@ -460,8 +463,8 @@ describe('role rules CRUD and isolation', () => {
       t.mutation(api.role_rules.addProductFromDiscordRole, {
         apiSecret: 'test-secret',
         authUserId: 'auth-creator-role-limit-discord',
-        sourceGuildId: '1169053833922629653',
-        requiredRoleId: '1169056856354852927',
+        sourceGuildId: DUMMY_DISCORD_SOURCE_GUILD_ID,
+        requiredRoleId: DUMMY_DISCORD_REQUIRED_ROLE_ID,
         guildId: 'guild-role-limit-discord',
         guildLinkId,
         verifiedRoleIds: Array.from({ length: 11 }, (_, index) => `role-limit-discord-${index}`),

--- a/ops/web-dev-runtime.test.ts
+++ b/ops/web-dev-runtime.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 const WEB_READY_PATTERN = /Local:\s+(http:\/\/(?:localhost|127\.0\.0\.1):\d+)/;
 const REQUEST_TIMEOUT_MS = 5_000;
 const STARTUP_TIMEOUT_MS = 90_000;
+const BUN_EXECUTABLE = process.execPath;
 
 const children = new Set<ChildProcessWithoutNullStreams>();
 
@@ -49,7 +50,7 @@ function isChildProcessAlive(child: ChildProcessWithoutNullStreams): boolean {
     return false;
   }
   if (!child.pid) {
-    return true;
+    return false;
   }
   try {
     process.kill(child.pid, 0);
@@ -92,7 +93,7 @@ describe('web dev runtime', () => {
       const tempEnvDir = await mkdtemp(join(tmpdir(), 'yucp-web-worker-env-'));
       const localWorkerEnvPath = join(tempEnvDir, '.dev.vars');
       const output: string[] = [];
-      const child = spawn('bun', ['run', '--filter', '@yucp/web', 'worker:dev'], {
+      const child = spawn(BUN_EXECUTABLE, ['run', '--filter', '@yucp/web', 'worker:dev'], {
         cwd: process.cwd(),
         env: {
           ...process.env,

--- a/packages/providers/src/discord/oauth.ts
+++ b/packages/providers/src/discord/oauth.ts
@@ -17,6 +17,7 @@
  */
 
 import { createAAD, decrypt, type EncryptedPayload, encrypt } from '@yucp/shared/crypto';
+import { withProviderRequestSpan } from '../core/observability';
 import {
   DEFAULT_SCOPES,
   type DiscordAPIError,
@@ -54,6 +55,7 @@ const DISCORD_OAUTH_TOKEN = 'https://discord.com/api/oauth2/token';
 const DISCORD_OAUTH_TOKEN_REVOKE = 'https://discord.com/api/oauth2/token/revoke';
 const DISCORD_API_BASE = 'https://discord.com/api/v10';
 const DISCORD_API_REQUEST_TIMEOUT_MS = 10_000;
+const DISCORD_OAUTH_TOKEN_REVOKE_PATH = '/oauth2/token/revoke';
 
 /** State expiration time (10 minutes) */
 const STATE_EXPIRY_MS = 10 * 60 * 1000;
@@ -498,16 +500,32 @@ export class DiscordOAuthProvider {
     });
 
     try {
-      // Discord OAuth2 token revocation docs:
-      // https://discord.com/developers/docs/topics/oauth2
-      await fetch(DISCORD_OAUTH_TOKEN_REVOKE, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
+      await withProviderRequestSpan(
+        'discord',
+        'POST',
+        DISCORD_OAUTH_TOKEN_REVOKE_PATH,
+        {
+          'server.address': new URL(DISCORD_OAUTH_TOKEN_REVOKE).host,
+          hasBody: true,
+          timeoutMs: DISCORD_API_REQUEST_TIMEOUT_MS,
         },
-        body: params.toString(),
-        signal: AbortSignal.timeout(DISCORD_API_REQUEST_TIMEOUT_MS),
-      });
+        async () => {
+          // Discord OAuth2 token revocation docs:
+          // https://discord.com/developers/docs/topics/oauth2
+          const response = await fetch(DISCORD_OAUTH_TOKEN_REVOKE, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: params.toString(),
+            signal: AbortSignal.timeout(DISCORD_API_REQUEST_TIMEOUT_MS),
+          });
+
+          if (!response.ok) {
+            throw new Error(`Discord token revocation failed with status ${response.status}`);
+          }
+        }
+      );
     } catch {
       // Remote revocation is best effort; local disconnect still clears encrypted tokens.
     } finally {

--- a/packages/providers/src/discord/oauth.ts
+++ b/packages/providers/src/discord/oauth.ts
@@ -52,6 +52,7 @@ interface DiscordGuildMemberAPIResponse {
 const DISCORD_OAUTH_AUTHORIZE = 'https://discord.com/oauth2/authorize';
 const DISCORD_OAUTH_TOKEN = 'https://discord.com/api/oauth2/token';
 const DISCORD_API_BASE = 'https://discord.com/api/v10';
+const DISCORD_API_REQUEST_TIMEOUT_MS = 10_000;
 
 /** State expiration time (10 minutes) */
 const STATE_EXPIRY_MS = 10 * 60 * 1000;
@@ -370,12 +371,15 @@ export class DiscordOAuthProvider {
       accessToken = accessTokenOrSessionId;
     }
 
+    // Discord Get Current User Guild Member docs:
+    // https://discord.com/developers/docs/resources/user#get-current-user-guild-member
     const response = await fetch(
       `${DISCORD_API_BASE}/users/@me/guilds/${encodeURIComponent(guildId)}/member`,
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
+        signal: AbortSignal.timeout(DISCORD_API_REQUEST_TIMEOUT_MS),
       }
     );
 

--- a/packages/providers/src/discord/oauth.ts
+++ b/packages/providers/src/discord/oauth.ts
@@ -51,6 +51,7 @@ interface DiscordGuildMemberAPIResponse {
 /** Discord OAuth endpoints */
 const DISCORD_OAUTH_AUTHORIZE = 'https://discord.com/oauth2/authorize';
 const DISCORD_OAUTH_TOKEN = 'https://discord.com/api/oauth2/token';
+const DISCORD_OAUTH_TOKEN_REVOKE = 'https://discord.com/api/oauth2/token/revoke';
 const DISCORD_API_BASE = 'https://discord.com/api/v10';
 const DISCORD_API_REQUEST_TIMEOUT_MS = 10_000;
 
@@ -295,12 +296,15 @@ export class DiscordOAuthProvider {
       code_verifier: codeVerifier,
     });
 
+    // Discord OAuth2 token exchange docs:
+    // https://discord.com/developers/docs/topics/oauth2
     const response = await fetch(DISCORD_OAUTH_TOKEN, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: params.toString(),
+      signal: AbortSignal.timeout(DISCORD_API_REQUEST_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -330,10 +334,13 @@ export class DiscordOAuthProvider {
       accessToken = accessTokenOrSessionId;
     }
 
+    // Discord Get Current User docs:
+    // https://discord.com/developers/docs/resources/user#get-current-user
     const response = await fetch(`${DISCORD_API_BASE}/users/@me`, {
       headers: {
         Authorization: `Bearer ${accessToken}`,
       },
+      signal: AbortSignal.timeout(DISCORD_API_REQUEST_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -429,12 +436,15 @@ export class DiscordOAuthProvider {
       refresh_token: refreshToken,
     });
 
+    // Discord OAuth2 token refresh docs:
+    // https://discord.com/developers/docs/topics/oauth2
     const response = await fetch(DISCORD_OAUTH_TOKEN, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: params.toString(),
+      signal: AbortSignal.timeout(DISCORD_API_REQUEST_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -487,12 +497,15 @@ export class DiscordOAuthProvider {
       token: accessToken,
     });
 
-    await fetch('https://discord.com/api/oauth2/token/revoke', {
+    // Discord OAuth2 token revocation docs:
+    // https://discord.com/developers/docs/topics/oauth2
+    await fetch(DISCORD_OAUTH_TOKEN_REVOKE, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: params.toString(),
+      signal: AbortSignal.timeout(DISCORD_API_REQUEST_TIMEOUT_MS),
     });
 
     // Delete stored tokens

--- a/packages/providers/src/discord/oauth.ts
+++ b/packages/providers/src/discord/oauth.ts
@@ -370,11 +370,14 @@ export class DiscordOAuthProvider {
       accessToken = accessTokenOrSessionId;
     }
 
-    const response = await fetch(`${DISCORD_API_BASE}/users/@me/guilds/${guildId}/member`, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
+    const response = await fetch(
+      `${DISCORD_API_BASE}/users/@me/guilds/${encodeURIComponent(guildId)}/member`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      }
+    );
 
     if (!response.ok) {
       if (response.status === 403) {

--- a/packages/providers/src/discord/oauth.ts
+++ b/packages/providers/src/discord/oauth.ts
@@ -497,19 +497,22 @@ export class DiscordOAuthProvider {
       token: accessToken,
     });
 
-    // Discord OAuth2 token revocation docs:
-    // https://discord.com/developers/docs/topics/oauth2
-    await fetch(DISCORD_OAUTH_TOKEN_REVOKE, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: params.toString(),
-      signal: AbortSignal.timeout(DISCORD_API_REQUEST_TIMEOUT_MS),
-    });
-
-    // Delete stored tokens
-    await this.storage.deleteTokens(verificationSessionId);
+    try {
+      // Discord OAuth2 token revocation docs:
+      // https://discord.com/developers/docs/topics/oauth2
+      await fetch(DISCORD_OAUTH_TOKEN_REVOKE, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: params.toString(),
+        signal: AbortSignal.timeout(DISCORD_API_REQUEST_TIMEOUT_MS),
+      });
+    } catch {
+      // Remote revocation is best effort; local disconnect still clears encrypted tokens.
+    } finally {
+      await this.storage.deleteTokens(verificationSessionId);
+    }
   }
 
   /**

--- a/packages/providers/test/discord/oauth.test.ts
+++ b/packages/providers/test/discord/oauth.test.ts
@@ -175,17 +175,21 @@ describe('DiscordOAuthProvider', () => {
       const beginResult = await provider.beginVerification();
 
       // Mock fetch responses
-      global.fetch = mock(async (input: string | URL | Request) => {
+      let tokenExchangeSignal: AbortSignal | undefined;
+      let userInfoSignal: AbortSignal | undefined;
+      global.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
         const url =
           typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
 
         if (url.includes('/oauth2/token')) {
+          tokenExchangeSignal = init?.signal ?? undefined;
           return new Response(JSON.stringify(mockTokens), {
             status: 200,
             headers: { 'Content-Type': 'application/json' },
           });
         }
         if (url.includes('/users/@me')) {
+          userInfoSignal = init?.signal ?? undefined;
           return new Response(JSON.stringify(mockUser), {
             status: 200,
             headers: { 'Content-Type': 'application/json' },
@@ -206,6 +210,8 @@ describe('DiscordOAuthProvider', () => {
       expect(result.encryptedTokens).toBeDefined();
       expect(result.encryptedTokens.encryptedAccessToken).toBeDefined();
       expect(result.encryptedTokens.encryptedRefreshToken).toBeDefined();
+      expect(tokenExchangeSignal).toBeInstanceOf(AbortSignal);
+      expect(userInfoSignal).toBeInstanceOf(AbortSignal);
     });
 
     it('should fail with invalid state', async () => {
@@ -600,7 +606,9 @@ describe('DiscordOAuthProvider', () => {
         scope: 'identify',
       };
 
-      global.fetch = mock(async () => {
+      let refreshSignal: AbortSignal | undefined;
+      global.fetch = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+        refreshSignal = init?.signal ?? undefined;
         return new Response(JSON.stringify(newTokens), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
@@ -619,6 +627,7 @@ describe('DiscordOAuthProvider', () => {
         aad: createAAD(config.authUserId, 'discord', 'access'),
       });
       expect(decryptedAccess).toBe('new-access-token');
+      expect(refreshSignal).toBeInstanceOf(AbortSignal);
     });
 
     it('should revoke tokens', async () => {
@@ -642,7 +651,9 @@ describe('DiscordOAuthProvider', () => {
       await storage.storeTokens('test-session-id', tokens);
 
       // Mock revocation response
-      global.fetch = mock(async () => {
+      let revokeSignal: AbortSignal | undefined;
+      global.fetch = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+        revokeSignal = init?.signal ?? undefined;
         return new Response(null, { status: 200 });
       }) as unknown as typeof fetch;
 
@@ -651,6 +662,7 @@ describe('DiscordOAuthProvider', () => {
       // Tokens should be deleted
       const stored = await storage.getTokens('test-session-id');
       expect(stored).toBeNull();
+      expect(revokeSignal).toBeInstanceOf(AbortSignal);
     });
     it('should not throw when revoking non-existent tokens', async () => {
       // revokeTokens returns early when tokens don't exist; must not throw

--- a/packages/providers/test/discord/oauth.test.ts
+++ b/packages/providers/test/discord/oauth.test.ts
@@ -376,7 +376,9 @@ describe('DiscordOAuthProvider', () => {
     };
 
     it('should get guild member info with access token', async () => {
-      global.fetch = mock(async () => {
+      let observedSignal: AbortSignal | undefined;
+      global.fetch = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+        observedSignal = init?.signal ?? undefined;
         return new Response(JSON.stringify(mockMember), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
@@ -389,6 +391,7 @@ describe('DiscordOAuthProvider', () => {
       expect(member.guildId).toBe('guild-123');
       expect(member.nick).toBe('Test Nick');
       expect(member.roles).toEqual(['role-1', 'role-2']);
+      expect(observedSignal).toBeInstanceOf(AbortSignal);
     });
 
     it('should handle 403 Forbidden (user not in guild)', async () => {

--- a/packages/providers/test/discord/oauth.test.ts
+++ b/packages/providers/test/discord/oauth.test.ts
@@ -664,6 +664,36 @@ describe('DiscordOAuthProvider', () => {
       expect(stored).toBeNull();
       expect(revokeSignal).toBeInstanceOf(AbortSignal);
     });
+
+    it('should delete stored tokens when Discord revocation request times out', async () => {
+      const accessToken = 'access-to-revoke';
+      const encryptedAccessToken = await encrypt(accessToken, {
+        keyId: config.keyId,
+        keyVersion: config.keyVersion,
+        kekBytes: config.kekBytes,
+        aad: createAAD(config.authUserId, 'discord', 'access'),
+      });
+
+      const tokens: EncryptedDiscordTokens = {
+        encryptedAccessToken,
+        encryptedRefreshToken: encryptedAccessToken,
+        expiresAt: new Date(Date.now() + 604800000),
+        scopes: ['identify'],
+        verificationSessionId: 'test-session-id',
+      };
+
+      await storage.storeTokens('test-session-id', tokens);
+
+      global.fetch = mock(async () => {
+        throw new DOMException('The operation timed out.', 'TimeoutError');
+      }) as unknown as typeof fetch;
+
+      await expect(provider.revokeTokens('test-session-id')).resolves.toBeUndefined();
+
+      const stored = await storage.getTokens('test-session-id');
+      expect(stored).toBeNull();
+    });
+
     it('should not throw when revoking non-existent tokens', async () => {
       // revokeTokens returns early when tokens don't exist; must not throw
       await expect(provider.revokeTokens('non-existent')).resolves.toBeUndefined();

--- a/packages/shared/src/discordIds.test.ts
+++ b/packages/shared/src/discordIds.test.ts
@@ -5,10 +5,13 @@ import {
   isDiscordSnowflakeId,
 } from './discordIds';
 
+const DUMMY_DISCORD_SNOWFLAKE_ID = '100000000000000001';
+const DUMMY_DISCORD_MAX_LENGTH_SNOWFLAKE_ID = '10000000000000000001';
+
 describe('discord ID helpers', () => {
   it('accepts Discord snowflake-shaped IDs', () => {
-    expect(isDiscordSnowflakeId('123456789012345678')).toBe(true);
-    expect(DISCORD_SNOWFLAKE_ID_PATTERN.test('12345678901234567890')).toBe(true);
+    expect(isDiscordSnowflakeId(DUMMY_DISCORD_SNOWFLAKE_ID)).toBe(true);
+    expect(DISCORD_SNOWFLAKE_ID_PATTERN.test(DUMMY_DISCORD_MAX_LENGTH_SNOWFLAKE_ID)).toBe(true);
   });
 
   it('rejects malformed Discord snowflake IDs', () => {

--- a/packages/shared/src/discordIds.test.ts
+++ b/packages/shared/src/discordIds.test.ts
@@ -17,6 +17,8 @@ describe('discord ID helpers', () => {
   it('rejects malformed Discord snowflake IDs', () => {
     expect(isDiscordSnowflakeId('../member')).toBe(false);
     expect(isDiscordSnowflakeId('123')).toBe(false);
+    expect(isDiscordSnowflakeId('1000000000000000')).toBe(false);
+    expect(isDiscordSnowflakeId('100000000000000000001')).toBe(false);
     expect(() => assertDiscordSnowflakeId('../member', 'source guild')).toThrow(
       'Invalid Discord source guild ID'
     );

--- a/packages/shared/src/discordIds.test.ts
+++ b/packages/shared/src/discordIds.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  assertDiscordSnowflakeId,
+  DISCORD_SNOWFLAKE_ID_PATTERN,
+  isDiscordSnowflakeId,
+} from './discordIds';
+
+describe('discord ID helpers', () => {
+  it('accepts Discord snowflake-shaped IDs', () => {
+    expect(isDiscordSnowflakeId('123456789012345678')).toBe(true);
+    expect(DISCORD_SNOWFLAKE_ID_PATTERN.test('12345678901234567890')).toBe(true);
+  });
+
+  it('rejects malformed Discord snowflake IDs', () => {
+    expect(isDiscordSnowflakeId('../member')).toBe(false);
+    expect(isDiscordSnowflakeId('123')).toBe(false);
+    expect(() => assertDiscordSnowflakeId('../member', 'source guild')).toThrow(
+      'Invalid Discord source guild ID'
+    );
+  });
+});

--- a/packages/shared/src/discordIds.ts
+++ b/packages/shared/src/discordIds.ts
@@ -1,0 +1,15 @@
+// Discord Snowflake docs:
+// https://discord.com/developers/docs/reference#snowflakes
+export const DISCORD_SNOWFLAKE_ID_PATTERN = /^\d{17,20}$/;
+
+export function isDiscordSnowflakeId(value: string): boolean {
+  return DISCORD_SNOWFLAKE_ID_PATTERN.test(value);
+}
+
+export function assertDiscordSnowflakeId(value: string, label = ''): asserts value is string {
+  if (isDiscordSnowflakeId(value)) {
+    return;
+  }
+  const labeledId = label ? `${label} ID` : 'ID';
+  throw new Error(`Invalid Discord ${labeledId}`);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -48,6 +48,7 @@ export * from './convexSiteUrl';
 // Crypto module exports
 export * from './crypto';
 export { sha256Hex } from './crypto';
+export * from './discordIds';
 // Entitlement module exports
 export * from './entitlement';
 export * from './featureFlags';


### PR DESCRIPTION
﻿## Summary

- Bound Discord account-link identity, guild-member, and OAuth token exchange requests with explicit abort timeouts.
- Capped the Discord 429 retry sleep so a retry cannot stall account linking for an unbounded interval.
- Made the web runtime ops check spawn the current Bun executable directly instead of relying on PATH lookup from a Bun child process.

## Why

Discord-backed account linking could wait indefinitely on slow or stalled upstream requests. The related runtime check also exposed a Windows-local spawn portability issue while validating the branch: Bun could run this repo command, but a nested Bun child process could not resolve `bun` by name.

## Validation

- `bun test apps/api/src/providers/discord/buyerLink.test.ts apps/api/src/verification/sessionManager.accountLink.test.ts`
- `bun test ops/web-dev-runtime.test.ts`
- `bun audit`
- `bun run lint`
- `bun run typecheck`
- `bun run test:external-integrations`
- `bun run test:ci`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Discord API request timeouts and OAuth token-exchange timeouts using `AbortSignal`.
* **Bug Fixes**
  * Improved Discord rate-limit handling by honoring `Retry-After`/`retry_after`, enforcing a retry budget, and safely retrying after 429s.
  * Hardened Discord snowflake validation for guild/role inputs with clearer “Invalid … ID” errors.
  * URL-encoded Discord guild IDs; improved token revocation by always cleaning up locally even if the remote call fails.
* **Tests**
  * Expanded coverage for abort-signal usage, retry behavior (including over-budget cases), and invalid-ID rejection.
* **Chores**
  * Improved dev-runtime test process reliability for worker startup/shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->