### PR TITLE
chore(convex): remove dead getGumroadWebhookSecret query

### DIFF
--- a/convex/providerConnections.ts
+++ b/convex/providerConnections.ts
@@ -278,30 +278,6 @@ export const getJinxxyWebhookSecretByRouteId = query({
 });
 
 /**
- * Get Gumroad webhook secret for a tenant.
- * Used by webhook handler for signature verification.
- */
-export const getGumroadWebhookSecret = query({
-  args: {
-    apiSecret: v.string(),
-    authUserId: v.string(),
-  },
-  returns: v.union(v.string(), v.null()),
-  handler: async (ctx, args) => {
-    requireApiSecret(args.apiSecret);
-    const conn = await ctx.db
-      .query('provider_connections')
-      .withIndex('by_auth_user_provider', (q) =>
-        q.eq('authUserId', args.authUserId).eq('provider', 'gumroad')
-      )
-      .first();
-    if (!conn) return null;
-    const credentialSecret = await getCredentialValue(ctx, conn._id, 'webhook_secret');
-    return credentialSecret ?? conn.webhookSecretRef ?? null;
-  },
-});
-
-/**
  * Get Gumroad webhook secret by routeId (authUserId).
  * Used by webhook handler for signature verification.
  */


### PR DESCRIPTION
## Summary

- Remove the dead `getGumroadWebhookSecret` Convex query from `convex/providerConnections.ts`.
- Keep the live webhook lookup paths intact: `getGumroadWebhookSecretByRouteId` and `getWebhookCredentialByRouteId`.

## Rationale

Repository grep found zero real callers for the deleted query outside `convex/_generated/**` and `.orchestration/**`. The webhook handler uses the routeId-specific or generic credential lookup instead.

The removed query was also subtly wrong: unlike both live siblings, it did not guard `conn.status === 'disconnected'`, so it could have returned a webhook secret for a disconnected connection if it became live again. Removing the dead export closes that latent secret-leak-on-disconnect footgun without changing behavior.

## Verification

- `bun run test:convex` passed on rerun: 45 files, 364 tests.
- `bun run test:convex:types` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused webhook credential lookup path and simplified how webhook secrets are resolved.
  * No user-facing behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->