### PR TITLE
test(convex): run real backend regression suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Boot and deploy self-hosted Convex
         run: bun run test:convex:real:up
 
-      - name: Run self-hosted Convex smoke
+      - name: Run self-hosted Convex real suite
         run: bun run test:convex:real
 
       - name: Dump Convex logs

--- a/convex/gumroadExternalBackfill.realtest.ts
+++ b/convex/gumroadExternalBackfill.realtest.ts
@@ -10,6 +10,8 @@ describe('gumroad external storefront backfill', () => {
 
   beforeEach(() => {
     process.env.CONVEX_API_SECRET = API_SECRET;
+    // Kept on convex-test because these cases drain scheduled backfill with fake timers.
+    // The real-backend suite covers backfill projection via deployed internal functions.
     vi.useFakeTimers();
   });
 

--- a/convex/migrations.realtest.ts
+++ b/convex/migrations.realtest.ts
@@ -588,6 +588,8 @@ describe('backstage alias metadata remediation', () => {
   });
 
   it('repairs a selected published release by backfilling the alias metadata contract', async () => {
+    // Kept on convex-test because this assertion drains scheduled repair work with fake timers.
+    // Real-backend scheduler coverage should use real waits in dedicated cases.
     vi.useFakeTimers();
     const t = makeTestConvex();
     const { catalogProductId, deliveryPackageReleaseId } =

--- a/convex/productAddScheduler.realtest.ts
+++ b/convex/productAddScheduler.realtest.ts
@@ -113,6 +113,8 @@ describe('grantEntitlement - no time-based past purchase block', () => {
 describe('addProductFromPayhip - schedules projection of existing purchase facts', () => {
   beforeEach(() => {
     process.env.CONVEX_API_SECRET = 'test-secret';
+    // Kept on convex-test because this file asserts scheduler behavior with fake timers.
+    // The real-backend suite covers the same Payhip projection path with real scheduler waits.
     vi.useFakeTimers();
   });
 

--- a/convex/testHelpersReal.ts
+++ b/convex/testHelpersReal.ts
@@ -80,7 +80,7 @@ export const clearAll = internalMutation({
     for (const table of appTableNames) {
       const docs = await ctx.db.query(table as never).collect();
       for (const doc of docs) {
-        await ctx.db.delete(doc._id);
+        await ctx.db.delete((doc as { _id: string })._id as never);
       }
     }
   },

--- a/convex/testHelpersReal.ts
+++ b/convex/testHelpersReal.ts
@@ -1,0 +1,87 @@
+import { v } from 'convex/values';
+import { internalMutation, internalQuery } from './_generated/server';
+import schema from './schema';
+
+function assertRealBackendTest(): void {
+  if (process.env.IS_TEST !== 'true') {
+    throw new Error('testHelpersReal functions require IS_TEST=true');
+  }
+}
+
+const appTableNames = Object.keys(schema.tables);
+
+export const insert = internalMutation({
+  args: {
+    table: v.string(),
+    doc: v.any(),
+  },
+  handler: async (ctx, args): Promise<string> => {
+    assertRealBackendTest();
+    return await ctx.db.insert(args.table as never, args.doc as never);
+  },
+});
+
+export const patch = internalMutation({
+  args: {
+    id: v.string(),
+    patch: v.any(),
+  },
+  handler: async (ctx, args): Promise<void> => {
+    assertRealBackendTest();
+    await ctx.db.patch(args.id as never, args.patch as never);
+  },
+});
+
+export const deleteById = internalMutation({
+  args: {
+    id: v.string(),
+  },
+  handler: async (ctx, args): Promise<void> => {
+    assertRealBackendTest();
+    await ctx.db.delete(args.id as never);
+  },
+});
+
+export const get = internalQuery({
+  args: {
+    id: v.string(),
+  },
+  handler: async (ctx, args): Promise<unknown> => {
+    assertRealBackendTest();
+    return await ctx.db.get(args.id as never);
+  },
+});
+
+export const collect = internalQuery({
+  args: {
+    table: v.string(),
+  },
+  handler: async (ctx, args): Promise<unknown[]> => {
+    assertRealBackendTest();
+    return await ctx.db.query(args.table as never).collect();
+  },
+});
+
+export const clearAll = internalMutation({
+  args: {},
+  handler: async (ctx): Promise<void> => {
+    assertRealBackendTest();
+
+    const scheduled = await ctx.db.system.query('_scheduled_functions').collect();
+    for (const job of scheduled) {
+      await ctx.scheduler.cancel(job._id);
+    }
+
+    const storedFiles = await ctx.db.system.query('_storage').collect();
+    for (const file of storedFiles) {
+      await ctx.storage.delete(file._id);
+    }
+
+    for (const table of appTableNames) {
+      const docs = await ctx.db.query(table as never).collect();
+      for (const doc of docs) {
+        await ctx.db.delete(doc._id);
+      }
+    }
+  },
+});

--- a/convex/testHelpersReal.ts
+++ b/convex/testHelpersReal.ts
@@ -5,8 +5,12 @@ import schema from './schema';
 const CLEAR_ALL_BATCH_LIMIT = 50;
 
 function assertRealBackendTest(): void {
-  if (process.env.IS_TEST !== 'true' && process.env.IS_TEST !== '1') {
-    throw new Error('testHelpersReal functions require IS_TEST=true');
+  const isTest = process.env.IS_TEST === 'true' || process.env.IS_TEST === '1';
+  const isRealBackendHarness = process.env.YUCP_REAL_BACKEND_TEST_HELPERS === 'true';
+  if (!isTest || !isRealBackendHarness) {
+    throw new Error(
+      'testHelpersReal functions require IS_TEST=true and YUCP_REAL_BACKEND_TEST_HELPERS=true'
+    );
   }
 }
 

--- a/convex/testHelpersReal.ts
+++ b/convex/testHelpersReal.ts
@@ -2,8 +2,10 @@ import { v } from 'convex/values';
 import { internalMutation, internalQuery } from './_generated/server';
 import schema from './schema';
 
+const CLEAR_ALL_BATCH_LIMIT = 50;
+
 function assertRealBackendTest(): void {
-  if (process.env.IS_TEST !== 'true') {
+  if (process.env.IS_TEST !== 'true' && process.env.IS_TEST !== '1') {
     throw new Error('testHelpersReal functions require IS_TEST=true');
   }
 }
@@ -63,25 +65,44 @@ export const collect = internalQuery({
 });
 
 export const clearAll = internalMutation({
-  args: {},
-  handler: async (ctx): Promise<void> => {
+  args: {
+    includeScheduled: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args): Promise<{ deleted: number }> => {
     assertRealBackendTest();
 
-    const scheduled = await ctx.db.system.query('_scheduled_functions').collect();
-    for (const job of scheduled) {
-      await ctx.scheduler.cancel(job._id);
-    }
+    let deleted = 0;
+    const remaining = () => CLEAR_ALL_BATCH_LIMIT - deleted;
 
-    const storedFiles = await ctx.db.system.query('_storage').collect();
-    for (const file of storedFiles) {
-      await ctx.storage.delete(file._id);
-    }
-
-    for (const table of appTableNames) {
-      const docs = await ctx.db.query(table as never).collect();
-      for (const doc of docs) {
-        await ctx.db.delete((doc as { _id: string })._id as never);
+    if (args.includeScheduled !== false) {
+      // ponytail: Scheduled cleanup is capped at CLEAR_ALL_BATCH_LIMIT per cleanup run
+      // because Convex/system component jobs can remain present after cancellation. If
+      // test-created scheduled jobs approach that ceiling, split this into an ID-cursor
+      // cleanup phase that verifies progress across calls.
+      const scheduled = await ctx.db.system.query('_scheduled_functions').take(remaining());
+      for (const job of scheduled) {
+        await ctx.scheduler.cancel(job._id);
+        deleted++;
       }
     }
+    if (remaining() <= 0) return { deleted };
+
+    const storedFiles = await ctx.db.system.query('_storage').take(remaining());
+    for (const file of storedFiles) {
+      await ctx.storage.delete(file._id);
+      deleted++;
+    }
+    if (remaining() <= 0) return { deleted };
+
+    for (const table of appTableNames) {
+      const docs = await ctx.db.query(table as never).take(remaining());
+      for (const doc of docs) {
+        await ctx.db.delete((doc as { _id: string })._id as never);
+        deleted++;
+      }
+      if (remaining() <= 0) return { deleted };
+    }
+
+    return { deleted };
   },
 });

--- a/convex/webhooks.realtest.ts
+++ b/convex/webhooks.realtest.ts
@@ -141,6 +141,8 @@ describe('insertWebhookEvent', () => {
 describe('processWebhookEvent pipeline', () => {
   beforeEach(() => {
     process.env.CONVEX_API_SECRET = API_SECRET;
+    // Kept on convex-test because these cases use fake timers to drain scheduled work.
+    // The real-backend suite covers webhook processing with deployed internal functions.
     vi.useFakeTimers();
   });
 

--- a/ops/convex-real/harness.ts
+++ b/ops/convex-real/harness.ts
@@ -1,0 +1,259 @@
+import {
+  createApiActorBinding,
+  createServiceApiActor,
+  isApiActorProtectedFunction,
+  type ApiActorBinding,
+} from '@yucp/shared/apiActor';
+import { ConvexHttpClient } from 'convex/browser';
+import {
+  type FunctionArgs,
+  type FunctionReference,
+  type FunctionReturnType,
+  getFunctionName,
+  makeFunctionReference,
+} from 'convex/server';
+import type { Doc, Id, TableNames } from '../../convex/_generated/dataModel';
+import { API_SECRET, BACKEND_URL, INTERNAL_SERVICE_AUTH_SECRET, PROJECT_NAME } from './config';
+
+type AnyFunctionReference = FunctionReference<
+  'query' | 'mutation' | 'action',
+  'public' | 'internal',
+  Record<string, unknown>,
+  unknown,
+  string | undefined
+>;
+type OptionalActorArgs<Args> = Args extends { actor: ApiActorBinding }
+  ? Omit<Args, 'actor'> & { actor?: ApiActorBinding }
+  : Args;
+type OptionalActorRestArgs<FuncRef extends AnyFunctionReference> =
+  keyof FunctionArgs<FuncRef> extends never
+    ? [args?: OptionalActorArgs<FunctionArgs<FuncRef>>]
+    : [args: OptionalActorArgs<FunctionArgs<FuncRef>>];
+
+const COMPOSE_FILE = `${import.meta.dir}/docker-compose.yml`;
+const helper = {
+  insert: makeFunctionReference<
+    'mutation',
+    { table: string; doc: Record<string, unknown> },
+    string
+  >('testHelpersReal:insert'),
+  patch: makeFunctionReference<'mutation', { id: string; patch: Record<string, unknown> }, void>(
+    'testHelpersReal:patch'
+  ),
+  deleteById: makeFunctionReference<'mutation', { id: string }, void>('testHelpersReal:deleteById'),
+  get: makeFunctionReference<'query', { id: string }, unknown>('testHelpersReal:get'),
+  collect: makeFunctionReference<'query', { table: string }, unknown[]>('testHelpersReal:collect'),
+  clearAll: makeFunctionReference<'mutation', {}, void>('testHelpersReal:clearAll'),
+};
+
+let adminKeyPromise: Promise<string> | null = null;
+let testActorPromise: Promise<ApiActorBinding> | null = null;
+
+async function run(args: string[], timeoutMs = 60_000): Promise<string> {
+  let timedOut = false;
+  const proc = Bun.spawn(args, {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const timeoutId = setTimeout(() => {
+    timedOut = true;
+    proc.kill('SIGTERM');
+  }, timeoutMs);
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  clearTimeout(timeoutId);
+
+  if (timedOut) {
+    throw new Error(`${args.join(' ')} timed out after ${timeoutMs}ms`);
+  }
+  if (exitCode !== 0) {
+    throw new Error(`${args.join(' ')} failed with exit code ${exitCode}: ${stderr || stdout}`);
+  }
+  return stdout;
+}
+
+function describeFunctionReference(functionReference: unknown): string {
+  try {
+    return getFunctionName(functionReference as never);
+  } catch {
+    return typeof functionReference === 'string' ? functionReference : 'unknown';
+  }
+}
+
+function mergeActorArg(args: unknown, actor: ApiActorBinding): unknown {
+  if (!args || typeof args !== 'object' || Array.isArray(args)) {
+    return { actor };
+  }
+  if ('actor' in (args as Record<string, unknown>)) {
+    return args;
+  }
+  return {
+    ...(args as Record<string, unknown>),
+    actor,
+  };
+}
+
+function shouldAttachActor(functionReference: unknown, args: unknown): boolean {
+  return (
+    isApiActorProtectedFunction(describeFunctionReference(functionReference)) &&
+    !!args &&
+    typeof args === 'object' &&
+    !Array.isArray(args) &&
+    'apiSecret' in (args as Record<string, unknown>) &&
+    !('actor' in (args as Record<string, unknown>))
+  );
+}
+
+function stripUndefined(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stripUndefined);
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, entryValue]) => entryValue !== undefined)
+    .map(([key, entryValue]) => [key, stripUndefined(entryValue)]);
+  return Object.fromEntries(entries);
+}
+
+export async function getRealBackendAdminKey(): Promise<string> {
+  adminKeyPromise ??= (async () => {
+    const output = await run([
+      'docker',
+      'compose',
+      '-p',
+      PROJECT_NAME,
+      '-f',
+      COMPOSE_FILE,
+      'exec',
+      '-T',
+      'backend',
+      './generate_admin_key.sh',
+    ]);
+    const adminKey = output
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => line.startsWith('convex-self-hosted|'));
+    if (!adminKey) {
+      throw new Error('Convex self-hosted admin key was not generated');
+    }
+    return adminKey;
+  })();
+  return await adminKeyPromise;
+}
+
+async function getTestActorBinding(): Promise<ApiActorBinding> {
+  testActorPromise ??= createApiActorBinding(
+    createServiceApiActor({
+      service: 'convex-real-test',
+      scopes: [
+        'creator:delegate',
+        'downloads:service',
+        'entitlements:service',
+        'manual-licenses:service',
+        'subjects:service',
+        'verification-intents:service',
+        'verification-sessions:service',
+      ],
+      now: Date.now(),
+    }),
+    INTERNAL_SERVICE_AUTH_SECRET
+  );
+  return await testActorPromise;
+}
+
+export type RealConvex = Awaited<ReturnType<typeof makeRealConvex>>;
+
+export async function makeRealConvex(options: { injectActor?: boolean } = {}) {
+  const client = new ConvexHttpClient(BACKEND_URL, {
+    skipConvexDeploymentUrlCheck: true,
+  });
+  client.setAdminAuth(await getRealBackendAdminKey());
+
+  async function withActor<FuncRef extends AnyFunctionReference>(
+    functionReference: FuncRef,
+    args: OptionalActorArgs<FunctionArgs<FuncRef>> | undefined
+  ): Promise<FunctionArgs<FuncRef>> {
+    if (options.injectActor === false || !shouldAttachActor(functionReference, args)) {
+      return args as FunctionArgs<FuncRef>;
+    }
+    return mergeActorArg(args, await getTestActorBinding()) as FunctionArgs<FuncRef>;
+  }
+
+  return {
+    apiSecret: API_SECRET,
+    query: async <FuncRef extends FunctionReference<'query'>>(
+      functionReference: FuncRef,
+      ...args: OptionalActorRestArgs<FuncRef>
+    ): Promise<FunctionReturnType<FuncRef>> => {
+      return await client.query(
+        functionReference,
+        await withActor(functionReference as never, args[0] as never)
+      );
+    },
+    mutation: async <FuncRef extends FunctionReference<'mutation'>>(
+      functionReference: FuncRef,
+      ...args: OptionalActorRestArgs<FuncRef>
+    ): Promise<FunctionReturnType<FuncRef>> => {
+      return await client.mutation(
+        functionReference,
+        await withActor(functionReference as never, args[0] as never)
+      );
+    },
+    action: async <FuncRef extends FunctionReference<'action'>>(
+      functionReference: FuncRef,
+      ...args: OptionalActorRestArgs<FuncRef>
+    ): Promise<FunctionReturnType<FuncRef>> => {
+      return await client.action(
+        functionReference,
+        await withActor(functionReference as never, args[0] as never)
+      );
+    },
+    insert: async <Table extends TableNames>(
+      table: Table,
+      doc: Record<string, unknown>
+    ): Promise<Id<Table>> => {
+      return (await client.mutation(helper.insert, {
+        table,
+        doc: stripUndefined(doc) as Record<string, unknown>,
+      })) as Id<Table>;
+    },
+    patch: async (id: string, patch: Record<string, unknown>): Promise<void> => {
+      await client.mutation(helper.patch, {
+        id,
+        patch: stripUndefined(patch) as Record<string, unknown>,
+      });
+    },
+    delete: async (id: string): Promise<void> => {
+      await client.mutation(helper.deleteById, { id });
+    },
+    get: async <Table extends TableNames>(id: Id<Table>): Promise<Doc<Table> | null> => {
+      return (await client.query(helper.get, { id })) as Doc<Table> | null;
+    },
+    collect: async <Table extends TableNames>(table: Table): Promise<Array<Doc<Table>>> => {
+      return (await client.query(helper.collect, { table })) as Array<Doc<Table>>;
+    },
+    clearAll: async (): Promise<void> => {
+      await client.mutation(helper.clearAll, {});
+    },
+  };
+}
+
+export async function waitFor(
+  predicate: () => Promise<boolean>,
+  options: { timeoutMs?: number; intervalMs?: number; description: string }
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  const intervalMs = options.intervalMs ?? 500;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await Bun.sleep(intervalMs);
+  }
+  throw new Error(`Timed out waiting for ${options.description}`);
+}

--- a/ops/convex-real/harness.ts
+++ b/ops/convex-real/harness.ts
@@ -180,6 +180,7 @@ export async function removeRealBackendEnv(name: string): Promise<void> {
 
 export async function restoreRealBackendTestSignal(): Promise<void> {
   await runConvexEnv(['set', 'IS_TEST', 'true']);
+  await runConvexEnv(['set', 'YUCP_REAL_BACKEND_TEST_HELPERS', 'true']);
 }
 
 export function resetTestActorBindingCacheForTest(): void {

--- a/ops/convex-real/harness.ts
+++ b/ops/convex-real/harness.ts
@@ -1,8 +1,10 @@
+import { resolve } from 'node:path';
 import {
+  API_ACTOR_TTL_MS,
+  type ApiActorBinding,
   createApiActorBinding,
   createServiceApiActor,
   isApiActorProtectedFunction,
-  type ApiActorBinding,
 } from '@yucp/shared/apiActor';
 import { ConvexHttpClient } from 'convex/browser';
 import {
@@ -31,6 +33,8 @@ type OptionalActorRestArgs<FuncRef extends AnyFunctionReference> =
     : [args: OptionalActorArgs<FunctionArgs<FuncRef>>];
 
 const COMPOSE_FILE = `${import.meta.dir}/docker-compose.yml`;
+const ROOT_DIR = resolve(import.meta.dir, '../..');
+const TEST_ACTOR_REFRESH_MARGIN_MS = 30_000;
 const helper = {
   insert: makeFunctionReference<
     'mutation',
@@ -43,15 +47,25 @@ const helper = {
   deleteById: makeFunctionReference<'mutation', { id: string }, void>('testHelpersReal:deleteById'),
   get: makeFunctionReference<'query', { id: string }, unknown>('testHelpersReal:get'),
   collect: makeFunctionReference<'query', { table: string }, unknown[]>('testHelpersReal:collect'),
-  clearAll: makeFunctionReference<'mutation', {}, void>('testHelpersReal:clearAll'),
+  clearAll: makeFunctionReference<'mutation', { includeScheduled?: boolean }, { deleted: number }>(
+    'testHelpersReal:clearAll'
+  ),
 };
 
 let adminKeyPromise: Promise<string> | null = null;
-let testActorPromise: Promise<ApiActorBinding> | null = null;
+let testActorCache: { binding: ApiActorBinding; expiresAt: number } | null = null;
 
-async function run(args: string[], timeoutMs = 60_000): Promise<string> {
+type RunOptions = {
+  env?: Record<string, string>;
+  timeoutMs?: number;
+};
+
+async function run(args: string[], options: RunOptions | number = {}): Promise<string> {
+  const timeoutMs = typeof options === 'number' ? options : (options.timeoutMs ?? 60_000);
   let timedOut = false;
   const proc = Bun.spawn(args, {
+    cwd: ROOT_DIR,
+    env: typeof options === 'number' ? process.env : { ...process.env, ...options.env },
     stdout: 'pipe',
     stderr: 'pipe',
   });
@@ -123,18 +137,21 @@ function stripUndefined(value: unknown): unknown {
 
 export async function getRealBackendAdminKey(): Promise<string> {
   adminKeyPromise ??= (async () => {
-    const output = await run([
-      'docker',
-      'compose',
-      '-p',
-      PROJECT_NAME,
-      '-f',
-      COMPOSE_FILE,
-      'exec',
-      '-T',
-      'backend',
-      './generate_admin_key.sh',
-    ]);
+    const output = await run(
+      [
+        'docker',
+        'compose',
+        '-p',
+        PROJECT_NAME,
+        '-f',
+        COMPOSE_FILE,
+        'exec',
+        '-T',
+        'backend',
+        './generate_admin_key.sh',
+      ],
+      60_000
+    );
     const adminKey = output
       .split(/\r?\n/)
       .map((line) => line.trim())
@@ -147,24 +164,54 @@ export async function getRealBackendAdminKey(): Promise<string> {
   return await adminKeyPromise;
 }
 
-async function getTestActorBinding(): Promise<ApiActorBinding> {
-  testActorPromise ??= createApiActorBinding(
-    createServiceApiActor({
-      service: 'convex-real-test',
-      scopes: [
-        'creator:delegate',
-        'downloads:service',
-        'entitlements:service',
-        'manual-licenses:service',
-        'subjects:service',
-        'verification-intents:service',
-        'verification-sessions:service',
-      ],
-      now: Date.now(),
-    }),
-    INTERNAL_SERVICE_AUTH_SECRET
-  );
-  return await testActorPromise;
+async function runConvexEnv(args: string[]): Promise<void> {
+  await run(['bun', 'x', 'convex', 'env', ...args], {
+    env: {
+      CONVEX_SELF_HOSTED_URL: BACKEND_URL,
+      CONVEX_SELF_HOSTED_ADMIN_KEY: await getRealBackendAdminKey(),
+    },
+    timeoutMs: 60_000,
+  });
+}
+
+export async function removeRealBackendEnv(name: string): Promise<void> {
+  await runConvexEnv(['remove', name]);
+}
+
+export async function restoreRealBackendTestSignal(): Promise<void> {
+  await runConvexEnv(['set', 'IS_TEST', 'true']);
+}
+
+export function resetTestActorBindingCacheForTest(): void {
+  testActorCache = null;
+}
+
+export async function getTestActorBindingForTest(now = Date.now()): Promise<ApiActorBinding> {
+  return await getTestActorBinding(now);
+}
+
+async function getTestActorBinding(now = Date.now()): Promise<ApiActorBinding> {
+  if (testActorCache && testActorCache.expiresAt - now > TEST_ACTOR_REFRESH_MARGIN_MS) {
+    return testActorCache.binding;
+  }
+
+  const actor = createServiceApiActor({
+    service: 'convex-real-test',
+    scopes: [
+      'creator:delegate',
+      'downloads:service',
+      'entitlements:service',
+      'manual-licenses:service',
+      'subjects:service',
+      'verification-intents:service',
+      'verification-sessions:service',
+    ],
+    now,
+    ttlMs: API_ACTOR_TTL_MS,
+  });
+  const binding = await createApiActorBinding(actor, INTERNAL_SERVICE_AUTH_SECRET);
+  testActorCache = { binding, expiresAt: actor.expiresAt };
+  return binding;
 }
 
 export type RealConvex = Awaited<ReturnType<typeof makeRealConvex>>;
@@ -239,7 +286,11 @@ export async function makeRealConvex(options: { injectActor?: boolean } = {}) {
       return (await client.query(helper.collect, { table })) as Array<Doc<Table>>;
     },
     clearAll: async (): Promise<void> => {
-      await client.mutation(helper.clearAll, {});
+      await client.mutation(helper.clearAll, { includeScheduled: true });
+      while (true) {
+        const result = await client.mutation(helper.clearAll, { includeScheduled: false });
+        if (result.deleted === 0) return;
+      }
     },
   };
 }

--- a/ops/convex-real/manage.ts
+++ b/ops/convex-real/manage.ts
@@ -75,6 +75,22 @@ async function waitForBackend(): Promise<void> {
   throw new Error(`Convex backend did not become healthy: ${String(lastError)}`);
 }
 
+async function pullImagesWithRetry(): Promise<void> {
+  const attempts = 3;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      await run(['docker', ...composeArgs, 'pull'], {
+        timeoutMs: 300_000,
+      });
+      return;
+    } catch (error) {
+      if (attempt === attempts) throw error;
+      console.warn(`Docker image pull failed on attempt ${attempt}; retrying.`);
+      await Bun.sleep(5_000 * attempt);
+    }
+  }
+}
+
 function findCompleteBetterAuthPackage(): string | null {
   const bunModulesDir = join(ROOT_DIR, 'node_modules', '.bun');
   if (!existsSync(bunModulesDir)) return null;
@@ -139,6 +155,7 @@ function writeTestEnvFile(): string {
       'ACCOUNT_RECOVERY_CONTEXT_SECRET=test-account-recovery-secret-for-convex-real-backend',
       `INTERNAL_SERVICE_AUTH_SECRET=${INTERNAL_SERVICE_AUTH_SECRET}`,
       `CONVEX_API_SECRET=${API_SECRET}`,
+      'IS_TEST=true',
       'VRCHAT_PROVIDER_SESSION_SECRET=test-vrchat-provider-session-secret',
       `BETTER_AUTH_URL=${SITE_URL}/api/auth`,
       'API_BASE_URL=http://127.0.0.1:3001',
@@ -182,6 +199,7 @@ async function deploy(adminKey: string): Promise<void> {
 }
 
 async function up(): Promise<void> {
+  await pullImagesWithRetry();
   await run(['docker', ...composeArgs, 'up', '-d']);
   await waitForBackend();
   await deploy(await getAdminKey());

--- a/ops/convex-real/manage.ts
+++ b/ops/convex-real/manage.ts
@@ -97,13 +97,7 @@ function findCompleteBetterAuthPackage(): string | null {
 
   for (const entry of readdirSync(bunModulesDir)) {
     if (!entry.startsWith('@convex-dev+better-auth@')) continue;
-    const candidate = join(
-      bunModulesDir,
-      entry,
-      'node_modules',
-      '@convex-dev',
-      'better-auth'
-    );
+    const candidate = join(bunModulesDir, entry, 'node_modules', '@convex-dev', 'better-auth');
     if (existsSync(join(candidate, 'package.json'))) {
       return candidate;
     }
@@ -156,6 +150,7 @@ function writeTestEnvFile(): string {
       `INTERNAL_SERVICE_AUTH_SECRET=${INTERNAL_SERVICE_AUTH_SECRET}`,
       `CONVEX_API_SECRET=${API_SECRET}`,
       'IS_TEST=true',
+      'YUCP_REAL_BACKEND_TEST_HELPERS=true',
       'VRCHAT_PROVIDER_SESSION_SECRET=test-vrchat-provider-session-secret',
       `BETTER_AUTH_URL=${SITE_URL}/api/auth`,
       'API_BASE_URL=http://127.0.0.1:3001',

--- a/ops/convex-real/real-backend-suite.test.ts
+++ b/ops/convex-real/real-backend-suite.test.ts
@@ -127,7 +127,20 @@ describe('real Convex backend contracts', () => {
   test('test-only deployed helpers reject when the real-backend test signal is absent', async () => {
     await removeRealBackendEnv('IS_TEST');
     try {
-      await expect(t.clearAll()).rejects.toThrow('testHelpersReal functions require IS_TEST=true');
+      await expect(t.clearAll()).rejects.toThrow(
+        'testHelpersReal functions require IS_TEST=true and YUCP_REAL_BACKEND_TEST_HELPERS=true'
+      );
+    } finally {
+      await restoreRealBackendTestSignal();
+    }
+  });
+
+  test('test-only deployed helpers reject when the real-backend helper marker is absent', async () => {
+    await removeRealBackendEnv('YUCP_REAL_BACKEND_TEST_HELPERS');
+    try {
+      await expect(t.clearAll()).rejects.toThrow(
+        'testHelpersReal functions require IS_TEST=true and YUCP_REAL_BACKEND_TEST_HELPERS=true'
+      );
     } finally {
       await restoreRealBackendTestSignal();
     }

--- a/ops/convex-real/real-backend-suite.test.ts
+++ b/ops/convex-real/real-backend-suite.test.ts
@@ -1,0 +1,450 @@
+import { sha256Hex } from '@yucp/shared/crypto';
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { api, internal } from '../../convex/_generated/api';
+import type { Id } from '../../convex/_generated/dataModel';
+import { makeRealConvex, type RealConvex, waitFor } from './harness';
+
+let t: RealConvex;
+
+function unique(label: string): string {
+  return `${label}-${Date.now()}-${crypto.randomUUID()}`;
+}
+
+async function seedSubject(
+  input: {
+    authUserId?: string;
+    primaryDiscordUserId?: string;
+    status?: 'active' | 'suspended' | 'quarantined' | 'deleted';
+  } = {}
+): Promise<Id<'subjects'>> {
+  const now = Date.now();
+  return await t.insert('subjects', {
+    primaryDiscordUserId: input.primaryDiscordUserId ?? unique('discord'),
+    status: input.status ?? 'active',
+    authUserId: input.authUserId,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+async function seedCreatorProfile(input: {
+  authUserId: string;
+  ownerDiscordUserId?: string;
+}): Promise<Id<'creator_profiles'>> {
+  const now = Date.now();
+  return await t.insert('creator_profiles', {
+    authUserId: input.authUserId,
+    name: 'Real Backend Test Creator',
+    ownerDiscordUserId: input.ownerDiscordUserId ?? unique('creator-discord'),
+    status: 'active',
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+async function seedExternalAccount(input: {
+  provider?: 'discord' | 'gumroad' | 'jinxxy' | 'lemonsqueezy' | 'payhip' | 'vrchat';
+  providerUserId: string;
+  emailHash?: string;
+}): Promise<Id<'external_accounts'>> {
+  const now = Date.now();
+  return await t.insert('external_accounts', {
+    provider: input.provider ?? 'discord',
+    providerUserId: input.providerUserId,
+    emailHash: input.emailHash,
+    status: 'active',
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+async function seedCatalogProduct(input: {
+  authUserId: string;
+  productId: string;
+  provider: 'gumroad' | 'payhip';
+  providerProductRef: string;
+}): Promise<Id<'product_catalog'>> {
+  const now = Date.now();
+  return await t.insert('product_catalog', {
+    authUserId: input.authUserId,
+    productId: input.productId,
+    provider: input.provider,
+    providerProductRef: input.providerProductRef,
+    displayName: 'Real Backend Product',
+    status: 'active',
+    supportsAutoDiscovery: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+async function seedPurchaseFact(input: {
+  authUserId: string;
+  provider: 'gumroad' | 'payhip';
+  providerProductId: string;
+  externalOrderId: string;
+  buyerEmailHash?: string;
+  subjectId?: Id<'subjects'>;
+}): Promise<Id<'purchase_facts'>> {
+  const now = Date.now();
+  return await t.insert('purchase_facts', {
+    authUserId: input.authUserId,
+    provider: input.provider,
+    externalOrderId: input.externalOrderId,
+    buyerEmailHash: input.buyerEmailHash,
+    providerProductId: input.providerProductId,
+    paymentStatus: 'paid',
+    lifecycleStatus: 'active',
+    purchasedAt: now - 60_000,
+    subjectId: input.subjectId,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+beforeAll(async () => {
+  t = await makeRealConvex();
+});
+
+beforeEach(async () => {
+  await t.clearAll();
+});
+
+afterEach(async () => {
+  await t.clearAll();
+});
+
+describe('real Convex backend contracts', () => {
+  test('public manual-license bounds run through the deployed backend', async () => {
+    const authUserId = unique('auth-manual-bounds');
+
+    await expect(
+      t.mutation(api.manualLicenses.bulkCreate, {
+        apiSecret: t.apiSecret,
+        authUserId,
+        licenses: Array.from({ length: 101 }, (_, index) => ({
+          licenseKeyHash: `${index}`.padStart(64, '0'),
+          productId: `product-${index}`,
+        })),
+      })
+    ).rejects.toThrow('Maximum of 100 licenses per bulk request');
+  });
+
+  test('raw seed helpers feed public subject and entitlement reads', async () => {
+    const creatorAuthUserId = unique('creator-subject-contract');
+    const buyerAuthUserId = unique('buyer-subject-contract');
+    const discordUserId = unique('discord-contract');
+    const subjectId = await seedSubject({
+      authUserId: buyerAuthUserId,
+      primaryDiscordUserId: discordUserId,
+    });
+    const externalAccountId = await seedExternalAccount({
+      provider: 'discord',
+      providerUserId: discordUserId,
+    });
+
+    await t.mutation(api.bindings.activateBinding, {
+      apiSecret: t.apiSecret,
+      authUserId: creatorAuthUserId,
+      subjectId,
+      externalAccountId,
+      bindingType: 'verification',
+    });
+
+    const entitlementId = await t.insert('entitlements', {
+      authUserId: creatorAuthUserId,
+      subjectId,
+      productId: 'product-real-entitlement-contract',
+      sourceProvider: 'gumroad',
+      sourceReference: 'source-real-entitlement-contract',
+      status: 'active',
+      grantedAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    const resolved = await t.query(api.subjects.resolveSubjectForPublicApi, {
+      apiSecret: t.apiSecret,
+      authUserId: creatorAuthUserId,
+      selector: { subjectId },
+    });
+    expect(resolved).toMatchObject({
+      found: true,
+      subject: {
+        _id: subjectId,
+        authUserId: buyerAuthUserId,
+        primaryDiscordUserId: discordUserId,
+        status: 'active',
+      },
+    });
+
+    const entitlements = await t.query(api.entitlements.getEntitlementsBySubject, {
+      apiSecret: t.apiSecret,
+      authUserId: creatorAuthUserId,
+      subjectId,
+    });
+    expect(entitlements).toHaveLength(1);
+    expect(entitlements[0]).toMatchObject({
+      _id: entitlementId,
+      subjectId,
+      productId: 'product-real-entitlement-contract',
+      sourceProvider: 'gumroad',
+      status: 'active',
+    });
+    expect('sourceReference' in entitlements[0]).toBe(false);
+
+    const withoutActor = await makeRealConvex({ injectActor: false });
+    await expect(
+      withoutActor.query(api.entitlements.getEntitlementsBySubject, {
+        apiSecret: t.apiSecret,
+        authUserId: creatorAuthUserId,
+        subjectId,
+      } as never)
+    ).rejects.toThrow(/actor/);
+  });
+
+  test('internal backfill projection materializes entitlements and buyer links', async () => {
+    const creatorAuthUserId = unique('creator-backfill');
+    const buyerAuthUserId = unique('buyer-backfill');
+    const buyerEmail = `${unique('buyer')}@example.com`;
+    const buyerEmailHash = await sha256Hex(buyerEmail);
+    const buyerSubjectId = await seedSubject({
+      authUserId: buyerAuthUserId,
+      primaryDiscordUserId: unique('discord-backfill'),
+    });
+
+    await seedCreatorProfile({ authUserId: creatorAuthUserId });
+    await seedCatalogProduct({
+      authUserId: creatorAuthUserId,
+      productId: 'gumroad-real-follow-up-product',
+      provider: 'gumroad',
+      providerProductRef: 'gumroad-real-follow-up-ref',
+    });
+
+    const syncResult = await t.mutation(api.identitySync.syncUserFromProvider, {
+      apiSecret: t.apiSecret,
+      authUserId: buyerAuthUserId,
+      provider: 'gumroad',
+      providerUserId: 'gumroad-real-backfill-buyer',
+      username: 'Real Backfill Buyer',
+      email: buyerEmail,
+      discordUserId: unique('discord-backfill-sync'),
+    });
+
+    await t.mutation(api.bindings.activateBinding, {
+      apiSecret: t.apiSecret,
+      authUserId: buyerAuthUserId,
+      subjectId: buyerSubjectId,
+      externalAccountId: syncResult.externalAccountId,
+      bindingType: 'verification',
+    });
+
+    await t.mutation(api.subjects.upsertBuyerProviderLink, {
+      apiSecret: t.apiSecret,
+      subjectId: buyerSubjectId,
+      provider: 'gumroad',
+      externalAccountId: syncResult.externalAccountId,
+      verificationMethod: 'account_link',
+    });
+
+    await seedPurchaseFact({
+      authUserId: creatorAuthUserId,
+      provider: 'gumroad',
+      providerProductId: 'gumroad-real-follow-up-ref',
+      externalOrderId: 'historical-order',
+      buyerEmailHash,
+    });
+
+    const projection = await t.mutation(
+      internal.backgroundSync.projectBackfilledPurchasesForProduct,
+      {
+        authUserId: creatorAuthUserId,
+        productId: 'gumroad-real-follow-up-product',
+        provider: 'gumroad',
+        providerProductRef: 'gumroad-real-follow-up-ref',
+      }
+    );
+
+    expect(projection).toMatchObject({
+      purchaseFactsFound: 1,
+      linkedToSubject: 1,
+      entitlementsGranted: 1,
+      unresolved: 0,
+    });
+
+    const entitlement = await t.query(api.entitlements.getActiveEntitlement, {
+      apiSecret: t.apiSecret,
+      authUserId: creatorAuthUserId,
+      subjectId: buyerSubjectId,
+      productId: 'gumroad-real-follow-up-product',
+    });
+    expect(entitlement).toMatchObject({
+      found: true,
+      entitlement: expect.objectContaining({
+        subjectId: buyerSubjectId,
+        productId: 'gumroad-real-follow-up-product',
+        sourceProvider: 'gumroad',
+      }),
+    });
+  });
+
+  test('webhook ingestion deduplicates concurrently on the real database', async () => {
+    const authUserId = unique('auth-webhook-dedup');
+    const providerEventId = unique('sale-real-dedup');
+    const args = {
+      apiSecret: t.apiSecret,
+      authUserId,
+      provider: 'gumroad' as const,
+      providerEventId,
+      eventType: 'sale',
+      rawPayload: {},
+      signatureValid: true,
+      verificationMethod: 'hmac',
+    };
+
+    const results = await Promise.all([
+      t.mutation(api.webhookIngestion.insertWebhookEvent, args),
+      t.mutation(api.webhookIngestion.insertWebhookEvent, args),
+      t.mutation(api.webhookIngestion.insertWebhookEvent, args),
+    ]);
+
+    expect(results.filter((result) => result.duplicate === false)).toHaveLength(1);
+    expect(results.filter((result) => result.duplicate === true)).toHaveLength(2);
+
+    const events = await t.collect('webhook_events');
+    expect(events).toHaveLength(1);
+  });
+
+  test('internal webhook processing updates persisted event state', async () => {
+    const authUserId = unique('auth-webhook-processing');
+    const insertResult = await t.mutation(api.webhookIngestion.insertWebhookEvent, {
+      apiSecret: t.apiSecret,
+      authUserId,
+      provider: 'gumroad',
+      providerEventId: unique('sale-process'),
+      eventType: 'sale',
+      rawPayload: {
+        sale_id: 'sale-real-processing',
+        product_id: 'prod-real-processing',
+        email: 'buyer-real-processing@example.com',
+      },
+      signatureValid: true,
+      verificationMethod: 'hmac',
+    });
+
+    const processResult = await t.mutation(internal.webhookProcessing.processWebhookEvent, {
+      apiSecret: t.apiSecret,
+      eventId: insertResult.eventId!,
+    });
+
+    expect(processResult).toMatchObject({ success: true });
+    const event = await t.get(insertResult.eventId!);
+    expect(event).toMatchObject({ status: 'processed' });
+
+    const purchaseFacts = await t.collect('purchase_facts');
+    expect(purchaseFacts).toHaveLength(1);
+    expect(purchaseFacts[0]).toMatchObject({
+      authUserId,
+      provider: 'gumroad',
+      externalOrderId: 'sale-real-processing',
+    });
+  });
+
+  test('webhook delivery lifecycle runs through internal admin calls and public reads', async () => {
+    const authUserId = unique('auth-webhook-delivery');
+    const subscriptionId = await t.mutation(api.webhookSubscriptions.create, {
+      apiSecret: t.apiSecret,
+      authUserId,
+      url: 'https://example.com/webhooks/yucp',
+      events: ['ping'],
+      signingSecretEnc: 'encrypted-secret',
+      signingSecretPrefix: 'whsec_real',
+    });
+
+    const eventId = await t.mutation(internal.creatorEvents.emitEvent, {
+      apiSecret: t.apiSecret,
+      authUserId,
+      eventType: 'ping',
+      resourceType: 'ping',
+      resourceId: 'first',
+      data: { ok: true },
+    });
+    const fanoutCount = await t.mutation(internal.creatorEvents.fanOutToSubscriptions, {
+      eventId,
+      authUserId,
+      eventType: 'ping',
+    });
+    expect(fanoutCount).toBe(1);
+
+    const pendingForWorker = await t.query(internal.webhookDeliveries.listPending, {});
+    expect(pendingForWorker).toHaveLength(1);
+
+    const pendingList = await t.query(api.webhookDeliveries.listBySubscription, {
+      apiSecret: t.apiSecret,
+      authUserId,
+      subscriptionId,
+      status: 'pending',
+      limit: 10,
+    });
+    expect(pendingList.deliveries).toHaveLength(1);
+
+    const deliveryId = pendingList.deliveries[0]._id as Id<'webhook_deliveries'>;
+    await t.mutation(internal.webhookDeliveries.markInProgress, { deliveryId });
+    await t.mutation(internal.webhookDeliveries.markFailed, {
+      deliveryId,
+      lastHttpStatus: 503,
+      lastError: 'temporary failure',
+    });
+
+    const failedList = await t.query(api.webhookDeliveries.listBySubscription, {
+      apiSecret: t.apiSecret,
+      authUserId,
+      subscriptionId,
+      status: 'failed',
+    });
+    expect(failedList.deliveries).toHaveLength(1);
+    expect(failedList.deliveries[0]).toMatchObject({
+      status: 'failed',
+      attemptCount: 1,
+      lastHttpStatus: 503,
+    });
+  });
+
+  test('real scheduler runs Payhip product projection without fake timers', async () => {
+    const authUserId = unique('auth-payhip-scheduler');
+    const subjectId = await seedSubject({
+      authUserId,
+      primaryDiscordUserId: unique('discord-payhip-scheduler'),
+    });
+    await seedCreatorProfile({ authUserId });
+    await seedPurchaseFact({
+      authUserId,
+      provider: 'payhip',
+      providerProductId: 'PAYHIPREAL',
+      externalOrderId: 'payhip-real-order',
+      subjectId,
+    });
+
+    await t.mutation(api.role_rules.addProductFromPayhip, {
+      apiSecret: t.apiSecret,
+      authUserId,
+      permalink: 'PAYHIPREAL',
+      displayName: 'Real Payhip Product',
+    });
+
+    await waitFor(
+      async () => {
+        const entitlements = await t.collect('entitlements');
+        return entitlements.some(
+          (entitlement) =>
+            entitlement.authUserId === authUserId &&
+            entitlement.productId === 'PAYHIPREAL' &&
+            entitlement.sourceProvider === 'payhip'
+        );
+      },
+      {
+        description: 'Payhip scheduler projection to create an entitlement',
+        timeoutMs: 30_000,
+      }
+    );
+  });
+});

--- a/ops/convex-real/real-backend-suite.test.ts
+++ b/ops/convex-real/real-backend-suite.test.ts
@@ -1,8 +1,17 @@
-import { sha256Hex } from '@yucp/shared/crypto';
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { API_ACTOR_TTL_MS, parseApiActorPayload } from '@yucp/shared/apiActor';
+import { sha256Hex } from '@yucp/shared/crypto';
 import { api, internal } from '../../convex/_generated/api';
 import type { Id } from '../../convex/_generated/dataModel';
-import { makeRealConvex, type RealConvex, waitFor } from './harness';
+import {
+  getTestActorBindingForTest,
+  makeRealConvex,
+  type RealConvex,
+  removeRealBackendEnv,
+  resetTestActorBindingCacheForTest,
+  restoreRealBackendTestSignal,
+  waitFor,
+} from './harness';
 
 let t: RealConvex;
 
@@ -115,6 +124,32 @@ afterEach(async () => {
 });
 
 describe('real Convex backend contracts', () => {
+  test('test-only deployed helpers reject when the real-backend test signal is absent', async () => {
+    await removeRealBackendEnv('IS_TEST');
+    try {
+      await expect(t.clearAll()).rejects.toThrow('testHelpersReal functions require IS_TEST=true');
+    } finally {
+      await restoreRealBackendTestSignal();
+    }
+  });
+
+  test('real backend harness refreshes the signed service actor before expiry', async () => {
+    const issuedAt = 1_700_000_000_000;
+    resetTestActorBindingCacheForTest();
+
+    const first = await getTestActorBindingForTest(issuedAt);
+    const reused = await getTestActorBindingForTest(issuedAt + API_ACTOR_TTL_MS - 30_001);
+    expect(reused).toEqual(first);
+
+    const refreshed = await getTestActorBindingForTest(issuedAt + API_ACTOR_TTL_MS - 30_000);
+    expect(refreshed).not.toEqual(first);
+
+    const firstActor = parseApiActorPayload(first.payload);
+    const refreshedActor = parseApiActorPayload(refreshed.payload);
+    expect(firstActor?.expiresAt).toBe(issuedAt + API_ACTOR_TTL_MS);
+    expect(refreshedActor?.expiresAt).toBe(issuedAt + 2 * API_ACTOR_TTL_MS - 30_000);
+  });
+
   test('public manual-license bounds run through the deployed backend', async () => {
     const authUserId = unique('auth-manual-bounds');
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "test:convex:types": "tsc --noEmit -p convex/tsconfig.json",
     "test:convex": "bun run test:convex:types && bun x vitest run --config convex/vitest.config.ts",
     "test:convex:real:up": "bun run ops/convex-real/manage.ts up",
-    "test:convex:real": "bun test ./ops/convex-real/real-backend-smoke.test.ts",
+    "test:convex:real": "bun test --timeout 60000 --max-concurrency 1 ./ops/convex-real/real-backend-smoke.test.ts ./ops/convex-real/real-backend-suite.test.ts",
     "test:convex:real:down": "bun run ops/convex-real/manage.ts down",
     "test:convex:prepare": "bun run infisical:convex -- bun x convex dev --once",
     "test:convex:prepare:debug": "bun run infisical:convex -- bun x convex dev --once --debug-node-apis",


### PR DESCRIPTION
## Summary
- Add a real self-hosted Convex harness using admin-authenticated ConvexHttpClient calls for public and internal functions.
- Add IS_TEST-gated real backend DB helpers for seeding, reads, cleanup, and scheduled job cleanup.
- Expand the convex-real CI job from smoke-only to a blocking real-backend suite with 60s test timeout and Docker pull retries.

## Verification
- bun run test:convex:real:up && bun run test:convex:real && bun run test:convex:real:down

## Notes
- Existing fake-timer scheduler tests stay on convex-test with comments. The real suite covers the Payhip scheduler path with real waits.
- Per instruction, I did not run bun run test:ci or bun run typecheck locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded real-backend end-to-end test coverage (license bulk-create limits, entitlement reads with actor injection requirements, backfill projections, webhook deduplication and status transitions, and webhook delivery lifecycle).
  * Added a real-backend test harness to boot, configure, seed, and poll a live backend, including helper operations and controlled cleanup.

* **Bug Fixes**
  * Improved real-backend startup reliability with Docker image pulling retries/backoff and longer, sequential real-test execution.
  * Updated real-backend test helper gating to support additional test flag values.

* **Chores**
  * Enhanced real-test cleanup to optionally include scheduled items and return deletion counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->