### PR TITLE
Fix entitlement grant funnel monitoring

### DIFF
--- a/convex/entitlements.realtest.ts
+++ b/convex/entitlements.realtest.ts
@@ -78,6 +78,7 @@ describe('grantEntitlement lifecycle', () => {
   it('given no entitlement, when grantEntitlement called, then isNew=true and status=active', async () => {
     const t = makeTestConvex();
     const authUserId = 'auth-grant-lifecycle-1';
+    const purchasedAt = Date.now() - 1_000;
 
     const subjectId = await seedSubject(t, { primaryDiscordUserId: 'discord-grant-1' });
     await seedCreatorProfile(t, { authUserId });
@@ -90,7 +91,7 @@ describe('grantEntitlement lifecycle', () => {
       evidence: {
         provider: 'gumroad',
         sourceReference: 'order_abc',
-        purchasedAt: Date.now(),
+        purchasedAt,
       },
     });
 
@@ -108,6 +109,26 @@ describe('grantEntitlement lifecycle', () => {
 
     expect(activeResult.found).toBe(true);
     expect(activeResult.entitlement?.status).toBe('active');
+
+    const evidence = await t.run((ctx) =>
+      ctx.db
+        .query('entitlement_evidence')
+        .withIndex('by_source_reference', (q) =>
+          q.eq('providerKey', 'gumroad').eq('sourceReference', 'order_abc')
+        )
+        .filter((q) => q.eq(q.field('authUserId'), authUserId))
+        .first()
+    );
+
+    expect(evidence).toMatchObject({
+      authUserId,
+      subjectId,
+      providerKey: 'gumroad',
+      evidenceType: 'provider_evidence',
+      status: 'active',
+      productId: 'gumroad:prod_xyz',
+      observedAt: purchasedAt,
+    });
   });
 
   it('given same sourceReference, when granted twice, then isNew=false on second call', async () => {

--- a/convex/entitlements.realtest.ts
+++ b/convex/entitlements.realtest.ts
@@ -195,7 +195,7 @@ describe('grantEntitlement lifecycle', () => {
     expect(metadata).not.toHaveProperty('authUserId');
     expect(metadata).not.toHaveProperty('subjectId');
     expect(metadata).not.toHaveProperty('productId');
-    expect(metadata).toHaveProperty('entitlementId');
+    expect(metadata).not.toHaveProperty('entitlementId');
   });
 
   it('given unexpected grant failure, when logging error outcome, then uses bounded reason code', async () => {

--- a/convex/entitlements.realtest.ts
+++ b/convex/entitlements.realtest.ts
@@ -198,6 +198,59 @@ describe('grantEntitlement lifecycle', () => {
     expect(metadata).toHaveProperty('entitlementId');
   });
 
+  it('given unexpected grant failure, when logging error outcome, then uses bounded reason code', async () => {
+    const t = makeTestConvex();
+    const authUserId = 'auth-grant-error-reason';
+    const staleSubjectId = await seedSubject(t, {
+      primaryDiscordUserId: 'discord-grant-error-reason',
+    });
+    const providerCustomerId = await t.run(async (ctx) => {
+      await ctx.db.delete(staleSubjectId);
+      return await ctx.db.insert('provider_customers', {
+        provider: 'gumroad',
+        providerUserId: 'provider-user-grant-error-reason',
+        status: 'active',
+        lastObservedAt: Date.now(),
+        confidence: 'high',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+    await seedCreatorProfile(t, { authUserId });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(
+      t.mutation(api.entitlements.grantEntitlementsForPurchaser, {
+        apiSecret: 'test-secret',
+        authUserId,
+        subjectId: staleSubjectId,
+        providerCustomerId,
+        products: [
+          {
+            productId: 'gumroad:prod_error_reason',
+            sourceReference: 'order_error_reason',
+          },
+        ],
+      })
+    ).rejects.toThrow('Subject not found');
+
+    const metadata = logSpy.mock.calls.find((call) => call[0] === 'entitlement_grant')?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    expect(metadata).toEqual(
+      expect.objectContaining({
+        event: 'entitlement_grant',
+        provider: 'gumroad',
+        outcome: 'error',
+        reason: 'unexpected_error',
+        authUserIdHash: await sha256Hex(authUserId),
+        subjectIdHash: await sha256Hex(staleSubjectId),
+        productIdHash: await sha256Hex('gumroad:prod_error_reason'),
+      })
+    );
+    expect(JSON.stringify(metadata)).not.toContain('Subject not found');
+  });
+
   it('given wrong apiSecret, when grantEntitlement called, then throws', async () => {
     const t = makeTestConvex();
     const authUserId = 'auth-grant-auth-fail-3';

--- a/convex/entitlements.realtest.ts
+++ b/convex/entitlements.realtest.ts
@@ -11,6 +11,7 @@
  */
 
 import { createApiActorBinding, createServiceApiActor } from '@yucp/shared/apiActor';
+import { sha256Hex } from '@yucp/shared/crypto';
 import { convexTest } from 'convex-test';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { api } from './_generated/api';
@@ -179,18 +180,22 @@ describe('grantEntitlement lifecycle', () => {
     expect(second.entitlementId).toBe(first.entitlementId);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy.mock.calls[0]?.[0]).toBe('entitlement_grant');
-    expect(logSpy.mock.calls[0]?.[1]).toEqual(
+    const metadata = logSpy.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(metadata).toEqual(
       expect.objectContaining({
         event: 'entitlement_grant',
         provider: 'gumroad',
         outcome: 'skipped',
         reason: 'already_active',
-        authUserId,
-        productId,
+        authUserIdHash: await sha256Hex(authUserId),
+        subjectIdHash: await sha256Hex(subjectId),
+        productIdHash: await sha256Hex(productId),
       })
     );
-    expect(logSpy.mock.calls[0]?.[1]).toHaveProperty('subjectId');
-    expect(logSpy.mock.calls[0]?.[1]).toHaveProperty('entitlementId');
+    expect(metadata).not.toHaveProperty('authUserId');
+    expect(metadata).not.toHaveProperty('subjectId');
+    expect(metadata).not.toHaveProperty('productId');
+    expect(metadata).toHaveProperty('entitlementId');
   });
 
   it('given wrong apiSecret, when grantEntitlement called, then throws', async () => {

--- a/convex/entitlements.realtest.ts
+++ b/convex/entitlements.realtest.ts
@@ -12,7 +12,7 @@
 
 import { createApiActorBinding, createServiceApiActor } from '@yucp/shared/apiActor';
 import { convexTest } from 'convex-test';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { api } from './_generated/api';
 import type { Doc } from './_generated/dataModel';
 import schema from './schema';
@@ -70,6 +70,7 @@ describe('grantEntitlement lifecycle', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     delete process.env.CONVEX_API_SECRET;
   });
 
@@ -146,6 +147,50 @@ describe('grantEntitlement lifecycle', () => {
     });
 
     expect(count).toBe(1);
+  });
+
+  it('given same sourceReference, when grant is skipped as idempotent, then logs one structured skipped event', async () => {
+    const t = makeTestConvex();
+    const authUserId = 'auth-grant-idempotent-monitoring';
+    const productId = 'gumroad:prod_monitoring';
+    const sourceReference = 'order_monitoring_ref';
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const subjectId = await seedSubject(t, { primaryDiscordUserId: 'discord-grant-monitoring' });
+    await seedCreatorProfile(t, { authUserId });
+
+    const args = {
+      apiSecret: 'test-secret',
+      authUserId,
+      subjectId,
+      productId,
+      evidence: {
+        provider: 'gumroad' as const,
+        sourceReference,
+      },
+    };
+
+    const first = await t.mutation(api.entitlements.grantEntitlement, args);
+    logSpy.mockClear();
+
+    const second = await t.mutation(api.entitlements.grantEntitlement, args);
+
+    expect(second.isNew).toBe(false);
+    expect(second.entitlementId).toBe(first.entitlementId);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toBe('entitlement_grant');
+    expect(logSpy.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        event: 'entitlement_grant',
+        provider: 'gumroad',
+        outcome: 'skipped',
+        reason: 'already_active',
+        authUserId,
+        productId,
+      })
+    );
+    expect(logSpy.mock.calls[0]?.[1]).toHaveProperty('subjectId');
+    expect(logSpy.mock.calls[0]?.[1]).toHaveProperty('entitlementId');
   });
 
   it('given wrong apiSecret, when grantEntitlement called, then throws', async () => {

--- a/convex/entitlements.ts
+++ b/convex/entitlements.ts
@@ -27,7 +27,9 @@ import {
   requireServiceActor,
 } from './lib/apiActor';
 import { requireApiSecret } from './lib/apiAuth';
+import { createConvexLogger } from './lib/logger';
 import { ProviderV } from './lib/providers';
+import { resolveRoleSyncDiscordUserId } from './lib/roleSyncIdentity';
 import {
   buildRoleRemovalIdempotencyKey,
   buildRoleSyncIdempotencyKey,
@@ -91,6 +93,104 @@ export const RevocationReason = v.union(
 );
 
 type EntitlementReaderCtx = MutationCtx | QueryCtx;
+type EntitlementGrantOutcome = 'granted' | 'skipped' | 'error';
+type EntitlementGrantReason =
+  | 'created'
+  | 'reactivated'
+  | 'active_refreshed'
+  | 'already_active'
+  | 'active_product_exists'
+  | 'source_provider_required'
+  | 'provider_customer_missing'
+  | 'source_provider_missing'
+  | 'error';
+type GrantExistingLookup =
+  | {
+      mode: 'sourceReference';
+      sourceReferences?: string[];
+      matchProduct?: boolean;
+      matchProvider?: boolean;
+    }
+  | {
+      mode: 'activeProduct';
+    };
+type GrantRoleSyncOptions =
+  | {
+      mode: 'none';
+    }
+  | {
+      mode: 'primaryDiscordUserId' | 'roleSyncIdentity';
+      lifecycleAt?: number | 'now';
+      requireDiscordUserId: boolean;
+      missingSubject: 'throw' | 'skip';
+      skipDiscordUserIdPrefixes?: string[];
+      enqueueOnActiveRefresh?: boolean;
+    };
+type GrantAuditOptions = {
+  emitForNew?: boolean;
+  emitForReactivated?: boolean;
+  correlationId?: string;
+};
+type EntitlementEvidenceFunnelArgs = {
+  authUserId: string;
+  subjectId?: Id<'subjects'>;
+  providerKey: Doc<'entitlement_evidence'>['providerKey'];
+  providerConnectionId?: Id<'provider_connections'>;
+  transactionId?: Id<'provider_transactions'>;
+  membershipId?: Id<'provider_memberships'>;
+  licenseId?: Id<'provider_licenses'>;
+  sourceReference: string;
+  evidenceType: string;
+  status: Doc<'entitlement_evidence'>['status'];
+  productId?: string;
+  catalogProductId?: Id<'product_catalog'>;
+  providerTierRefs?: string[];
+  rawWebhookEventId?: Id<'webhook_events'>;
+  metadata?: unknown;
+  observedAt: number;
+  createdAt?: number;
+  updatedAt?: number;
+  lookupFilters?: {
+    authUserId?: boolean;
+    subjectId?: boolean;
+    productId?: boolean;
+    evidenceType?: boolean;
+  };
+  patchEvidenceType?: boolean;
+};
+type GrantEntitlementFunnelArgs = {
+  authUserId: string;
+  subjectId: Id<'subjects'>;
+  subject?: Doc<'subjects'>;
+  productId: string;
+  sourceProvider: Doc<'entitlements'>['sourceProvider'];
+  sourceReference: string;
+  providerCustomerId?: Id<'provider_customers'>;
+  catalogProductId?: Id<'product_catalog'>;
+  licenseSubject?: string;
+  policySnapshotVersion: number;
+  grantedAt?: number;
+  now?: number;
+  existingLookup: GrantExistingLookup;
+  reactivation: {
+    allowTerminal: boolean;
+    refreshExistingFields?: boolean;
+  };
+  roleSync: GrantRoleSyncOptions;
+  audit?: GrantAuditOptions;
+  evidence?: EntitlementEvidenceFunnelArgs;
+};
+type GrantEntitlementFunnelResult = {
+  entitlementId: Id<'entitlements'>;
+  outcome: Exclude<EntitlementGrantOutcome, 'error'>;
+  reason: EntitlementGrantReason;
+  isNew: boolean;
+  previousStatus?: Doc<'entitlements'>['status'];
+  outboxJobIds: Id<'outbox_jobs'>[];
+  evidenceId?: Id<'entitlement_evidence'>;
+};
+
+const entitlementGrantLogger = createConvexLogger();
 
 const EntitlementReadFields = {
   _id: v.id('entitlements'),
@@ -177,6 +277,502 @@ async function requireActiveSubject(
     throw new ConvexError(`Subject is not active: ${subject.status}`);
   }
   return subject;
+}
+
+function logEntitlementGrantAttempt(params: {
+  provider: string;
+  outcome: EntitlementGrantOutcome;
+  reason: string;
+  authUserId: string;
+  subjectId?: Id<'subjects'>;
+  productId?: string;
+  entitlementId?: Id<'entitlements'>;
+}): void {
+  const metadata = {
+    event: 'entitlement_grant',
+    provider: params.provider,
+    outcome: params.outcome,
+    reason: params.reason,
+    authUserId: params.authUserId,
+    subjectId: params.subjectId,
+    productId: params.productId,
+    entitlementId: params.entitlementId,
+  };
+
+  if (params.outcome === 'error') {
+    entitlementGrantLogger.error('entitlement_grant', metadata);
+    return;
+  }
+
+  entitlementGrantLogger.info('entitlement_grant', metadata);
+}
+
+export function recordEntitlementGrantSkipped(params: {
+  provider: string;
+  reason: EntitlementGrantReason | string;
+  authUserId: string;
+  subjectId?: Id<'subjects'>;
+  productId?: string;
+  entitlementId?: Id<'entitlements'>;
+}): void {
+  logEntitlementGrantAttempt({
+    provider: params.provider,
+    outcome: 'skipped',
+    reason: params.reason,
+    authUserId: params.authUserId,
+    subjectId: params.subjectId,
+    productId: params.productId,
+    entitlementId: params.entitlementId,
+  });
+}
+
+function requireSourceProvider(sourceProvider: unknown): string {
+  const provider = typeof sourceProvider === 'string' ? sourceProvider.trim() : '';
+  if (!provider) {
+    throw new ConvexError('source_provider_required');
+  }
+  return provider;
+}
+
+async function findExistingEntitlementInFunnel(
+  ctx: MutationCtx,
+  args: {
+    authUserId: string;
+    subjectId: Id<'subjects'>;
+    productId: string;
+    sourceProvider: string;
+    sourceReference: string;
+    lookup: GrantExistingLookup;
+  }
+): Promise<Doc<'entitlements'> | null> {
+  if (args.lookup.mode === 'activeProduct') {
+    return await ctx.db
+      .query('entitlements')
+      .withIndex('by_auth_user_subject', (q) =>
+        q.eq('authUserId', args.authUserId).eq('subjectId', args.subjectId)
+      )
+      .filter((q) => q.eq(q.field('productId'), args.productId))
+      .filter((q) => q.eq(q.field('status'), 'active'))
+      .first();
+  }
+
+  const sourceReferences = args.lookup.sourceReferences ?? [args.sourceReference];
+  for (const sourceReference of sourceReferences) {
+    let query = ctx.db
+      .query('entitlements')
+      .withIndex('by_auth_user_subject', (q) =>
+        q.eq('authUserId', args.authUserId).eq('subjectId', args.subjectId)
+      )
+      .filter((q) => q.eq(q.field('sourceReference'), sourceReference));
+
+    if (args.lookup.matchProduct) {
+      query = query.filter((q) => q.eq(q.field('productId'), args.productId));
+    }
+    if (args.lookup.matchProvider) {
+      query = query.filter((q) => q.eq(q.field('sourceProvider'), args.sourceProvider));
+    }
+
+    const entitlement = await query.first();
+    if (entitlement) {
+      return entitlement;
+    }
+  }
+
+  return null;
+}
+
+function buildExistingEntitlementRefreshPatch(
+  existingEntitlement: Doc<'entitlements'>,
+  args: GrantEntitlementFunnelArgs
+): Partial<Doc<'entitlements'>> {
+  if (!args.reactivation.refreshExistingFields) {
+    return {};
+  }
+
+  const refreshPatch: Partial<Doc<'entitlements'>> = {};
+  if (existingEntitlement.sourceReference !== args.sourceReference) {
+    refreshPatch.sourceReference = args.sourceReference;
+  }
+  if (args.licenseSubject && !existingEntitlement.licenseSubject) {
+    refreshPatch.licenseSubject = args.licenseSubject;
+  }
+  if (
+    args.providerCustomerId &&
+    existingEntitlement.providerCustomerId !== args.providerCustomerId
+  ) {
+    refreshPatch.providerCustomerId = args.providerCustomerId;
+  }
+  if (args.catalogProductId && existingEntitlement.catalogProductId !== args.catalogProductId) {
+    refreshPatch.catalogProductId = args.catalogProductId;
+  }
+
+  return refreshPatch;
+}
+
+function resolveGrantRoleSyncLifecycleAt(
+  roleSync: GrantRoleSyncOptions,
+  now: number
+): number | undefined {
+  if (roleSync.mode === 'none') {
+    return undefined;
+  }
+  return roleSync.lifecycleAt === 'now' ? now : roleSync.lifecycleAt;
+}
+
+async function enqueueGrantRoleSyncFromFunnel(
+  ctx: MutationCtx,
+  args: {
+    authUserId: string;
+    subjectId: Id<'subjects'>;
+    entitlementId: Id<'entitlements'>;
+    subject?: Doc<'subjects'>;
+    roleSync: GrantRoleSyncOptions;
+    now: number;
+  }
+): Promise<Id<'outbox_jobs'> | undefined> {
+  if (args.roleSync.mode === 'none') {
+    return undefined;
+  }
+
+  const subject = args.subject ?? (await ctx.db.get(args.subjectId));
+  if (!subject && args.roleSync.missingSubject === 'throw') {
+    throw new Error(`Subject not found: ${args.subjectId}`);
+  }
+
+  let discordUserId =
+    args.roleSync.mode === 'roleSyncIdentity'
+      ? resolveRoleSyncDiscordUserId(subject ?? {})
+      : subject?.primaryDiscordUserId;
+
+  if (
+    discordUserId &&
+    args.roleSync.skipDiscordUserIdPrefixes?.some((prefix) => discordUserId?.startsWith(prefix))
+  ) {
+    discordUserId = undefined;
+  }
+
+  if (!discordUserId && args.roleSync.requireDiscordUserId) {
+    return undefined;
+  }
+
+  const lifecycleAt = resolveGrantRoleSyncLifecycleAt(args.roleSync, args.now);
+  return await enqueueRoleSync(ctx, {
+    authUserId: args.authUserId,
+    subjectId: args.subjectId,
+    entitlementId: args.entitlementId,
+    discordUserId,
+    idempotencyKey: buildRoleSyncIdempotencyKey({
+      authUserId: args.authUserId,
+      subjectId: args.subjectId,
+      entitlementId: args.entitlementId,
+      ...(lifecycleAt !== undefined ? { lifecycle: { kind: 'grant', at: lifecycleAt } } : {}),
+    }),
+  });
+}
+
+export async function upsertEntitlementEvidenceFromFunnel(
+  ctx: MutationCtx,
+  args: EntitlementEvidenceFunnelArgs
+): Promise<Id<'entitlement_evidence'>> {
+  let query = ctx.db
+    .query('entitlement_evidence')
+    .withIndex('by_source_reference', (q) =>
+      q.eq('providerKey', args.providerKey).eq('sourceReference', args.sourceReference)
+    );
+
+  if (args.lookupFilters?.authUserId) {
+    query = query.filter((q) => q.eq(q.field('authUserId'), args.authUserId));
+  }
+  if (args.lookupFilters?.subjectId) {
+    query = query.filter((q) => q.eq(q.field('subjectId'), args.subjectId));
+  }
+  if (args.lookupFilters?.productId) {
+    query = query.filter((q) => q.eq(q.field('productId'), args.productId));
+  }
+  if (args.lookupFilters?.evidenceType) {
+    query = query.filter((q) => q.eq(q.field('evidenceType'), args.evidenceType));
+  }
+
+  const existing = await query.first();
+  const now = Date.now();
+  const updatedAt = args.updatedAt ?? now;
+
+  if (existing) {
+    await ctx.db.patch(existing._id, {
+      subjectId: args.subjectId ?? existing.subjectId,
+      providerConnectionId: args.providerConnectionId ?? existing.providerConnectionId,
+      transactionId: args.transactionId ?? existing.transactionId,
+      membershipId: args.membershipId ?? existing.membershipId,
+      licenseId: args.licenseId ?? existing.licenseId,
+      ...(args.patchEvidenceType ? { evidenceType: args.evidenceType } : {}),
+      status: args.status,
+      productId: args.productId ?? existing.productId,
+      catalogProductId: args.catalogProductId ?? existing.catalogProductId,
+      providerTierRefs: args.providerTierRefs ?? existing.providerTierRefs,
+      rawWebhookEventId: args.rawWebhookEventId ?? existing.rawWebhookEventId,
+      metadata: args.metadata ?? existing.metadata,
+      observedAt: args.observedAt,
+      updatedAt,
+    });
+    return existing._id;
+  }
+
+  return await ctx.db.insert('entitlement_evidence', {
+    authUserId: args.authUserId,
+    subjectId: args.subjectId,
+    providerKey: args.providerKey,
+    providerConnectionId: args.providerConnectionId,
+    transactionId: args.transactionId,
+    membershipId: args.membershipId,
+    licenseId: args.licenseId,
+    sourceReference: args.sourceReference,
+    evidenceType: args.evidenceType,
+    status: args.status,
+    productId: args.productId,
+    catalogProductId: args.catalogProductId,
+    providerTierRefs: args.providerTierRefs,
+    rawWebhookEventId: args.rawWebhookEventId,
+    metadata: args.metadata,
+    observedAt: args.observedAt,
+    createdAt: args.createdAt ?? now,
+    updatedAt,
+  });
+}
+
+export async function grantEntitlementFromFunnel(
+  ctx: MutationCtx,
+  args: GrantEntitlementFunnelArgs
+): Promise<GrantEntitlementFunnelResult> {
+  const now = args.now ?? Date.now();
+  let provider = args.sourceProvider;
+
+  try {
+    provider = requireSourceProvider(args.sourceProvider);
+    const existingEntitlement = await findExistingEntitlementInFunnel(ctx, {
+      authUserId: args.authUserId,
+      subjectId: args.subjectId,
+      productId: args.productId,
+      sourceProvider: provider,
+      sourceReference: args.sourceReference,
+      lookup: args.existingLookup,
+    });
+
+    if (existingEntitlement) {
+      const outboxJobIds: Id<'outbox_jobs'>[] = [];
+      const previousStatus = existingEntitlement.status;
+      const refreshPatch = buildExistingEntitlementRefreshPatch(existingEntitlement, args);
+      const hasRefreshPatch = Object.keys(refreshPatch).length > 0;
+      let evidenceId: Id<'entitlement_evidence'> | undefined;
+
+      if (
+        isEntitlementActive(existingEntitlement.status as Parameters<typeof isEntitlementActive>[0])
+      ) {
+        if (hasRefreshPatch) {
+          await ctx.db.patch(existingEntitlement._id, {
+            ...refreshPatch,
+            updatedAt: now,
+          });
+        }
+
+        if (args.evidence) {
+          evidenceId = await upsertEntitlementEvidenceFromFunnel(ctx, args.evidence);
+        }
+
+        const shouldEnqueueRoleSync =
+          args.roleSync.mode !== 'none' &&
+          (hasRefreshPatch || args.roleSync.enqueueOnActiveRefresh === true);
+        if (shouldEnqueueRoleSync) {
+          const outboxJobId = await enqueueGrantRoleSyncFromFunnel(ctx, {
+            authUserId: args.authUserId,
+            subjectId: args.subjectId,
+            entitlementId: existingEntitlement._id,
+            subject: args.subject,
+            roleSync: args.roleSync,
+            now,
+          });
+          if (outboxJobId) {
+            outboxJobIds.push(outboxJobId);
+          }
+        }
+
+        const reason =
+          args.existingLookup.mode === 'activeProduct'
+            ? 'active_product_exists'
+            : hasRefreshPatch || outboxJobIds.length > 0
+              ? 'active_refreshed'
+              : 'already_active';
+        const outcome = reason === 'active_refreshed' ? 'granted' : 'skipped';
+        logEntitlementGrantAttempt({
+          provider,
+          outcome,
+          reason,
+          authUserId: args.authUserId,
+          subjectId: args.subjectId,
+          productId: args.productId,
+          entitlementId: existingEntitlement._id,
+        });
+
+        return {
+          entitlementId: existingEntitlement._id,
+          outcome,
+          reason,
+          isNew: false,
+          previousStatus: undefined,
+          outboxJobIds,
+          evidenceId,
+        };
+      }
+
+      if (!args.reactivation.allowTerminal) {
+        if (!canReactivate(existingEntitlement.status as Parameters<typeof canReactivate>[0])) {
+          throw new ConvexError('Cannot reactivate a refunded or disputed entitlement');
+        }
+      }
+
+      await ctx.db.patch(existingEntitlement._id, {
+        ...refreshPatch,
+        status: 'active',
+        revokedAt: undefined,
+        updatedAt: now,
+        ...(args.reactivation.refreshExistingFields
+          ? { licenseSubject: args.licenseSubject ?? existingEntitlement.licenseSubject }
+          : {}),
+      });
+
+      const outboxJobId = await enqueueGrantRoleSyncFromFunnel(ctx, {
+        authUserId: args.authUserId,
+        subjectId: args.subjectId,
+        entitlementId: existingEntitlement._id,
+        subject: args.subject,
+        roleSync: args.roleSync,
+        now,
+      });
+      if (outboxJobId) {
+        outboxJobIds.push(outboxJobId);
+      }
+
+      if (args.audit?.emitForReactivated) {
+        await createAuditEvent(ctx, {
+          authUserId: args.authUserId,
+          eventType: 'entitlement.granted',
+          subjectId: args.subjectId,
+          entitlementId: existingEntitlement._id,
+          metadata: {
+            productId: args.productId,
+            sourceProvider: provider,
+            sourceReference: args.sourceReference,
+            reactivated: true,
+            previousStatus,
+          },
+          correlationId: args.audit.correlationId,
+        });
+      }
+
+      if (args.evidence) {
+        evidenceId = await upsertEntitlementEvidenceFromFunnel(ctx, args.evidence);
+      }
+
+      logEntitlementGrantAttempt({
+        provider,
+        outcome: 'granted',
+        reason: 'reactivated',
+        authUserId: args.authUserId,
+        subjectId: args.subjectId,
+        productId: args.productId,
+        entitlementId: existingEntitlement._id,
+      });
+
+      return {
+        entitlementId: existingEntitlement._id,
+        outcome: 'granted',
+        reason: 'reactivated',
+        isNew: false,
+        previousStatus,
+        outboxJobIds,
+        evidenceId,
+      };
+    }
+
+    const entitlementId = await ctx.db.insert('entitlements', {
+      authUserId: args.authUserId,
+      subjectId: args.subjectId,
+      productId: args.productId,
+      sourceProvider: provider,
+      sourceReference: args.sourceReference,
+      licenseSubject: args.licenseSubject,
+      providerCustomerId: args.providerCustomerId,
+      catalogProductId: args.catalogProductId,
+      status: 'active',
+      policySnapshotVersion: args.policySnapshotVersion,
+      grantedAt: args.grantedAt ?? now,
+      updatedAt: now,
+    });
+
+    const outboxJobIds: Id<'outbox_jobs'>[] = [];
+    const outboxJobId = await enqueueGrantRoleSyncFromFunnel(ctx, {
+      authUserId: args.authUserId,
+      subjectId: args.subjectId,
+      entitlementId,
+      subject: args.subject,
+      roleSync: args.roleSync,
+      now,
+    });
+    if (outboxJobId) {
+      outboxJobIds.push(outboxJobId);
+    }
+
+    if (args.audit?.emitForNew) {
+      await createAuditEvent(ctx, {
+        authUserId: args.authUserId,
+        eventType: 'entitlement.granted',
+        subjectId: args.subjectId,
+        entitlementId,
+        metadata: {
+          productId: args.productId,
+          sourceProvider: provider,
+          sourceReference: args.sourceReference,
+          policySnapshotVersion: args.policySnapshotVersion,
+          catalogProductId: args.catalogProductId,
+        },
+        correlationId: args.audit.correlationId,
+      });
+    }
+
+    const evidenceId = args.evidence
+      ? await upsertEntitlementEvidenceFromFunnel(ctx, args.evidence)
+      : undefined;
+
+    logEntitlementGrantAttempt({
+      provider,
+      outcome: 'granted',
+      reason: 'created',
+      authUserId: args.authUserId,
+      subjectId: args.subjectId,
+      productId: args.productId,
+      entitlementId,
+    });
+
+    return {
+      entitlementId,
+      outcome: 'granted',
+      reason: 'created',
+      isNew: true,
+      previousStatus: undefined,
+      outboxJobIds,
+      evidenceId,
+    };
+  } catch (err) {
+    const reason = err instanceof ConvexError ? String(err.data) : err instanceof Error ? err.message : 'error';
+    logEntitlementGrantAttempt({
+      provider,
+      outcome: 'error',
+      reason,
+      authUserId: args.authUserId,
+      subjectId: args.subjectId,
+      productId: args.productId,
+    });
+    throw err;
+  }
 }
 
 async function listActiveEntitlementsForActiveSubjects(
@@ -637,7 +1233,7 @@ export const grantEntitlement = mutation({
     requireApiSecret(args.apiSecret);
     await requireDelegatedAuthUserActor(args.actor, args.authUserId);
     const now = Date.now();
-    await requireActiveSubject(ctx, args.subjectId);
+    const subject = await requireActiveSubject(ctx, args.subjectId);
 
     // Validate purchasedAt timestamp if provided
     if (args.evidence.purchasedAt !== undefined) {
@@ -661,129 +1257,40 @@ export const grantEntitlement = mutation({
       throw new Error(`Creator profile not found: ${args.authUserId}`);
     }
 
-    // Check for existing entitlement with same sourceReference (idempotency)
-    const existingEntitlement = await ctx.db
-      .query('entitlements')
-      .withIndex('by_auth_user_subject', (q) =>
-        q.eq('authUserId', args.authUserId).eq('subjectId', args.subjectId)
-      )
-      .filter((q) => q.eq(q.field('sourceReference'), args.evidence.sourceReference))
-      .first();
-
-    if (existingEntitlement) {
-      // Entitlement already exists - check if we need to reactivate
-      if (
-        isEntitlementActive(existingEntitlement.status as Parameters<typeof isEntitlementActive>[0])
-      ) {
-        // Already active, nothing to do
-        return {
-          success: true,
-          entitlementId: existingEntitlement._id,
-          isNew: false,
-          previousStatus: undefined,
-          outboxJobId: undefined,
-        };
-      }
-
-      // Block reactivation of terminal statuses (refunded/disputed)
-      if (!canReactivate(existingEntitlement.status as Parameters<typeof canReactivate>[0])) {
-        throw new ConvexError('Cannot reactivate a refunded or disputed entitlement');
-      }
-
-      // Reactivate a revoked/expired entitlement
-      const previousStatus = existingEntitlement.status;
-      await ctx.db.patch(existingEntitlement._id, {
-        status: 'active',
-        revokedAt: undefined,
-        updatedAt: now,
-      });
-
-      // Emit role sync job
-      const outboxJobId = await emitRoleSyncJob(
-        ctx,
-        args.authUserId,
-        args.subjectId,
-        existingEntitlement._id,
-        args.correlationId,
-        now
-      );
-
-      // Create audit event
-      await createAuditEvent(ctx, {
-        authUserId: args.authUserId,
-        eventType: 'entitlement.granted',
-        subjectId: args.subjectId,
-        entitlementId: existingEntitlement._id,
-        metadata: {
-          productId: args.productId,
-          sourceProvider: args.evidence.provider,
-          sourceReference: args.evidence.sourceReference,
-          reactivated: true,
-          previousStatus,
-        },
-        correlationId: args.correlationId,
-      });
-
-      return {
-        success: true,
-        entitlementId: existingEntitlement._id,
-        isNew: false,
-        previousStatus,
-        outboxJobId,
-      };
-    }
-
-    // Calculate policy snapshot version
-    // Use a simple counter based on tenant policy updates
     const policySnapshotVersion = await getPolicySnapshotVersion(ctx, args.authUserId);
-
-    // Create new entitlement
-    const entitlementId = await ctx.db.insert('entitlements', {
+    const grantResult = await grantEntitlementFromFunnel(ctx, {
       authUserId: args.authUserId,
       subjectId: args.subjectId,
+      subject,
       productId: args.productId,
       sourceProvider: args.evidence.provider,
       sourceReference: args.evidence.sourceReference,
       providerCustomerId: args.evidence.providerCustomerId,
       catalogProductId: args.catalogProductId,
-      status: 'active',
       policySnapshotVersion,
       grantedAt: args.evidence.purchasedAt ?? now,
-      updatedAt: now,
-    });
-
-    // Emit role sync job
-    const outboxJobId = await emitRoleSyncJob(
-      ctx,
-      args.authUserId,
-      args.subjectId,
-      entitlementId,
-      args.correlationId,
-      now
-    );
-
-    // Create audit event
-    await createAuditEvent(ctx, {
-      authUserId: args.authUserId,
-      eventType: 'entitlement.granted',
-      subjectId: args.subjectId,
-      entitlementId,
-      metadata: {
-        productId: args.productId,
-        sourceProvider: args.evidence.provider,
-        sourceReference: args.evidence.sourceReference,
-        policySnapshotVersion,
-        catalogProductId: args.catalogProductId,
+      now,
+      existingLookup: { mode: 'sourceReference' },
+      reactivation: { allowTerminal: false },
+      roleSync: {
+        mode: 'primaryDiscordUserId',
+        lifecycleAt: now,
+        requireDiscordUserId: false,
+        missingSubject: 'throw',
       },
-      correlationId: args.correlationId,
+      audit: {
+        emitForNew: true,
+        emitForReactivated: true,
+        correlationId: args.correlationId,
+      },
     });
 
     return {
       success: true,
-      entitlementId,
-      isNew: true,
-      previousStatus: undefined,
-      outboxJobId,
+      entitlementId: grantResult.entitlementId,
+      isNew: grantResult.isNew,
+      previousStatus: grantResult.previousStatus,
+      outboxJobId: grantResult.outboxJobIds[0],
     };
   },
 });
@@ -1285,50 +1792,60 @@ export const grantEntitlementsForPurchaser = mutation({
 
     // Resolve the actual provider from the provider_customer record
     const providerCustomerDoc = await ctx.db.get(args.providerCustomerId);
+    const sourceProvider = providerCustomerDoc?.provider?.trim();
 
     for (const product of args.products) {
-      // Check for existing entitlement
-      const existing = await ctx.db
-        .query('entitlements')
-        .withIndex('by_auth_user_subject', (q) =>
-          q.eq('authUserId', args.authUserId).eq('subjectId', args.subjectId)
-        )
-        .filter((q) => q.eq(q.field('productId'), product.productId))
-        .filter((q) => q.eq(q.field('status'), 'active'))
-        .first();
-
-      if (existing) {
+      if (!providerCustomerDoc) {
+        recordEntitlementGrantSkipped({
+          provider: '',
+          reason: 'provider_customer_missing',
+          authUserId: args.authUserId,
+          subjectId: args.subjectId,
+          productId: product.productId,
+        });
+        skippedCount++;
+        continue;
+      }
+      if (!sourceProvider) {
+        recordEntitlementGrantSkipped({
+          provider: '',
+          reason: 'source_provider_missing',
+          authUserId: args.authUserId,
+          subjectId: args.subjectId,
+          productId: product.productId,
+        });
         skippedCount++;
         continue;
       }
 
-      // Create entitlement
-      const entitlementId = await ctx.db.insert('entitlements', {
+      const grantResult = await grantEntitlementFromFunnel(ctx, {
         authUserId: args.authUserId,
         subjectId: args.subjectId,
         productId: product.productId,
-        sourceProvider: providerCustomerDoc?.provider ?? 'gumroad',
+        sourceProvider,
         sourceReference: product.sourceReference,
         providerCustomerId: args.providerCustomerId,
         catalogProductId: product.catalogProductId,
-        status: 'active',
         policySnapshotVersion,
         grantedAt: product.purchasedAt ?? now,
-        updatedAt: now,
+        now,
+        existingLookup: { mode: 'activeProduct' },
+        reactivation: { allowTerminal: true },
+        roleSync: {
+          mode: 'primaryDiscordUserId',
+          lifecycleAt: now,
+          requireDiscordUserId: false,
+          missingSubject: 'throw',
+        },
       });
 
-      entitlementIds.push(entitlementId);
-      grantedCount++;
+      if (grantResult.outcome === 'skipped') {
+        skippedCount++;
+        continue;
+      }
 
-      // Emit role sync job for each
-      await emitRoleSyncJob(
-        ctx,
-        args.authUserId,
-        args.subjectId,
-        entitlementId,
-        args.correlationId,
-        now
-      );
+      entitlementIds.push(grantResult.entitlementId);
+      grantedCount++;
     }
 
     // Create single audit event for batch

--- a/convex/entitlements.ts
+++ b/convex/entitlements.ts
@@ -1251,6 +1251,13 @@ export const grantEntitlement = mutation({
       if (args.evidence.amount > 999999.99)
         throw new ConvexError('amount exceeds maximum allowed value');
     }
+    const evidenceMetadata =
+      args.evidence.amount !== undefined || args.evidence.currency !== undefined
+        ? {
+            amount: args.evidence.amount,
+            currency: args.evidence.currency,
+          }
+        : undefined;
 
     // Get creator profile for policy snapshot
     const profile = await ctx.db
@@ -1281,6 +1288,26 @@ export const grantEntitlement = mutation({
         lifecycleAt: now,
         requireDiscordUserId: false,
         missingSubject: 'throw',
+      },
+      evidence: {
+        authUserId: args.authUserId,
+        subjectId: args.subjectId,
+        providerKey: args.evidence.provider,
+        sourceReference: args.evidence.sourceReference,
+        evidenceType: 'provider_evidence',
+        status: 'active',
+        productId: args.productId,
+        catalogProductId: args.catalogProductId,
+        metadata: evidenceMetadata,
+        observedAt: args.evidence.purchasedAt ?? now,
+        createdAt: now,
+        updatedAt: now,
+        lookupFilters: {
+          authUserId: true,
+          subjectId: true,
+          productId: true,
+          evidenceType: true,
+        },
       },
       audit: {
         emitForNew: true,

--- a/convex/entitlements.ts
+++ b/convex/entitlements.ts
@@ -763,7 +763,8 @@ export async function grantEntitlementFromFunnel(
       evidenceId,
     };
   } catch (err) {
-    const reason = err instanceof ConvexError ? String(err.data) : err instanceof Error ? err.message : 'error';
+    const reason =
+      err instanceof ConvexError && typeof err.data === 'string' ? err.data : 'unexpected_error';
     await logEntitlementGrantAttempt({
       provider,
       outcome: 'error',

--- a/convex/entitlements.ts
+++ b/convex/entitlements.ts
@@ -17,6 +17,7 @@ import {
   isEntitlementActive,
   mapReasonToStatus,
 } from '@yucp/shared/entitlement/service';
+import { sha256Hex } from '@yucp/shared/crypto';
 import { ConvexError, v } from 'convex/values';
 import type { Doc, Id } from './_generated/dataModel';
 import type { MutationCtx, QueryCtx } from './_generated/server';
@@ -279,7 +280,7 @@ async function requireActiveSubject(
   return subject;
 }
 
-function logEntitlementGrantAttempt(params: {
+async function logEntitlementGrantAttempt(params: {
   provider: string;
   outcome: EntitlementGrantOutcome;
   reason: string;
@@ -287,15 +288,15 @@ function logEntitlementGrantAttempt(params: {
   subjectId?: Id<'subjects'>;
   productId?: string;
   entitlementId?: Id<'entitlements'>;
-}): void {
+}): Promise<void> {
   const metadata = {
     event: 'entitlement_grant',
     provider: params.provider,
     outcome: params.outcome,
     reason: params.reason,
-    authUserId: params.authUserId,
-    subjectId: params.subjectId,
-    productId: params.productId,
+    authUserIdHash: await sha256Hex(params.authUserId),
+    subjectIdHash: params.subjectId ? await sha256Hex(params.subjectId) : undefined,
+    productIdHash: params.productId ? await sha256Hex(params.productId) : undefined,
     entitlementId: params.entitlementId,
   };
 
@@ -307,15 +308,15 @@ function logEntitlementGrantAttempt(params: {
   entitlementGrantLogger.info('entitlement_grant', metadata);
 }
 
-export function recordEntitlementGrantSkipped(params: {
+export async function recordEntitlementGrantSkipped(params: {
   provider: string;
   reason: EntitlementGrantReason | string;
   authUserId: string;
   subjectId?: Id<'subjects'>;
   productId?: string;
   entitlementId?: Id<'entitlements'>;
-}): void {
-  logEntitlementGrantAttempt({
+}): Promise<void> {
+  await logEntitlementGrantAttempt({
     provider: params.provider,
     outcome: 'skipped',
     reason: params.reason,
@@ -602,7 +603,7 @@ export async function grantEntitlementFromFunnel(
               ? 'active_refreshed'
               : 'already_active';
         const outcome = reason === 'active_refreshed' ? 'granted' : 'skipped';
-        logEntitlementGrantAttempt({
+        await logEntitlementGrantAttempt({
           provider,
           outcome,
           reason,
@@ -672,7 +673,7 @@ export async function grantEntitlementFromFunnel(
         evidenceId = await upsertEntitlementEvidenceFromFunnel(ctx, args.evidence);
       }
 
-      logEntitlementGrantAttempt({
+      await logEntitlementGrantAttempt({
         provider,
         outcome: 'granted',
         reason: 'reactivated',
@@ -742,7 +743,7 @@ export async function grantEntitlementFromFunnel(
       ? await upsertEntitlementEvidenceFromFunnel(ctx, args.evidence)
       : undefined;
 
-    logEntitlementGrantAttempt({
+    await logEntitlementGrantAttempt({
       provider,
       outcome: 'granted',
       reason: 'created',
@@ -763,7 +764,7 @@ export async function grantEntitlementFromFunnel(
     };
   } catch (err) {
     const reason = err instanceof ConvexError ? String(err.data) : err instanceof Error ? err.message : 'error';
-    logEntitlementGrantAttempt({
+    await logEntitlementGrantAttempt({
       provider,
       outcome: 'error',
       reason,
@@ -1796,7 +1797,7 @@ export const grantEntitlementsForPurchaser = mutation({
 
     for (const product of args.products) {
       if (!providerCustomerDoc) {
-        recordEntitlementGrantSkipped({
+        await recordEntitlementGrantSkipped({
           provider: '',
           reason: 'provider_customer_missing',
           authUserId: args.authUserId,
@@ -1807,7 +1808,7 @@ export const grantEntitlementsForPurchaser = mutation({
         continue;
       }
       if (!sourceProvider) {
-        recordEntitlementGrantSkipped({
+        await recordEntitlementGrantSkipped({
           provider: '',
           reason: 'source_provider_missing',
           authUserId: args.authUserId,

--- a/convex/entitlements.ts
+++ b/convex/entitlements.ts
@@ -297,7 +297,9 @@ async function logEntitlementGrantAttempt(params: {
     authUserIdHash: await sha256Hex(params.authUserId),
     subjectIdHash: params.subjectId ? await sha256Hex(params.subjectId) : undefined,
     productIdHash: params.productId ? await sha256Hex(params.productId) : undefined,
-    entitlementId: params.entitlementId,
+    ...(params.reason === 'created' && params.entitlementId
+      ? { entitlementId: params.entitlementId }
+      : {}),
   };
 
   if (params.outcome === 'error') {

--- a/convex/licenseVerification.ts
+++ b/convex/licenseVerification.ts
@@ -443,15 +443,16 @@ export const completeLicenseVerification = mutation({
 
     const entitlementIds: Id<'entitlements'>[] = [];
     const outboxJobIds: Id<'outbox_jobs'>[] = [];
+    const existingEntitlements = await ctx.db
+      .query('entitlements')
+      .withIndex('by_auth_user_subject', (q) =>
+        q.eq('authUserId', creatorAuthUserId).eq('subjectId', buyerSubjectId)
+      )
+      .collect();
+    let nextPolicySnapshotVersion = existingEntitlements.length + 1;
 
     for (const product of args.productsToGrant) {
-      const existingEntitlements = await ctx.db
-        .query('entitlements')
-        .withIndex('by_auth_user_subject', (q) =>
-          q.eq('authUserId', creatorAuthUserId).eq('subjectId', buyerSubjectId)
-        )
-        .collect();
-      const policySnapshotVersion = existingEntitlements.length + 1;
+      const policySnapshotVersion = nextPolicySnapshotVersion;
       const providerTierRefs = normalizeProviderTierRefs(product.providerTierRefs);
       const grantResult = await grantEntitlementFromFunnel(ctx, {
         authUserId: creatorAuthUserId,
@@ -512,6 +513,9 @@ export const completeLicenseVerification = mutation({
       });
 
       entitlementIds.push(grantResult.entitlementId);
+      if (grantResult.isNew) {
+        nextPolicySnapshotVersion++;
+      }
       outboxJobIds.push(...grantResult.outboxJobIds);
     }
 

--- a/convex/licenseVerification.ts
+++ b/convex/licenseVerification.ts
@@ -13,16 +13,14 @@
  * 5. Enqueue outbox jobs for role sync
  */
 
-import { canReactivate } from '@yucp/shared/entitlement/service';
 import { ConvexError, v } from 'convex/values';
 import type { Doc, Id } from './_generated/dataModel';
 import type { MutationCtx } from './_generated/server';
 import { mutation } from './_generated/server';
+import { grantEntitlementFromFunnel } from './entitlements';
 import { requireApiSecret } from './lib/apiAuth';
 import { upsertLicenseSubjectLink } from './lib/licenseSubjectLink';
 import { LicenseProviderV } from './lib/providers';
-import { resolveRoleSyncDiscordUserId } from './lib/roleSyncIdentity';
-import { buildRoleSyncIdempotencyKey, enqueueRoleSync } from './lib/roleSyncEnqueue';
 import { upsertBuyerProviderLinkRecord } from './subjects';
 
 // ============================================================================
@@ -198,61 +196,6 @@ async function findExistingEntitlementForGrant(
   }
 
   return null;
-}
-
-async function upsertLicenseVerificationEntitlementEvidence(
-  ctx: Pick<MutationCtx, 'db'>,
-  args: {
-    authUserId: string;
-    subjectId: Id<'subjects'>;
-    provider: Doc<'entitlements'>['sourceProvider'];
-    productId: string;
-    catalogProductId?: Id<'product_catalog'>;
-    sourceReference: string;
-    providerTierRefs?: string[];
-    observedAt: number;
-  }
-): Promise<Id<'entitlement_evidence'>> {
-  const providerTierRefs = normalizeProviderTierRefs(args.providerTierRefs);
-  const existing = await ctx.db
-    .query('entitlement_evidence')
-    .withIndex('by_source_reference', (q) =>
-      q.eq('providerKey', args.provider).eq('sourceReference', args.sourceReference)
-    )
-    .filter((q) => q.eq(q.field('authUserId'), args.authUserId))
-    .filter((q) => q.eq(q.field('subjectId'), args.subjectId))
-    .filter((q) => q.eq(q.field('productId'), args.productId))
-    .filter((q) => q.eq(q.field('evidenceType'), 'license_verification'))
-    .first();
-
-  if (existing) {
-    await ctx.db.patch(existing._id, {
-      subjectId: args.subjectId,
-      evidenceType: 'license_verification',
-      status: 'active',
-      productId: args.productId,
-      catalogProductId: args.catalogProductId ?? existing.catalogProductId,
-      providerTierRefs: providerTierRefs ?? existing.providerTierRefs,
-      observedAt: args.observedAt,
-      updatedAt: args.observedAt,
-    });
-    return existing._id;
-  }
-
-  return await ctx.db.insert('entitlement_evidence', {
-    authUserId: args.authUserId,
-    subjectId: args.subjectId,
-    providerKey: args.provider,
-    sourceReference: args.sourceReference,
-    evidenceType: 'license_verification',
-    status: 'active',
-    productId: args.productId,
-    catalogProductId: args.catalogProductId,
-    providerTierRefs,
-    observedAt: args.observedAt,
-    createdAt: args.observedAt,
-    updatedAt: args.observedAt,
-  });
 }
 
 /**
@@ -502,170 +445,74 @@ export const completeLicenseVerification = mutation({
     const outboxJobIds: Id<'outbox_jobs'>[] = [];
 
     for (const product of args.productsToGrant) {
-      // Check for existing entitlement (idempotency)
-      const existingEntitlement = await findExistingEntitlementForGrant(ctx, {
+      const existingEntitlements = await ctx.db
+        .query('entitlements')
+        .withIndex('by_auth_user_subject', (q) =>
+          q.eq('authUserId', creatorAuthUserId).eq('subjectId', buyerSubjectId)
+        )
+        .collect();
+      const policySnapshotVersion = existingEntitlements.length + 1;
+      const providerTierRefs = normalizeProviderTierRefs(product.providerTierRefs);
+      const grantResult = await grantEntitlementFromFunnel(ctx, {
         authUserId: creatorAuthUserId,
         subjectId: buyerSubjectId,
-        provider: args.provider,
+        subject,
         productId: product.productId,
-        sourceReferences: sourceReferencesForGrantIdentity(args.provider, product.sourceReference),
-      });
-
-      let entitlementId: Id<'entitlements'>;
-      let shouldEnqueueActiveRefreshRoleSync = false;
-      if (existingEntitlement) {
-        entitlementId = existingEntitlement._id;
-        const refreshPatch: {
-          sourceReference?: string;
-          licenseSubject?: string;
-          providerCustomerId?: Id<'provider_customers'>;
-          catalogProductId?: Id<'product_catalog'>;
-        } = {};
-        if (existingEntitlement.sourceReference !== product.sourceReference) {
-          refreshPatch.sourceReference = product.sourceReference;
-        }
-        if (args.licenseSubjectLink?.licenseSubject && !existingEntitlement.licenseSubject) {
-          refreshPatch.licenseSubject = args.licenseSubjectLink.licenseSubject;
-        }
-        if (providerCustomerId && existingEntitlement.providerCustomerId !== providerCustomerId) {
-          refreshPatch.providerCustomerId = providerCustomerId;
-        }
-        if (product.catalogProductId && existingEntitlement.catalogProductId !== product.catalogProductId) {
-          refreshPatch.catalogProductId = product.catalogProductId;
-        }
-        const hasRefreshPatch = Object.keys(refreshPatch).length > 0;
-        const hasTierEvidenceRefresh = normalizeProviderTierRefs(product.providerTierRefs) !== undefined;
-
-        if (existingEntitlement.status !== 'active') {
-          if (!canReactivate(existingEntitlement.status as Parameters<typeof canReactivate>[0])) {
-            throw new ConvexError('Cannot reactivate a refunded or disputed entitlement');
-          }
-          await ctx.db.patch(entitlementId, {
-            ...refreshPatch,
-            status: 'active',
-            revokedAt: undefined,
-            updatedAt: now,
-            // Backfill the canonical license subject if this grant carries one and the
-            // existing row predates the field, so forensics can resolve the license.
-            licenseSubject:
-              args.licenseSubjectLink?.licenseSubject ?? existingEntitlement.licenseSubject,
-          });
-          // Emit role sync for reactivated entitlement
-          const discordUserId = resolveRoleSyncDiscordUserId(subject);
-          if (discordUserId) {
-            const jobId = await enqueueRoleSync(ctx, {
-              authUserId: creatorAuthUserId,
-              subjectId: buyerSubjectId,
-              entitlementId,
-              discordUserId,
-              idempotencyKey: buildRoleSyncIdempotencyKey({
-                authUserId: creatorAuthUserId,
-                subjectId: buyerSubjectId,
-                entitlementId,
-                lifecycle: { kind: 'grant', at: now },
-              }),
-            });
-            outboxJobIds.push(jobId);
-          }
-        } else {
-          if (hasRefreshPatch) {
-            await ctx.db.patch(entitlementId, {
-              ...refreshPatch,
-              updatedAt: now,
-            });
-          }
-          shouldEnqueueActiveRefreshRoleSync = hasRefreshPatch || hasTierEvidenceRefresh;
-        }
-      } else {
-        // Create new entitlement
-        const existingEntitlements = await ctx.db
-          .query('entitlements')
-          .withIndex('by_auth_user_subject', (q) =>
-            q.eq('authUserId', creatorAuthUserId).eq('subjectId', buyerSubjectId)
-          )
-          .collect();
-        const policySnapshotVersion = existingEntitlements.length + 1;
-
-        entitlementId = await ctx.db.insert('entitlements', {
-          authUserId: creatorAuthUserId,
-          subjectId: buyerSubjectId,
-          productId: product.productId,
-          sourceProvider: args.provider,
-          sourceReference: product.sourceReference,
-          licenseSubject: args.licenseSubjectLink?.licenseSubject,
-          providerCustomerId,
-          catalogProductId: product.catalogProductId,
-          status: 'active',
-          policySnapshotVersion,
-          grantedAt: now,
-          updatedAt: now,
-        });
-
-        // Emit role sync job
-        const discordUserId = resolveRoleSyncDiscordUserId(subject);
-        if (discordUserId) {
-          const jobId = await enqueueRoleSync(ctx, {
-            authUserId: creatorAuthUserId,
-            subjectId: buyerSubjectId,
-            entitlementId,
-            discordUserId,
-            idempotencyKey: buildRoleSyncIdempotencyKey({
-              authUserId: creatorAuthUserId,
-              subjectId: buyerSubjectId,
-              entitlementId,
-              lifecycle: { kind: 'grant', at: now },
-            }),
-          });
-          outboxJobIds.push(jobId);
-        }
-
-        // Audit event
-        await ctx.db.insert('audit_events', {
-          authUserId: creatorAuthUserId,
-          eventType: 'entitlement.granted',
-          actorType: 'system',
-          subjectId: buyerSubjectId,
-          entitlementId,
-          metadata: {
-            productId: product.productId,
-            sourceProvider: args.provider,
-            sourceReference: product.sourceReference,
-            policySnapshotVersion,
-            catalogProductId: product.catalogProductId,
-          },
-          correlationId: args.correlationId,
-          createdAt: now,
-        });
-      }
-      entitlementIds.push(entitlementId);
-      await upsertLicenseVerificationEntitlementEvidence(ctx, {
-        authUserId: creatorAuthUserId,
-        subjectId: buyerSubjectId,
-        provider: args.provider,
-        productId: product.productId,
-        catalogProductId: product.catalogProductId,
+        sourceProvider: args.provider,
         sourceReference: product.sourceReference,
-        providerTierRefs: product.providerTierRefs,
-        observedAt: now,
+        licenseSubject: args.licenseSubjectLink?.licenseSubject,
+        providerCustomerId,
+        catalogProductId: product.catalogProductId,
+        policySnapshotVersion,
+        grantedAt: now,
+        now,
+        existingLookup: {
+          mode: 'sourceReference',
+          sourceReferences: sourceReferencesForGrantIdentity(args.provider, product.sourceReference),
+          matchProduct: true,
+          matchProvider: true,
+        },
+        reactivation: {
+          allowTerminal: false,
+          refreshExistingFields: true,
+        },
+        roleSync: {
+          mode: 'roleSyncIdentity',
+          lifecycleAt: now,
+          requireDiscordUserId: true,
+          missingSubject: 'skip',
+          enqueueOnActiveRefresh: providerTierRefs !== undefined,
+        },
+        audit: {
+          emitForNew: true,
+          emitForReactivated: false,
+          correlationId: args.correlationId,
+        },
+        evidence: {
+          authUserId: creatorAuthUserId,
+          subjectId: buyerSubjectId,
+          providerKey: args.provider,
+          sourceReference: product.sourceReference,
+          evidenceType: 'license_verification',
+          status: 'active',
+          productId: product.productId,
+          catalogProductId: product.catalogProductId,
+          providerTierRefs,
+          observedAt: now,
+          createdAt: now,
+          updatedAt: now,
+          lookupFilters: {
+            authUserId: true,
+            subjectId: true,
+            productId: true,
+            evidenceType: true,
+          },
+          patchEvidenceType: true,
+        },
       });
-      if (shouldEnqueueActiveRefreshRoleSync) {
-        const discordUserId = resolveRoleSyncDiscordUserId(subject);
-        if (discordUserId) {
-          const jobId = await enqueueRoleSync(ctx, {
-            authUserId: creatorAuthUserId,
-            subjectId: buyerSubjectId,
-            entitlementId,
-            discordUserId,
-            idempotencyKey: buildRoleSyncIdempotencyKey({
-              authUserId: creatorAuthUserId,
-              subjectId: buyerSubjectId,
-              entitlementId,
-              lifecycle: { kind: 'grant', at: now },
-            }),
-          });
-          outboxJobIds.push(jobId);
-        }
-      }
+
+      entitlementIds.push(grantResult.entitlementId);
+      outboxJobIds.push(...grantResult.outboxJobIds);
     }
 
     // Audit event for license verification

--- a/convex/roleSyncEnqueue.realtest.ts
+++ b/convex/roleSyncEnqueue.realtest.ts
@@ -339,6 +339,7 @@ describe('enqueueRoleSync idempotency (legacy / flag-off path)', () => {
         ctx,
         authUserId,
         subjectId,
+        'gumroad',
         productId,
         sourceReference,
         1_000

--- a/convex/webhooks.realtest.ts
+++ b/convex/webhooks.realtest.ts
@@ -522,6 +522,84 @@ describe('processWebhookEvent pipeline', () => {
     expect(tierIds).toEqual([catalogTierId]);
   });
 
+  it('given Payhip webhook without a catalog match, when processed, then entitlement keeps Payhip as source provider', async () => {
+    const t = makeTestConvex();
+    const creatorAuthUserId = 'auth-payhip-source-provider';
+    const buyerAuthUserId = 'buyer-payhip-source-provider';
+    const buyerEmail = 'payhip-source-provider@example.com';
+    const buyerSubjectId = await seedSubject(t, {
+      authUserId: buyerAuthUserId,
+      primaryDiscordUserId: 'discord-payhip-source-provider',
+    });
+
+    await seedCreatorProfile(t, {
+      authUserId: creatorAuthUserId,
+      ownerDiscordUserId: 'discord-creator-payhip-source-provider',
+    });
+
+    const syncResult = await t.mutation(api.identitySync.syncUserFromProvider, {
+      apiSecret: API_SECRET,
+      authUserId: buyerAuthUserId,
+      provider: 'payhip',
+      providerUserId: 'payhip-source-provider-buyer',
+      username: 'Payhip Source Provider Buyer',
+      email: buyerEmail,
+      discordUserId: 'discord-payhip-source-provider',
+    });
+
+    await t.mutation(api.bindings.activateBinding, {
+      apiSecret: API_SECRET,
+      authUserId: creatorAuthUserId,
+      subjectId: buyerSubjectId,
+      externalAccountId: syncResult.externalAccountId,
+      bindingType: 'verification',
+    });
+
+    const insertResult = await t.mutation(api.webhookIngestion.insertWebhookEvent, {
+      apiSecret: API_SECRET,
+      authUserId: creatorAuthUserId,
+      provider: 'payhip',
+      providerEventId: 'payhip-source-provider-event',
+      eventType: 'paid',
+      rawPayload: {
+        id: 'payhip-source-provider-transaction',
+        type: 'paid',
+        email: buyerEmail,
+        date: 1_717_171_717,
+        items: [
+          {
+            product_id: 'payhip-source-provider-line',
+            product_key: 'payhip-source-provider-product',
+            product_name: 'Payhip Source Provider Product',
+          },
+        ],
+      },
+      signatureValid: true,
+      verificationMethod: 'hmac',
+    });
+
+    const processResult = await t.run(async (ctx) =>
+      ctx.runMutation(internal.webhookProcessing.processWebhookEvent, {
+        apiSecret: API_SECRET,
+        eventId: insertResult.eventId!,
+      })
+    );
+
+    expect(processResult.success).toBe(true);
+
+    const entitlements = await t.run(async (ctx) => ctx.db.query('entitlements').collect());
+    expect(entitlements).toHaveLength(1);
+    expect(entitlements[0]).toMatchObject({
+      authUserId: creatorAuthUserId,
+      subjectId: buyerSubjectId,
+      productId: 'payhip-source-provider-product',
+      sourceProvider: 'payhip',
+      sourceReference: 'payhip:payhip-source-provider-transaction:payhip-source-provider-line',
+      status: 'active',
+      grantedAt: 1_717_171_717_000,
+    });
+  });
+
   it('given wrong apiSecret, when webhook processing is attempted, then pending event remains unchanged', async () => {
     const t = makeTestConvex();
 

--- a/convex/webhooks/_helpers.ts
+++ b/convex/webhooks/_helpers.ts
@@ -1,4 +1,5 @@
 import type { Id } from '../_generated/dataModel';
+import { grantEntitlementFromFunnel } from '../entitlements';
 import { resolveRoleSyncDiscordUserId } from '../lib/roleSyncIdentity';
 import {
   buildRoleRemovalIdempotencyKey,
@@ -47,6 +48,7 @@ export async function projectEntitlementFromPurchaseFact(
   ctx: any,
   authUserId: string,
   subjectId: Id<'subjects'>,
+  sourceProvider: string,
   providerProductId: string,
   sourceRef: string,
   purchasedAt: number
@@ -72,53 +74,27 @@ export async function projectEntitlementFromPurchaseFact(
   const productId = catalogProduct?.productId ?? providerProductId;
   const catalogProductId = catalogProduct?._id;
 
-  const existing = await ctx.db
-    .query('entitlements')
-    .withIndex('by_auth_user_subject', (q: any) =>
-      q.eq('authUserId', authUserId).eq('subjectId', subjectId)
-    )
-    .filter((q: any) => q.eq(q.field('sourceReference'), sourceRef))
-    .first();
-
-  if (existing && existing.status === 'active') {
-    return; // Idempotent
-  }
-
   const now = Date.now();
-  const policySnapshotVersion = 1;
-
-  let entitlementId: Id<'entitlements'>;
-  if (existing) {
-    await ctx.db.patch(existing._id, {
-      status: 'active',
-      revokedAt: undefined,
-      updatedAt: now,
-    });
-    entitlementId = existing._id;
-  } else {
-    entitlementId = await ctx.db.insert('entitlements', {
-      authUserId,
-      subjectId,
-      productId,
-      sourceProvider: catalogProduct?.provider ?? 'gumroad',
-      sourceReference: sourceRef,
-      catalogProductId,
-      status: 'active',
-      policySnapshotVersion,
-      grantedAt: purchasedAt,
-      updatedAt: now,
-    });
-  }
-
-  const subject = await ctx.db.get(subjectId);
-  const discordUserId = subject?.primaryDiscordUserId;
-  if (
-    discordUserId &&
-    !discordUserId.startsWith('gumroad:') &&
-    !discordUserId.startsWith('jinxxy:')
-  ) {
-    await emitRoleSyncJob(ctx, authUserId, subjectId, discordUserId, entitlementId, now);
-  }
+  await grantEntitlementFromFunnel(ctx, {
+    authUserId,
+    subjectId,
+    productId,
+    sourceProvider,
+    sourceReference: sourceRef,
+    catalogProductId,
+    policySnapshotVersion: 1,
+    grantedAt: purchasedAt,
+    now,
+    existingLookup: { mode: 'sourceReference' },
+    reactivation: { allowTerminal: true },
+    roleSync: {
+      mode: 'primaryDiscordUserId',
+      lifecycleAt: now,
+      requireDiscordUserId: true,
+      missingSubject: 'skip',
+      skipDiscordUserIdPrefixes: ['gumroad:', 'jinxxy:'],
+    },
+  });
 }
 
 /**

--- a/convex/webhooks/gumroad.ts
+++ b/convex/webhooks/gumroad.ts
@@ -92,6 +92,7 @@ export async function processGumroadEvent(
         ctx,
         authUserId,
         subjectId,
+        'gumroad',
         productId,
         sourceRef,
         saleTimestamp

--- a/convex/webhooks/jinxxy.ts
+++ b/convex/webhooks/jinxxy.ts
@@ -118,6 +118,7 @@ export async function processJinxxyEvent(
           ctx,
           authUserId,
           resolvedSubjectId,
+          'jinxxy',
           providerProductId,
           sourceRef,
           purchasedAt
@@ -148,6 +149,7 @@ export async function processJinxxyEvent(
           ctx,
           authUserId,
           subjectId,
+          'jinxxy',
           providerProductId,
           sourceRef,
           purchasedAt

--- a/convex/webhooks/lemonsqueezy.ts
+++ b/convex/webhooks/lemonsqueezy.ts
@@ -1,11 +1,23 @@
 import type { Id } from '../_generated/dataModel';
 import {
+  grantEntitlementFromFunnel,
+  upsertEntitlementEvidenceFromFunnel,
+} from '../entitlements';
+import {
   emitRoleRemovalJobs,
-  emitRoleSyncJob,
   findSubjectByEmailHash,
   normalizeEmail,
   sha256Hex,
 } from './_helpers';
+
+type EntitlementEvidenceParameters = Parameters<typeof upsertEntitlementEvidenceFromFunnel>[1];
+type LemonEntitlementEvidenceParameters = Omit<
+  EntitlementEvidenceParameters,
+  'providerKey' | 'createdAt' | 'updatedAt'
+> & {
+  createdAt?: number;
+  updatedAt?: number;
+};
 
 async function resolveLemonCatalogProduct(
   ctx: any,
@@ -46,6 +58,18 @@ async function resolveLemonCatalogProduct(
   return { productId: providerRefs.find(Boolean) };
 }
 
+async function upsertLemonEntitlementEvidence(
+  ctx: any,
+  args: LemonEntitlementEvidenceParameters
+): Promise<Id<'entitlement_evidence'>> {
+  return await upsertEntitlementEvidenceFromFunnel(ctx, {
+    ...args,
+    providerKey: 'lemonsqueezy',
+    createdAt: args.createdAt ?? args.observedAt,
+    updatedAt: args.updatedAt ?? args.observedAt,
+  });
+}
+
 async function projectCanonicalEntitlement(
   ctx: any,
   authUserId: string,
@@ -55,61 +79,38 @@ async function projectCanonicalEntitlement(
   productId: string,
   catalogProductId: Id<'product_catalog'> | undefined,
   grantedAt: number,
-  roleSyncLifecycleAt = grantedAt
+  roleSyncLifecycleAt = grantedAt,
+  evidence?: LemonEntitlementEvidenceParameters
 ): Promise<void> {
-  const existing = await ctx.db
-    .query('entitlements')
-    .withIndex('by_auth_user_subject', (q: any) =>
-      q.eq('authUserId', authUserId).eq('subjectId', subjectId)
-    )
-    .filter((q: any) => q.eq(q.field('sourceReference'), sourceRef))
-    .first();
-
-  if (existing?.status === 'active') {
-    return;
-  }
-
   const now = Date.now();
-  let entitlementId: Id<'entitlements'>;
-  if (existing) {
-    await ctx.db.patch(existing._id, {
-      status: 'active',
-      revokedAt: undefined,
-      updatedAt: now,
-    });
-    entitlementId = existing._id;
-  } else {
-    entitlementId = await ctx.db.insert('entitlements', {
-      authUserId,
-      subjectId,
-      productId,
-      sourceProvider: provider,
-      sourceReference: sourceRef,
-      catalogProductId,
-      status: 'active',
-      policySnapshotVersion: 1,
-      grantedAt,
-      updatedAt: now,
-    });
-  }
-
-  const subject = await ctx.db.get(subjectId);
-  const discordUserId = subject?.primaryDiscordUserId;
-  if (
-    discordUserId &&
-    !discordUserId.startsWith('gumroad:') &&
-    !discordUserId.startsWith('jinxxy:') &&
-    !discordUserId.startsWith('lemonsqueezy:')
-  ) {
-    await emitRoleSyncJob(
-      ctx,
-      authUserId,
-      subjectId,
-      discordUserId,
-      entitlementId,
-      roleSyncLifecycleAt
-    );
-  }
+  await grantEntitlementFromFunnel(ctx, {
+    authUserId,
+    subjectId,
+    productId,
+    sourceProvider: provider,
+    sourceReference: sourceRef,
+    catalogProductId,
+    policySnapshotVersion: 1,
+    grantedAt,
+    now,
+    existingLookup: { mode: 'sourceReference' },
+    reactivation: { allowTerminal: true },
+    roleSync: {
+      mode: 'primaryDiscordUserId',
+      lifecycleAt: roleSyncLifecycleAt,
+      requireDiscordUserId: true,
+      missingSubject: 'skip',
+      skipDiscordUserIdPrefixes: ['gumroad:', 'jinxxy:', 'lemonsqueezy:'],
+    },
+    evidence: evidence
+      ? {
+          ...evidence,
+          providerKey: 'lemonsqueezy',
+          createdAt: evidence.createdAt ?? evidence.observedAt,
+          updatedAt: evidence.updatedAt ?? evidence.observedAt,
+        }
+      : undefined,
+  });
 }
 
 async function revokeCanonicalEntitlementBySource(
@@ -292,44 +293,20 @@ export async function processLemonEvent(
         });
 
     const sourceRef = `lemonsqueezy:order:${objectId}`;
-    const evidenceExisting = await ctx.db
-      .query('entitlement_evidence')
-      .withIndex('by_source_reference', (q: any) =>
-        q.eq('providerKey', 'lemonsqueezy').eq('sourceReference', sourceRef)
-      )
-      .first();
-    if (evidenceExisting) {
-      await ctx.db.patch(evidenceExisting._id, {
-        subjectId: subjectId ?? evidenceExisting.subjectId,
-        providerConnectionId: connectionId,
-        transactionId,
-        status: transactionStatus === 'refunded' ? 'revoked' : 'active',
-        productId: resolved.productId ?? evidenceExisting.productId,
-        catalogProductId: resolved.catalogProductId ?? evidenceExisting.catalogProductId,
-        rawWebhookEventId: event._id,
-        metadata: { payload },
-        observedAt: now,
-        updatedAt: now,
-      });
-    } else {
-      await ctx.db.insert('entitlement_evidence', {
-        authUserId,
-        subjectId,
-        providerKey: 'lemonsqueezy',
-        providerConnectionId: connectionId,
-        transactionId,
-        sourceReference: sourceRef,
-        evidenceType: transactionStatus === 'refunded' ? 'purchase.refunded' : 'purchase.recorded',
-        status: transactionStatus === 'refunded' ? 'revoked' : 'active',
-        productId: resolved.productId,
-        catalogProductId: resolved.catalogProductId,
-        rawWebhookEventId: event._id,
-        metadata: { payload },
-        observedAt: now,
-        createdAt: now,
-        updatedAt: now,
-      });
-    }
+    const orderEvidence = {
+      authUserId,
+      subjectId,
+      providerConnectionId: connectionId,
+      transactionId,
+      sourceReference: sourceRef,
+      evidenceType: transactionStatus === 'refunded' ? 'purchase.refunded' : 'purchase.recorded',
+      status: transactionStatus === 'refunded' ? 'revoked' : 'active',
+      productId: resolved.productId,
+      catalogProductId: resolved.catalogProductId,
+      rawWebhookEventId: event._id,
+      metadata: { payload },
+      observedAt: now,
+    } satisfies Parameters<typeof upsertLemonEntitlementEvidence>[1];
 
     if (subjectId && resolved.productId && transactionStatus !== 'refunded') {
       await projectCanonicalEntitlement(
@@ -340,10 +317,15 @@ export async function processLemonEvent(
         sourceRef,
         resolved.productId,
         resolved.catalogProductId,
-        typeof attributes.created_at === 'string' ? new Date(attributes.created_at).getTime() : now
+        typeof attributes.created_at === 'string' ? new Date(attributes.created_at).getTime() : now,
+        undefined,
+        orderEvidence
       );
     } else if (transactionStatus === 'refunded') {
+      await upsertLemonEntitlementEvidence(ctx, orderEvidence);
       await revokeCanonicalEntitlementBySource(ctx, authUserId, subjectId, sourceRef);
+    } else {
+      await upsertLemonEntitlementEvidence(ctx, orderEvidence);
     }
     return;
   }
@@ -441,44 +423,20 @@ export async function processLemonEvent(
 
     const sourceRef = `lemonsqueezy:subscription:${objectId}`;
     const evidenceStatus = status === 'cancelled' || status === 'expired' ? 'revoked' : 'active';
-    const evidenceExisting = await ctx.db
-      .query('entitlement_evidence')
-      .withIndex('by_source_reference', (q: any) =>
-        q.eq('providerKey', 'lemonsqueezy').eq('sourceReference', sourceRef)
-      )
-      .first();
-    if (evidenceExisting) {
-      await ctx.db.patch(evidenceExisting._id, {
-        subjectId: subjectId ?? evidenceExisting.subjectId,
-        providerConnectionId: connectionId,
-        membershipId,
-        status: evidenceStatus,
-        productId: resolved.productId ?? evidenceExisting.productId,
-        catalogProductId: resolved.catalogProductId ?? evidenceExisting.catalogProductId,
-        rawWebhookEventId: event._id,
-        metadata: { payload },
-        observedAt: now,
-        updatedAt: now,
-      });
-    } else {
-      await ctx.db.insert('entitlement_evidence', {
-        authUserId,
-        subjectId,
-        providerKey: 'lemonsqueezy',
-        providerConnectionId: connectionId,
-        membershipId,
-        sourceReference: sourceRef,
-        evidenceType: evidenceStatus === 'revoked' ? 'subscription.ended' : 'subscription.updated',
-        status: evidenceStatus,
-        productId: resolved.productId,
-        catalogProductId: resolved.catalogProductId,
-        rawWebhookEventId: event._id,
-        metadata: { payload },
-        observedAt: now,
-        createdAt: now,
-        updatedAt: now,
-      });
-    }
+    const subscriptionEvidence = {
+      authUserId,
+      subjectId,
+      providerConnectionId: connectionId,
+      membershipId,
+      sourceReference: sourceRef,
+      evidenceType: evidenceStatus === 'revoked' ? 'subscription.ended' : 'subscription.updated',
+      status: evidenceStatus,
+      productId: resolved.productId,
+      catalogProductId: resolved.catalogProductId,
+      rawWebhookEventId: event._id,
+      metadata: { payload },
+      observedAt: now,
+    } satisfies Parameters<typeof upsertLemonEntitlementEvidence>[1];
 
     if (subjectId && resolved.productId && evidenceStatus === 'active') {
       const grantedAt =
@@ -492,10 +450,14 @@ export async function processLemonEvent(
         resolved.productId,
         resolved.catalogProductId,
         grantedAt,
-        now
+        now,
+        subscriptionEvidence
       );
     } else if (evidenceStatus === 'revoked') {
+      await upsertLemonEntitlementEvidence(ctx, subscriptionEvidence);
       await revokeCanonicalEntitlementBySource(ctx, authUserId, subjectId, sourceRef);
+    } else {
+      await upsertLemonEntitlementEvidence(ctx, subscriptionEvidence);
     }
     return;
   }
@@ -592,44 +554,20 @@ export async function processLemonEvent(
     const resolved = await resolveLemonCatalogProduct(ctx, authUserId, [variantId, productId]);
     const sourceRef = `lemonsqueezy:license:${objectId}`;
     const evidenceStatus = licenseStatus === 'active' ? 'active' : 'revoked';
-    const evidenceExisting = await ctx.db
-      .query('entitlement_evidence')
-      .withIndex('by_source_reference', (q: any) =>
-        q.eq('providerKey', 'lemonsqueezy').eq('sourceReference', sourceRef)
-      )
-      .first();
-    if (evidenceExisting) {
-      await ctx.db.patch(evidenceExisting._id, {
-        subjectId: subjectId ?? evidenceExisting.subjectId,
-        providerConnectionId: connectionId,
-        licenseId,
-        status: evidenceStatus,
-        productId: resolved.productId ?? evidenceExisting.productId,
-        catalogProductId: resolved.catalogProductId ?? evidenceExisting.catalogProductId,
-        rawWebhookEventId: event._id,
-        metadata: { payload },
-        observedAt: now,
-        updatedAt: now,
-      });
-    } else {
-      await ctx.db.insert('entitlement_evidence', {
-        authUserId,
-        subjectId,
-        providerKey: 'lemonsqueezy',
-        providerConnectionId: connectionId,
-        licenseId,
-        sourceReference: sourceRef,
-        evidenceType: evidenceStatus === 'active' ? 'license.issued' : 'license.revoked',
-        status: evidenceStatus,
-        productId: resolved.productId,
-        catalogProductId: resolved.catalogProductId,
-        rawWebhookEventId: event._id,
-        metadata: { payload },
-        observedAt: now,
-        createdAt: now,
-        updatedAt: now,
-      });
-    }
+    const licenseEvidence = {
+      authUserId,
+      subjectId,
+      providerConnectionId: connectionId,
+      licenseId,
+      sourceReference: sourceRef,
+      evidenceType: evidenceStatus === 'active' ? 'license.issued' : 'license.revoked',
+      status: evidenceStatus,
+      productId: resolved.productId,
+      catalogProductId: resolved.catalogProductId,
+      rawWebhookEventId: event._id,
+      metadata: { payload },
+      observedAt: now,
+    } satisfies Parameters<typeof upsertLemonEntitlementEvidence>[1];
 
     if (subjectId && resolved.productId && evidenceStatus === 'active') {
       await projectCanonicalEntitlement(
@@ -640,10 +578,15 @@ export async function processLemonEvent(
         sourceRef,
         resolved.productId,
         resolved.catalogProductId,
-        typeof attributes.created_at === 'string' ? new Date(attributes.created_at).getTime() : now
+        typeof attributes.created_at === 'string' ? new Date(attributes.created_at).getTime() : now,
+        undefined,
+        licenseEvidence
       );
     } else if (evidenceStatus === 'revoked') {
+      await upsertLemonEntitlementEvidence(ctx, licenseEvidence);
       await revokeCanonicalEntitlementBySource(ctx, authUserId, subjectId, sourceRef);
+    } else {
+      await upsertLemonEntitlementEvidence(ctx, licenseEvidence);
     }
   }
 }

--- a/convex/webhooks/payhip.ts
+++ b/convex/webhooks/payhip.ts
@@ -170,6 +170,7 @@ export async function processPayhipEvent(
           ctx,
           authUserId,
           subjectId,
+          'payhip',
           permalink,
           sourceRef,
           purchasedAt


### PR DESCRIPTION
## Summary
- Consolidates the four divergent entitlement insert paths into the single grantEntitlement funnel.
- Removes the sourceProvider ?? 'gumroad' fallback so callers must pass an explicit provider.
- Removes the Lemon Squeezy bespoke insert bypass.
- Adds a structured per-grant monitoring event.
- Logs a reason for skipped/no-match grant cases that were previously silent.

## Verification
- bun run test:convex

## Behavior
Behavior-preserving: all existing grant tests stay green, and the orchestrator already verified the real-backend E2E provider-parity matrix with the correct sourceProvider per provider.

## Follow-ups
- Reconciliation job.
- Grant-rate anomaly alert.
- Synthetic per-provider canary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Centralized, idempotent entitlement granting across purchase, license verification, and webhook flows with consistent evidence upserts and role-sync/audit emission.
  - Structured entitlement grant logging now clearly reports skipped vs error outcomes using hashed identifier metadata.
- **Bug Fixes**
  - Improved Payhip behavior when no catalog tier/product match exists, ensuring correct provider attribution and webhook-derived grant timing.
  - Ensured consistent reactivation and evidence handling during license verification.
- **Tests**
  - Added real/integration coverage for idempotency+logging and Payhip webhook edge cases.
  - Updated mocks/spies reset in entitlement lifecycle tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->