### PR TITLE
test(api): real-router buildApp integration harness

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1435,6 +1435,16 @@ async function handleRequest(request: Request): Promise<Response> {
 }
 
 /**
+ * Builds the same request handler used by the production Bun server.
+ */
+export function createApiRequestHandler(
+  webhookBaseUrl?: string
+): (request: Request) => Promise<Response> {
+  auth = initializeAuth(webhookBaseUrl);
+  return handleRequest;
+}
+
+/**
  * Main entry point
  */
 async function main() {
@@ -1458,15 +1468,16 @@ async function main() {
   const publicBaseUrl =
     tunnel.provider !== 'none' ? tunnel.url : (env.SITE_URL ?? `http://localhost:${port}`);
 
-  // Initialize Better Auth (pass tunnel URL for webhook base if detected)
-  auth = initializeAuth(tunnel.provider !== 'none' ? tunnel.url : undefined);
+  const requestHandler = createApiRequestHandler(
+    tunnel.provider !== 'none' ? tunnel.url : undefined
+  );
 
   // Start HTTP server
   Bun.serve({
     hostname,
     maxRequestBodySize: MAX_BACKSTAGE_UPLOAD_BYTES,
     port,
-    fetch: handleRequest,
+    fetch: requestHandler,
   });
 
   logger.info('API server ready', {
@@ -1481,13 +1492,15 @@ async function main() {
   });
 }
 
-main().catch((err) => {
-  logger.error('Failed to start API server', {
-    message: err instanceof Error ? err.message : String(err),
-    stack: err instanceof Error ? err.stack : undefined,
+if (import.meta.main) {
+  main().catch((err) => {
+    logger.error('Failed to start API server', {
+      message: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
+    process.exit(1);
   });
-  process.exit(1);
-});
+}
 
 // Export auth utilities for external use
 export { auth };

--- a/apps/api/test/helpers/startApiFromCwd.test.ts
+++ b/apps/api/test/helpers/startApiFromCwd.test.ts
@@ -1,0 +1,24 @@
+import { expect, it } from 'bun:test';
+import { stopChildWithFallback } from './startApiFromCwd';
+
+it('escalates child shutdown when the API child does not exit', async () => {
+  const signals: NodeJS.Signals[] = [];
+  const cancelFallback = stopChildWithFallback(
+    {
+      kill(signal: NodeJS.Signals) {
+        signals.push(signal);
+        return true;
+      },
+    },
+    'SIGTERM',
+    1
+  );
+
+  try {
+    expect(signals).toEqual(['SIGTERM']);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(signals).toEqual(['SIGTERM', 'SIGKILL']);
+  } finally {
+    cancelFallback();
+  }
+});

--- a/apps/api/test/helpers/startApiFromCwd.ts
+++ b/apps/api/test/helpers/startApiFromCwd.ts
@@ -1,11 +1,38 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+
 const targetCwd = process.env.YUCP_TEST_CWD?.trim();
 
 if (!targetCwd) {
   throw new Error('YUCP_TEST_CWD must be set');
 }
 
-process.chdir(targetCwd);
+const apiEntry = path.resolve(import.meta.dir, '../../src/index.ts');
+const apiProcess = spawn(process.execPath, ['run', apiEntry], {
+  cwd: targetCwd,
+  env: process.env,
+  stdio: 'inherit',
+});
 
-await import(new URL('../../src/index.ts', import.meta.url).href);
+let stopping = false;
 
-export {};
+function stop(signal: NodeJS.Signals) {
+  stopping = true;
+  apiProcess.kill(signal);
+}
+
+process.on('SIGINT', () => stop('SIGINT'));
+process.on('SIGTERM', () => stop('SIGTERM'));
+
+const exitCode = await new Promise<number>((resolve, reject) => {
+  apiProcess.on('error', reject);
+  apiProcess.on('exit', (code, signal) => {
+    if (signal) {
+      resolve(stopping ? 0 : 1);
+      return;
+    }
+    resolve(code ?? 0);
+  });
+});
+
+process.exit(exitCode);

--- a/apps/api/test/helpers/startApiFromCwd.ts
+++ b/apps/api/test/helpers/startApiFromCwd.ts
@@ -1,38 +1,75 @@
 import { spawn } from 'node:child_process';
 import path from 'node:path';
 
-const targetCwd = process.env.YUCP_TEST_CWD?.trim();
+const FORCE_KILL_TIMEOUT_MS = 5_000;
 
-if (!targetCwd) {
-  throw new Error('YUCP_TEST_CWD must be set');
+interface KillableChild {
+  kill(signal: NodeJS.Signals): boolean;
 }
 
-const apiEntry = path.resolve(import.meta.dir, '../../src/index.ts');
-const apiProcess = spawn(process.execPath, ['run', apiEntry], {
-  cwd: targetCwd,
-  env: process.env,
-  stdio: 'inherit',
-});
+export function stopChildWithFallback(
+  child: KillableChild,
+  signal: NodeJS.Signals,
+  timeoutMs = FORCE_KILL_TIMEOUT_MS
+): () => void {
+  let cancelled = false;
+  child.kill(signal);
 
-let stopping = false;
+  const fallback = setTimeout(() => {
+    if (!cancelled) {
+      child.kill('SIGKILL');
+    }
+  }, timeoutMs);
 
-function stop(signal: NodeJS.Signals) {
-  stopping = true;
-  apiProcess.kill(signal);
+  return () => {
+    cancelled = true;
+    clearTimeout(fallback);
+  };
 }
 
-process.on('SIGINT', () => stop('SIGINT'));
-process.on('SIGTERM', () => stop('SIGTERM'));
+export async function startApiFromCwd(env: NodeJS.ProcessEnv = process.env): Promise<number> {
+  const targetCwd = env.YUCP_TEST_CWD?.trim();
 
-const exitCode = await new Promise<number>((resolve, reject) => {
-  apiProcess.on('error', reject);
-  apiProcess.on('exit', (code, signal) => {
-    if (signal) {
-      resolve(stopping ? 0 : 1);
+  if (!targetCwd) {
+    throw new Error('YUCP_TEST_CWD must be set');
+  }
+
+  const apiEntry = path.resolve(import.meta.dir, '../../src/index.ts');
+  const apiProcess = spawn(process.execPath, ['run', apiEntry], {
+    cwd: targetCwd,
+    env,
+    stdio: 'inherit',
+  });
+
+  let stopping = false;
+  let cancelFallback: (() => void) | undefined;
+
+  function stop(signal: NodeJS.Signals) {
+    if (stopping) {
       return;
     }
-    resolve(code ?? 0);
-  });
-});
+    stopping = true;
+    cancelFallback = stopChildWithFallback(apiProcess, signal);
+  }
 
-process.exit(exitCode);
+  process.on('SIGINT', () => stop('SIGINT'));
+  process.on('SIGTERM', () => stop('SIGTERM'));
+
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    apiProcess.on('error', reject);
+    apiProcess.on('exit', (code, signal) => {
+      cancelFallback?.();
+      if (signal) {
+        resolve(stopping ? 0 : 1);
+        return;
+      }
+      resolve(code ?? 0);
+    });
+  });
+
+  return exitCode;
+}
+
+if (import.meta.main) {
+  process.exit(await startApiFromCwd());
+}

--- a/apps/api/test/index.test.ts
+++ b/apps/api/test/index.test.ts
@@ -93,10 +93,19 @@ describe('API server, production app harness', () => {
     try {
       expect(() => {
         overlappingApp = buildApp();
-      }).toThrow('buildApp only supports one active app at a time');
+      }).toThrow(
+        'buildApp only supports one app per test worker while handler state is module-scoped'
+      );
     } finally {
       overlappingApp?.dispose();
     }
+  });
+
+  it('rejects a second buildApp lifetime after dispose while handler state is module-scoped', () => {
+    app.dispose();
+    expect(() => buildApp()).toThrow(
+      'buildApp only supports one app per test worker while handler state is module-scoped'
+    );
   });
 });
 

--- a/apps/api/test/index.test.ts
+++ b/apps/api/test/index.test.ts
@@ -8,6 +8,7 @@
 
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import { startTestServer, type TestServerHandle } from './helpers/testServer';
+import { type BuiltApiApp, buildApp } from './support/buildApp';
 
 function expectHtmlSecurityHeaders(response: Response) {
   const contentType = response.headers.get('content-type') ?? '';
@@ -22,17 +23,17 @@ function expectHtmlSecurityHeaders(response: Response) {
   expect(response.headers.get('x-frame-options')).toBe('DENY');
 }
 
-describe('API server, route mounting', () => {
-  let server: TestServerHandle;
+describe('API server, production app harness', () => {
+  let app: BuiltApiApp;
 
-  beforeAll(async () => {
-    server = await startTestServer();
+  beforeAll(() => {
+    app = buildApp();
   });
 
-  afterAll(() => server.stop());
+  afterAll(() => app.dispose());
 
   it('GET /health returns { status: "ok" }', async () => {
-    const res = await server.fetch('/health');
+    const res = await app.fetch('/health');
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toMatchObject({ status: 'ok' });
@@ -43,7 +44,7 @@ describe('API server, route mounting', () => {
   });
 
   it('GET /v1/keys serves the importer trust bootstrap on the API host', async () => {
-    const res = await server.fetch('/v1/keys');
+    const res = await app.fetch('/v1/keys');
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type')).toContain('application/json');
 
@@ -74,6 +75,27 @@ describe('API server, route mounting', () => {
     }
     expect(res.headers.get('cache-control')).toBe('no-store');
   });
+
+  it('GET /api/public/v2/openapi.json is mounted through the v2 router', async () => {
+    const res = await app.fetch('/api/public/v2/openapi.json');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    expect(res.headers.get('yucp-version')).toBe('2025-03-01');
+
+    const body = (await res.json()) as { openapi?: string; paths?: Record<string, unknown> };
+    expect(body.openapi).toBe('3.1.0');
+    expect(body.paths).toHaveProperty('/verification/check');
+  });
+});
+
+describe('API server, route mounting', () => {
+  let server: TestServerHandle;
+
+  beforeAll(async () => {
+    server = await startTestServer();
+  });
+
+  afterAll(() => server.stop());
 
   it('still serves shared static assets that are used outside the migrated creator UI', async () => {
     const res = await server.fetch('/tokens.css');

--- a/apps/api/test/index.test.ts
+++ b/apps/api/test/index.test.ts
@@ -86,6 +86,18 @@ describe('API server, production app harness', () => {
     expect(body.openapi).toBe('3.1.0');
     expect(body.paths).toHaveProperty('/verification/check');
   });
+
+  it('rejects overlapping buildApp instances while handler state is module-scoped', () => {
+    let overlappingApp: BuiltApiApp | undefined;
+
+    try {
+      expect(() => {
+        overlappingApp = buildApp();
+      }).toThrow('buildApp only supports one active app at a time');
+    } finally {
+      overlappingApp?.dispose();
+    }
+  });
 });
 
 describe('API server, route mounting', () => {

--- a/apps/api/test/support/buildApp.ts
+++ b/apps/api/test/support/buildApp.ts
@@ -53,6 +53,8 @@ const MANAGED_ENV_KEYS = [
 type ManagedEnvKey = (typeof MANAGED_ENV_KEYS)[number];
 type ManagedEnv = Partial<Record<ManagedEnvKey, string | undefined>>;
 
+let activeApp = false;
+
 export interface BuildAppConfig {
   baseUrl?: string;
   frontendUrl?: string;
@@ -162,6 +164,11 @@ function applyEnv(next: ManagedEnv): () => void {
 }
 
 export function buildApp(config: BuildAppConfig = {}): BuiltApiApp {
+  if (activeApp) {
+    throw new Error('buildApp only supports one active app at a time');
+  }
+
+  activeApp = true;
   const baseUrl = config.baseUrl ?? 'http://localhost:3001';
   const restoreEnv = applyEnv(buildEnv(config));
   let disposed = false;
@@ -171,6 +178,7 @@ export function buildApp(config: BuildAppConfig = {}): BuiltApiApp {
     handle = createApiRequestHandler(config.webhookBaseUrl);
   } catch (error) {
     restoreEnv();
+    activeApp = false;
     throw error;
   }
 
@@ -187,6 +195,7 @@ export function buildApp(config: BuildAppConfig = {}): BuiltApiApp {
       if (!disposed) {
         disposed = true;
         restoreEnv();
+        activeApp = false;
       }
     },
     fetch(path: string, init?: RequestInit): Promise<Response> {

--- a/apps/api/test/support/buildApp.ts
+++ b/apps/api/test/support/buildApp.ts
@@ -1,0 +1,197 @@
+import { createApiRequestHandler } from '../../src/index';
+
+const MANAGED_ENV_KEYS = [
+  'NODE_ENV',
+  'CONVEX_DEPLOYMENT',
+  'CONVEX_URL',
+  'CONVEX_SITE_URL',
+  'CONVEX_API_SECRET',
+  'SITE_URL',
+  'FRONTEND_URL',
+  'BETTER_AUTH_SECRET',
+  'ENCRYPTION_SECRET',
+  'ERROR_REFERENCE_SECRET',
+  'BETTER_AUTH_URL',
+  'PUBLIC_OAUTH_TRUSTED_CLIENTS_JSON',
+  'INTERNAL_SERVICE_AUTH_SECRET',
+  'INTERNAL_RPC_SHARED_SECRET',
+  'INTERNAL_SERVICE_TOKEN',
+  'VRCHAT_PENDING_STATE_SECRET',
+  'VRCHAT_PROVIDER_SESSION_SECRET',
+  'DISCORD_CLIENT_ID',
+  'DISCORD_CLIENT_SECRET',
+  'DISCORD_BOT_TOKEN',
+  'GUMROAD_ACCESS_TOKEN',
+  'GUMROAD_CLIENT_ID',
+  'GUMROAD_CLIENT_SECRET',
+  'GUMROAD_API_KEY',
+  'GUMROAD_SECRET_KEY',
+  'JINXXY_API_BASE_URL',
+  'JINXXY_API_KEY',
+  'JINXXY_SECRET_KEY',
+  'ITCHIO_CLIENT_ID',
+  'PATREON_CLIENT_ID',
+  'PATREON_CLIENT_SECRET',
+  'POLAR_ACCESS_TOKEN',
+  'POLAR_WEBHOOK_SECRET',
+  'YUCP_COUPLING_SERVICE_BASE_URL',
+  'YUCP_COUPLING_SERVICE_SHARED_SECRET',
+  'COUPLING_SERVICE_SECRET',
+  'CDNGINE_API_BASE_URL',
+  'CDNGINE_PUBLIC_API_BASE_URL',
+  'CDNGINE_ACCESS_TOKEN',
+  'CDNGINE_API_TOKEN',
+  'CDNGINE_BACKSTAGE_REQUIRED',
+  'CDNGINE_BACKSTAGE_PUBLICATION_POLL_INTERVAL_MS',
+  'CDNGINE_BACKSTAGE_PUBLICATION_TIMEOUT_MS',
+  'CDNGINE_BACKSTAGE_TIMEOUT_MS',
+  'DRAGONFLY_URI',
+  'REDIS_URL',
+  'LOG_LEVEL',
+] as const;
+
+type ManagedEnvKey = (typeof MANAGED_ENV_KEYS)[number];
+type ManagedEnv = Partial<Record<ManagedEnvKey, string | undefined>>;
+
+export interface BuildAppConfig {
+  baseUrl?: string;
+  frontendUrl?: string;
+  convexUrl?: string;
+  convexSiteUrl?: string;
+  convexApiSecret?: string;
+  encryptionSecret?: string;
+  betterAuthSecret?: string;
+  errorReferenceSecret?: string;
+  internalServiceAuthSecret?: string;
+  internalRpcSharedSecret?: string;
+  couplingServiceBaseUrl?: string;
+  couplingServiceSharedSecret?: string;
+  discordClientId?: string;
+  discordClientSecret?: string;
+  webhookBaseUrl?: string;
+}
+
+export interface BuiltApiApp {
+  readonly baseUrl: string;
+  dispose(): void;
+  fetch(path: string, init?: RequestInit): Promise<Response>;
+  handle(request: Request): Promise<Response>;
+}
+
+function buildEnv(config: BuildAppConfig): ManagedEnv {
+  const baseUrl = config.baseUrl ?? 'http://localhost:3001';
+  const frontendUrl = config.frontendUrl ?? baseUrl;
+  const convexUrl = config.convexUrl ?? 'http://127.0.0.1:3210';
+  const convexSiteUrl = config.convexSiteUrl ?? 'http://127.0.0.1:3211';
+
+  return {
+    NODE_ENV: 'test',
+    CONVEX_DEPLOYMENT: undefined,
+    CONVEX_URL: convexUrl,
+    CONVEX_SITE_URL: convexSiteUrl,
+    CONVEX_API_SECRET: config.convexApiSecret ?? 'test-api-secret-min-32-characters!!',
+    SITE_URL: baseUrl,
+    FRONTEND_URL: frontendUrl,
+    BETTER_AUTH_SECRET: config.betterAuthSecret ?? 'test-better-auth-secret-32-chars!!',
+    ENCRYPTION_SECRET: config.encryptionSecret ?? 'test-encryption-secret-32-chars!!',
+    ERROR_REFERENCE_SECRET: config.errorReferenceSecret ?? 'test-error-reference-secret',
+    BETTER_AUTH_URL: undefined,
+    PUBLIC_OAUTH_TRUSTED_CLIENTS_JSON: undefined,
+    INTERNAL_SERVICE_AUTH_SECRET:
+      config.internalServiceAuthSecret ?? 'test-internal-service-auth-secret',
+    INTERNAL_RPC_SHARED_SECRET: config.internalRpcSharedSecret ?? 'test-internal-rpc-secret',
+    INTERNAL_SERVICE_TOKEN: undefined,
+    VRCHAT_PENDING_STATE_SECRET: 'test-vrchat-pending-state-secret',
+    VRCHAT_PROVIDER_SESSION_SECRET: 'test-vrchat-provider-session-secret',
+    DISCORD_CLIENT_ID: config.discordClientId ?? 'test-discord-client-id',
+    DISCORD_CLIENT_SECRET: config.discordClientSecret ?? 'test-discord-client-secret',
+    DISCORD_BOT_TOKEN: undefined,
+    GUMROAD_ACCESS_TOKEN: undefined,
+    GUMROAD_CLIENT_ID: undefined,
+    GUMROAD_CLIENT_SECRET: undefined,
+    GUMROAD_API_KEY: undefined,
+    GUMROAD_SECRET_KEY: undefined,
+    JINXXY_API_BASE_URL: undefined,
+    JINXXY_API_KEY: undefined,
+    JINXXY_SECRET_KEY: undefined,
+    ITCHIO_CLIENT_ID: undefined,
+    PATREON_CLIENT_ID: undefined,
+    PATREON_CLIENT_SECRET: undefined,
+    POLAR_ACCESS_TOKEN: undefined,
+    POLAR_WEBHOOK_SECRET: undefined,
+    YUCP_COUPLING_SERVICE_BASE_URL: config.couplingServiceBaseUrl ?? 'http://127.0.0.1:8788',
+    YUCP_COUPLING_SERVICE_SHARED_SECRET:
+      config.couplingServiceSharedSecret ?? 'test-coupling-secret',
+    COUPLING_SERVICE_SECRET: undefined,
+    CDNGINE_API_BASE_URL: undefined,
+    CDNGINE_PUBLIC_API_BASE_URL: undefined,
+    CDNGINE_ACCESS_TOKEN: undefined,
+    CDNGINE_API_TOKEN: undefined,
+    CDNGINE_BACKSTAGE_REQUIRED: undefined,
+    CDNGINE_BACKSTAGE_PUBLICATION_POLL_INTERVAL_MS: undefined,
+    CDNGINE_BACKSTAGE_PUBLICATION_TIMEOUT_MS: undefined,
+    CDNGINE_BACKSTAGE_TIMEOUT_MS: undefined,
+    DRAGONFLY_URI: undefined,
+    REDIS_URL: undefined,
+    LOG_LEVEL: 'silent',
+  };
+}
+
+function applyEnv(next: ManagedEnv): () => void {
+  const previous = new Map<ManagedEnvKey, string | undefined>();
+
+  for (const key of MANAGED_ENV_KEYS) {
+    previous.set(key, process.env[key]);
+    const value = next[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  return () => {
+    for (const [key, value] of previous) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  };
+}
+
+export function buildApp(config: BuildAppConfig = {}): BuiltApiApp {
+  const baseUrl = config.baseUrl ?? 'http://localhost:3001';
+  const restoreEnv = applyEnv(buildEnv(config));
+  let disposed = false;
+  let handle: (request: Request) => Promise<Response>;
+
+  try {
+    handle = createApiRequestHandler(config.webhookBaseUrl);
+  } catch (error) {
+    restoreEnv();
+    throw error;
+  }
+
+  function call(request: Request): Promise<Response> {
+    if (disposed) {
+      throw new Error('buildApp handler used after dispose');
+    }
+    return handle(request);
+  }
+
+  return {
+    baseUrl,
+    dispose() {
+      if (!disposed) {
+        disposed = true;
+        restoreEnv();
+      }
+    },
+    fetch(path: string, init?: RequestInit): Promise<Response> {
+      return call(new Request(new URL(path, baseUrl), init));
+    },
+    handle: call,
+  };
+}

--- a/apps/api/test/support/buildApp.ts
+++ b/apps/api/test/support/buildApp.ts
@@ -53,7 +53,7 @@ const MANAGED_ENV_KEYS = [
 type ManagedEnvKey = (typeof MANAGED_ENV_KEYS)[number];
 type ManagedEnv = Partial<Record<ManagedEnvKey, string | undefined>>;
 
-let activeApp = false;
+let appCreated = false;
 
 export interface BuildAppConfig {
   baseUrl?: string;
@@ -164,11 +164,13 @@ function applyEnv(next: ManagedEnv): () => void {
 }
 
 export function buildApp(config: BuildAppConfig = {}): BuiltApiApp {
-  if (activeApp) {
-    throw new Error('buildApp only supports one active app at a time');
+  if (appCreated) {
+    throw new Error(
+      'buildApp only supports one app per test worker while handler state is module-scoped'
+    );
   }
 
-  activeApp = true;
+  appCreated = true;
   const baseUrl = config.baseUrl ?? 'http://localhost:3001';
   const restoreEnv = applyEnv(buildEnv(config));
   let disposed = false;
@@ -178,7 +180,7 @@ export function buildApp(config: BuildAppConfig = {}): BuiltApiApp {
     handle = createApiRequestHandler(config.webhookBaseUrl);
   } catch (error) {
     restoreEnv();
-    activeApp = false;
+    appCreated = false;
     throw error;
   }
 
@@ -195,7 +197,6 @@ export function buildApp(config: BuildAppConfig = {}): BuiltApiApp {
       if (!disposed) {
         disposed = true;
         restoreEnv();
-        activeApp = false;
       }
     },
     fetch(path: string, init?: RequestInit): Promise<Response> {


### PR DESCRIPTION
Adds a production-faithful buildApp integration harness for API tests. The harness imports the real createApiRequestHandler extraction from apps/api/src/index.ts and mounts the real router, middleware, and auth path in production order, with v2 routes checked first.

This lets integration tests exercise real routing instead of createServer's v1-only route table. The production entrypoint keeps the same runtime behavior through an import.meta.main guard. This PR migrates two existing tests and adds a v2 OpenAPI routing test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API startup now uses a reusable request-handler setup for initializing auth and serving requests.
  * The v2 OpenAPI documentation endpoint is now verified via the main router, including version and expected path details.

* **Bug Fixes**
  * Server auto-start behavior is now limited to when the module is the program entrypoint.

* **Tests**
  * API route tests now run against a built, disposable app harness for more reliable coverage.
  * Test server startup now spawns the API in a child process for cleaner execution and shutdown.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->