### PR TITLE
fix(bot): scope verify picker products to guild role rules

### DIFF
--- a/apps/bot/src/commands/licenseVerify.ts
+++ b/apps/bot/src/commands/licenseVerify.ts
@@ -3,7 +3,7 @@
  *
  * Flow:
  *   1. User clicks "Use License Key" button
- *      → showProductPicker(): loads tenant's products, renders StringSelectMenu
+ *      → showProductPicker(): loads server configured products, renders StringSelectMenu
  *         with filter buttons (All / Gumroad / Jinxxy) and pagination (Prev/Next).
  *   2. User selects a product from the select menu
  *      → handleProductSelected(): shows a modal pre-titled with the product name.
@@ -265,6 +265,22 @@ async function enrichDisplayNames(
   });
 }
 
+async function loadConfiguredProductsForPicker(
+  convex: ConvexHttpClient,
+  apiSecret: string,
+  authUserId: string,
+  guildId: string | null
+): Promise<Product[]> {
+  if (!guildId) return [];
+
+  const products = (await convex.query(api.productResolution.getProductsConfiguredForGuild, {
+    apiSecret,
+    authUserId,
+    guildId,
+  })) as Product[];
+  return await enrichDisplayNames(products, authUserId, apiSecret);
+}
+
 export async function showProductPicker(
   interaction: ButtonInteraction,
   convex: ConvexHttpClient,
@@ -277,11 +293,12 @@ export async function showProductPicker(
 
   let products: Product[] = [];
   try {
-    products = (await convex.query(api.productResolution.getProductsForTenant, {
+    products = await loadConfiguredProductsForPicker(
+      convex,
       apiSecret,
       authUserId,
-    })) as Product[];
-    products = await enrichDisplayNames(products, authUserId, apiSecret);
+      interaction.guildId
+    );
   } catch (err) {
     logger.error('Failed to load products for picker', { err });
   }
@@ -320,11 +337,12 @@ export async function handlePickerNavigation(
 
   let products: Product[] = [];
   try {
-    products = (await convex.query(api.productResolution.getProductsForTenant, {
+    products = await loadConfiguredProductsForPicker(
+      convex,
       apiSecret,
       authUserId,
-    })) as Product[];
-    products = await enrichDisplayNames(products, authUserId, apiSecret);
+      interaction.guildId
+    );
   } catch (err) {
     logger.error('Failed to reload products for picker nav', { err });
   }

--- a/apps/bot/src/commands/licenseVerify.ts
+++ b/apps/bot/src/commands/licenseVerify.ts
@@ -64,7 +64,6 @@ type Filter = 'all' | string;
 type ProductPickerRow = ActionRowBuilder<any>;
 
 interface Product {
-  _id: string;
   productId: string;
   provider: string;
   providerProductRef: string;

--- a/convex/productResolution.ts
+++ b/convex/productResolution.ts
@@ -159,6 +159,7 @@ export const getProductsConfiguredForGuild = query({
       .withIndex('by_auth_user_guild', (q) =>
         q.eq('authUserId', args.authUserId).eq('guildId', args.guildId)
       )
+      .filter((q) => q.eq(q.field('enabled'), true))
       .order('asc')
       .take(1000);
 

--- a/convex/productResolution.ts
+++ b/convex/productResolution.ts
@@ -143,8 +143,6 @@ export const getProductsConfiguredForGuild = query({
   },
   returns: v.array(
     v.object({
-      _id: v.id('product_catalog'),
-      catalogProductId: v.id('product_catalog'),
       productId: v.string(),
       provider: ProviderV,
       providerProductRef: v.string(),
@@ -188,8 +186,6 @@ export const getProductsConfiguredForGuild = query({
     }
 
     return products.map((p) => ({
-      _id: p._id,
-      catalogProductId: p._id,
       productId: p.productId,
       provider: p.provider,
       providerProductRef: p.providerProductRef,

--- a/convex/productResolution.ts
+++ b/convex/productResolution.ts
@@ -7,6 +7,7 @@
 
 import { sha256Hex } from '@yucp/shared/crypto';
 import { v } from 'convex/values';
+import type { Doc } from './_generated/dataModel';
 import { internalQuery, query } from './_generated/server';
 import { requireApiSecret } from './lib/apiAuth';
 import { ProviderV } from './lib/providers';
@@ -74,8 +75,7 @@ export const resolveProductByUrl = internalQuery({
 
 /**
  * Get all active products registered for a tenant.
- * Used by the Discord bot product picker for license key verification.
- * Returns Gumroad and Jinxxy products with their provider refs.
+ * Returns catalog products with their provider refs.
  */
 export const getProductsForTenant = query({
   args: {
@@ -127,6 +127,67 @@ export const getProductsForTenant = query({
       canonicalSlug: p.canonicalSlug,
       displayName: p.displayName,
       lastSyncedAt: freshestByCatalogId.get(String(p._id)) ?? p.updatedAt,
+    }));
+  },
+});
+
+/**
+ * Get active catalog products that have role rules in one Discord guild.
+ * Used by the license verification picker so unconfigured catalog products do not appear.
+ */
+export const getProductsConfiguredForGuild = query({
+  args: {
+    apiSecret: v.string(),
+    authUserId: v.string(),
+    guildId: v.string(),
+  },
+  returns: v.array(
+    v.object({
+      _id: v.id('product_catalog'),
+      catalogProductId: v.id('product_catalog'),
+      productId: v.string(),
+      provider: ProviderV,
+      providerProductRef: v.string(),
+      canonicalSlug: v.optional(v.string()),
+      displayName: v.optional(v.string()),
+    })
+  ),
+  handler: async (ctx, args) => {
+    requireApiSecret(args.apiSecret);
+    const rules = await ctx.db
+      .query('role_rules')
+      .withIndex('by_auth_user_guild', (q) =>
+        q.eq('authUserId', args.authUserId).eq('guildId', args.guildId)
+      )
+      .order('asc')
+      .take(1000);
+
+    const seenCatalogIds = new Set<string>();
+    const products: Doc<'product_catalog'>[] = [];
+
+    for (const rule of rules) {
+      if (!rule.catalogProductId) continue;
+
+      const catalogId = String(rule.catalogProductId);
+      if (seenCatalogIds.has(catalogId)) continue;
+
+      const catalog = await ctx.db.get(rule.catalogProductId);
+      if (!catalog || catalog.authUserId !== args.authUserId || catalog.status !== 'active') {
+        continue;
+      }
+
+      seenCatalogIds.add(catalogId);
+      products.push(catalog);
+    }
+
+    return products.map((p) => ({
+      _id: p._id,
+      catalogProductId: p._id,
+      productId: p.productId,
+      provider: p.provider,
+      providerProductRef: p.providerProductRef,
+      canonicalSlug: p.canonicalSlug,
+      displayName: p.displayName,
     }));
   },
 });

--- a/convex/productResolution.ts
+++ b/convex/productResolution.ts
@@ -7,7 +7,7 @@
 
 import { sha256Hex } from '@yucp/shared/crypto';
 import { v } from 'convex/values';
-import type { Doc } from './_generated/dataModel';
+import type { Doc, Id } from './_generated/dataModel';
 import { internalQuery, query } from './_generated/server';
 import { requireApiSecret } from './lib/apiAuth';
 import { ProviderV } from './lib/providers';
@@ -164,7 +164,7 @@ export const getProductsConfiguredForGuild = query({
       .take(1000);
 
     const seenCatalogIds = new Set<string>();
-    const products: Doc<'product_catalog'>[] = [];
+    const catalogProductIds: Id<'product_catalog'>[] = [];
 
     for (const rule of rules) {
       if (!rule.catalogProductId) continue;
@@ -172,12 +172,18 @@ export const getProductsConfiguredForGuild = query({
       const catalogId = String(rule.catalogProductId);
       if (seenCatalogIds.has(catalogId)) continue;
 
-      const catalog = await ctx.db.get(rule.catalogProductId);
+      seenCatalogIds.add(catalogId);
+      catalogProductIds.push(rule.catalogProductId);
+    }
+
+    const catalogDocs = await Promise.all(catalogProductIds.map((id) => ctx.db.get(id)));
+    const products: Doc<'product_catalog'>[] = [];
+
+    for (const catalog of catalogDocs) {
       if (!catalog || catalog.authUserId !== args.authUserId || catalog.status !== 'active') {
         continue;
       }
 
-      seenCatalogIds.add(catalogId);
       products.push(catalog);
     }
 

--- a/convex/roleRules.realtest.ts
+++ b/convex/roleRules.realtest.ts
@@ -259,8 +259,8 @@ describe('role rules CRUD and isolation', () => {
     const guildG = 'guild-license-picker-g';
     const guildH = 'guild-license-picker-h';
 
-    const [catalogAId, catalogBId, catalogCId] = await t.run(async (ctx) =>
-      Promise.all([
+    const [catalogAId, catalogBId] = await t.run(async (ctx) => {
+      const created = await Promise.all([
         ctx.db.insert('product_catalog', {
           authUserId,
           productId: 'product-a',
@@ -294,8 +294,9 @@ describe('role rules CRUD and isolation', () => {
           createdAt: now,
           updatedAt: now,
         }),
-      ])
-    );
+      ]);
+      return [created[0], created[1]] as const;
+    });
 
     const guildLinkG = await seedGuildLink(t, {
       authUserId,
@@ -341,14 +342,14 @@ describe('role rules CRUD and isolation', () => {
       guildId: guildG,
     });
     const productIds = products.map((product) => product.productId);
-    const catalogIds = products.map((product) => product.catalogProductId);
     const providerRefs = products.map((product) => product.providerProductRef);
 
     expect(productIds).toEqual(['product-a']);
-    expect(catalogIds).toEqual([catalogAId]);
     expect(providerRefs).toEqual(['provider-ref-a']);
-    expect(catalogIds).not.toContain(catalogBId);
-    expect(catalogIds).not.toContain(catalogCId);
+    expect(productIds).not.toContain('product-b');
+    expect(productIds).not.toContain('product-c');
+    expect(products[0]).not.toHaveProperty('_id');
+    expect(products[0]).not.toHaveProperty('catalogProductId');
 
     const emptyGuildProducts = await t.query(api.productResolution.getProductsConfiguredForGuild, {
       apiSecret: 'test-secret',
@@ -431,11 +432,12 @@ describe('role rules CRUD and isolation', () => {
       authUserId,
       guildId,
     });
-    const catalogIds = products.map((product) => product.catalogProductId);
+    const productIds = products.map((product) => product.productId);
 
-    expect(products.map((product) => product.productId)).toEqual(['enabled-product']);
-    expect(catalogIds).toEqual([enabledCatalogId]);
-    expect(catalogIds).not.toContain(disabledCatalogId);
+    expect(productIds).toEqual(['enabled-product']);
+    expect(productIds).not.toContain('disabled-product');
+    expect(products[0]).not.toHaveProperty('_id');
+    expect(products[0]).not.toHaveProperty('catalogProductId');
   });
 
   it('enqueues a verify prompt refresh job when a role rule is created', async () => {

--- a/convex/roleRules.realtest.ts
+++ b/convex/roleRules.realtest.ts
@@ -252,6 +252,113 @@ describe('role rules CRUD and isolation', () => {
     expect(providers.length).toBe(2); // no duplicates
   });
 
+  it('given catalog products across guilds, license picker products are scoped to the current guild rules', async () => {
+    const t = makeTestConvex();
+    const now = Date.now();
+    const authUserId = 'auth-license-picker-scope';
+    const guildG = 'guild-license-picker-g';
+    const guildH = 'guild-license-picker-h';
+
+    const [catalogAId, catalogBId, catalogCId] = await t.run(async (ctx) =>
+      Promise.all([
+        ctx.db.insert('product_catalog', {
+          authUserId,
+          productId: 'product-a',
+          provider: 'jinxxy',
+          providerProductRef: 'provider-ref-a',
+          displayName: 'Product A',
+          status: 'active',
+          supportsAutoDiscovery: false,
+          createdAt: now,
+          updatedAt: now,
+        }),
+        ctx.db.insert('product_catalog', {
+          authUserId,
+          productId: 'product-b',
+          provider: 'jinxxy',
+          providerProductRef: 'provider-ref-b',
+          displayName: 'Product B',
+          status: 'active',
+          supportsAutoDiscovery: false,
+          createdAt: now,
+          updatedAt: now,
+        }),
+        ctx.db.insert('product_catalog', {
+          authUserId,
+          productId: 'product-c',
+          provider: 'jinxxy',
+          providerProductRef: 'provider-ref-c',
+          displayName: 'Product C',
+          status: 'active',
+          supportsAutoDiscovery: false,
+          createdAt: now,
+          updatedAt: now,
+        }),
+      ])
+    );
+
+    const guildLinkG = await seedGuildLink(t, {
+      authUserId,
+      discordGuildId: guildG,
+    });
+    const guildLinkH = await seedGuildLink(t, {
+      authUserId,
+      discordGuildId: guildH,
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('role_rules', {
+        authUserId,
+        guildId: guildG,
+        guildLinkId: guildLinkG,
+        productId: 'product-a',
+        catalogProductId: catalogAId,
+        verifiedRoleId: 'role-a',
+        removeOnRevoke: true,
+        priority: 0,
+        enabled: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await ctx.db.insert('role_rules', {
+        authUserId,
+        guildId: guildH,
+        guildLinkId: guildLinkH,
+        productId: 'product-b',
+        catalogProductId: catalogBId,
+        verifiedRoleId: 'role-b',
+        removeOnRevoke: true,
+        priority: 0,
+        enabled: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    const products = await t.query(api.productResolution.getProductsConfiguredForGuild, {
+      apiSecret: 'test-secret',
+      authUserId,
+      guildId: guildG,
+    });
+    const productIds = products.map((product) => product.productId);
+    const catalogIds = products.map((product) => product.catalogProductId);
+    const providerRefs = products.map((product) => product.providerProductRef);
+
+    expect(productIds).toEqual(['product-a']);
+    expect(catalogIds).toEqual([catalogAId]);
+    expect(providerRefs).toEqual(['provider-ref-a']);
+    expect(catalogIds).not.toContain(catalogBId);
+    expect(catalogIds).not.toContain(catalogCId);
+
+    const emptyGuildProducts = await t.query(api.productResolution.getProductsConfiguredForGuild, {
+      apiSecret: 'test-secret',
+      authUserId,
+      guildId: 'guild-license-picker-empty',
+    });
+
+    expect(emptyGuildProducts).toEqual([]);
+  });
+
   it('enqueues a verify prompt refresh job when a role rule is created', async () => {
     const t = makeTestConvex();
 

--- a/convex/roleRules.realtest.ts
+++ b/convex/roleRules.realtest.ts
@@ -359,6 +359,85 @@ describe('role rules CRUD and isolation', () => {
     expect(emptyGuildProducts).toEqual([]);
   });
 
+  it('given disabled role rules, license picker products only include enabled products', async () => {
+    const t = makeTestConvex();
+    const now = Date.now();
+    const authUserId = 'auth-license-picker-enabled';
+    const guildId = 'guild-license-picker-enabled';
+
+    const [enabledCatalogId, disabledCatalogId] = await t.run(async (ctx) =>
+      Promise.all([
+        ctx.db.insert('product_catalog', {
+          authUserId,
+          productId: 'enabled-product',
+          provider: 'jinxxy',
+          providerProductRef: 'enabled-provider-ref',
+          displayName: 'Enabled Product',
+          status: 'active',
+          supportsAutoDiscovery: false,
+          createdAt: now,
+          updatedAt: now,
+        }),
+        ctx.db.insert('product_catalog', {
+          authUserId,
+          productId: 'disabled-product',
+          provider: 'jinxxy',
+          providerProductRef: 'disabled-provider-ref',
+          displayName: 'Disabled Product',
+          status: 'active',
+          supportsAutoDiscovery: false,
+          createdAt: now,
+          updatedAt: now,
+        }),
+      ])
+    );
+
+    const guildLinkId = await seedGuildLink(t, {
+      authUserId,
+      discordGuildId: guildId,
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('role_rules', {
+        authUserId,
+        guildId,
+        guildLinkId,
+        productId: 'enabled-product',
+        catalogProductId: enabledCatalogId,
+        verifiedRoleId: 'enabled-role',
+        removeOnRevoke: true,
+        priority: 0,
+        enabled: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await ctx.db.insert('role_rules', {
+        authUserId,
+        guildId,
+        guildLinkId,
+        productId: 'disabled-product',
+        catalogProductId: disabledCatalogId,
+        verifiedRoleId: 'disabled-role',
+        removeOnRevoke: true,
+        priority: 0,
+        enabled: false,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    const products = await t.query(api.productResolution.getProductsConfiguredForGuild, {
+      apiSecret: 'test-secret',
+      authUserId,
+      guildId,
+    });
+    const catalogIds = products.map((product) => product.catalogProductId);
+
+    expect(products.map((product) => product.productId)).toEqual(['enabled-product']);
+    expect(catalogIds).toEqual([enabledCatalogId]);
+    expect(catalogIds).not.toContain(disabledCatalogId);
+  });
+
   it('enqueues a verify prompt refresh job when a role rule is created', async () => {
     const t = makeTestConvex();
 


### PR DESCRIPTION
## Summary
- Add a guild role scoped productResolution query for verify picker catalog products.
- Switch both initial picker render and picker navigation to load products for interaction.guildId.
- Add a Convex regression that proves only product A appears for guild G, product B in guild H and unconfigured product C are absent, and an empty guild returns an empty list.

## Verification
- node_modules\\.bin\\vitest run --config convex\\vitest.config.ts convex\\roleRules.realtest.ts -t "license picker products are scoped"
- bun run test:convex
- bun run --filter '@yucp/bot' typecheck
- bun run lint
- bun run typecheck
- bun run test:external-integrations

## Mutation proof
- Temporarily changed the picker product source query back to tenant-wide catalog lookup. The new regression failed with product-b and product-c leaking into the result, then passed again after restoring the scoped query.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the product picker to show server (guild)–configured products, including improved display-name enrichment.

* **Bug Fixes**
  * Ensures picker results are correctly scoped to the active server during navigation.
  * When no server context is available, the picker shows no products.
  * Only enabled product configurations are returned; disabled configurations and catalog entries are excluded.

* **Tests**
  * Added integration tests validating guild scoping and enabled/disabled filtering for license picker configured products.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->