### PR TITLE
fix: preserve API key userId

### DIFF
--- a/convex/betterAuth/adapter.ts
+++ b/convex/betterAuth/adapter.ts
@@ -1,17 +1,85 @@
 import { createApi } from '@convex-dev/better-auth';
+import { anyApi, type FunctionReference } from 'convex/server';
+import { v } from 'convex/values';
+import { mutation } from './_generated/server';
 import { createSchemaAuthOptions } from './options';
 import schema from './schema';
 
-const api = createApi(schema, createSchemaAuthOptions);
+const adapterApi = createApi(schema, createSchemaAuthOptions);
 
-export const create = api.create;
-export const findOne = api.findOne;
-export const findMany = api.findMany;
+type RawCreateReference = FunctionReference<
+  'mutation',
+  'public',
+  {
+    input: unknown;
+    select?: string[];
+    onCreateHandle?: string;
+  },
+  unknown,
+  string | undefined
+>;
+
+const rawCreateRef = (anyApi as unknown as { adapter: { rawCreate: RawCreateReference } }).adapter
+  .rawCreate;
+
+function normalizeApiKeyCreateInput(input: unknown): unknown {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return input;
+  }
+
+  const inputRecord = input as Record<string, unknown>;
+  if (inputRecord.model !== 'apikey') {
+    return input;
+  }
+
+  const data = inputRecord.data;
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return input;
+  }
+
+  const dataRecord = data as Record<string, unknown>;
+  if (typeof dataRecord.userId === 'string' && dataRecord.userId.length > 0) {
+    return input;
+  }
+
+  if (typeof dataRecord.referenceId !== 'string' || dataRecord.referenceId.length === 0) {
+    return input;
+  }
+
+  // Better Auth API-key create derives the user owner into referenceId and does
+  // not include userId in the adapter insert payload.
+  return {
+    ...inputRecord,
+    data: {
+      ...dataRecord,
+      userId: dataRecord.referenceId,
+    },
+  };
+}
+
+export const rawCreate = adapterApi.create;
+
+export const create = mutation({
+  args: {
+    input: v.any(),
+    select: v.optional(v.array(v.string())),
+    onCreateHandle: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<unknown> => {
+    return await ctx.runMutation(rawCreateRef, {
+      ...args,
+      input: normalizeApiKeyCreateInput(args.input),
+    });
+  },
+});
+
+export const findOne = adapterApi.findOne;
+export const findMany = adapterApi.findMany;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const updateOne = api.updateOne as any;
+export const updateOne = adapterApi.updateOne as any;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const updateMany = api.updateMany as any;
+export const updateMany = adapterApi.updateMany as any;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const deleteOne = api.deleteOne as any;
+export const deleteOne = adapterApi.deleteOne as any;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const deleteMany = api.deleteMany as any;
+export const deleteMany = adapterApi.deleteMany as any;

--- a/convex/betterAuth/adapter.ts
+++ b/convex/betterAuth/adapter.ts
@@ -1,7 +1,7 @@
 import { createApi } from '@convex-dev/better-auth';
 import { anyApi, type FunctionReference } from 'convex/server';
 import { v } from 'convex/values';
-import { mutation } from './_generated/server';
+import { internalMutation } from './_generated/server';
 import { createSchemaAuthOptions } from './options';
 import schema from './schema';
 
@@ -59,7 +59,7 @@ function normalizeApiKeyCreateInput(input: unknown): unknown {
 
 export const rawCreate = adapterApi.create;
 
-export const create = mutation({
+export const create = internalMutation({
   args: {
     input: v.any(),
     select: v.optional(v.array(v.string())),

--- a/convex/betterAuthApiKeys.realtest.ts
+++ b/convex/betterAuthApiKeys.realtest.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { api } from './_generated/api';
+import betterAuthSchema from './betterAuth/schema';
+import { makeTestConvex } from './testHelpers';
+
+const API_SECRET = 'test-secret';
+
+type BetterAuthComponentCtx = {
+  db: {
+    insert: (table: string, value: Record<string, unknown>) => Promise<string>;
+    query: (table: string) => {
+      collect: () => Promise<Array<Record<string, unknown>>>;
+    };
+  };
+};
+
+type ComponentAwareTestConvex = ReturnType<typeof makeTestConvex> & {
+  runInComponent: <Output>(
+    componentPath: string,
+    handler: (ctx: BetterAuthComponentCtx) => Promise<Output>
+  ) => Promise<Output>;
+};
+
+async function seedBetterAuthUser(t: ComponentAwareTestConvex): Promise<string> {
+  return await t.runInComponent('betterAuth', async (ctx) => {
+    const now = Date.now();
+    return await ctx.db.insert('user', {
+      name: 'Public API Owner',
+      email: 'public-api-owner@example.com',
+      emailVerified: true,
+      image: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+  });
+}
+
+describe('betterAuthApiKeys', () => {
+  beforeEach(() => {
+    process.env.BETTER_AUTH_SECRET = 'test-better-auth-secret';
+    process.env.CONVEX_API_SECRET = API_SECRET;
+    process.env.CONVEX_SITE_URL = 'https://public-api.test.example';
+  });
+
+  it('creates managed public API keys with the Better Auth owner stored in userId', async () => {
+    const t = makeTestConvex() as ComponentAwareTestConvex;
+    t.registerComponent('betterAuth', betterAuthSchema, import.meta.glob('./betterAuth/**/*.ts'));
+    const ownerAuthUserId = await seedBetterAuthUser(t);
+
+    const result = await t.mutation(api.betterAuthApiKeys.createApiKey, {
+      apiSecret: API_SECRET,
+      userId: ownerAuthUserId,
+      authUserId: ownerAuthUserId,
+      name: 'Production public API key',
+      scopes: ['cert:issue'],
+      expiresIn: null,
+    });
+
+    expect(result.key).toMatch(/^ypsk_/);
+    expect(result.apiKey.userId).toBe(ownerAuthUserId);
+    expect(result.apiKey.metadata).toEqual({
+      kind: 'public-api',
+      authUserId: ownerAuthUserId,
+    });
+
+    const storedKeys = await t.runInComponent('betterAuth', async (ctx) => {
+      return await ctx.db.query('apikey').collect();
+    });
+
+    expect(storedKeys).toHaveLength(1);
+    expect(storedKeys[0]?.userId).toBe(ownerAuthUserId);
+    expect(storedKeys[0]?.referenceId).toBe(ownerAuthUserId);
+
+    const verified = await t.mutation(api.betterAuthApiKeys.verifyApiKey, {
+      apiSecret: API_SECRET,
+      key: result.key,
+      scopes: ['cert:issue'],
+    });
+
+    expect(verified.valid).toBe(true);
+    expect(verified.key?.userId).toBe(ownerAuthUserId);
+    expect(verified.key?.metadata).toEqual({
+      kind: 'public-api',
+      authUserId: ownerAuthUserId,
+    });
+  });
+});

--- a/convex/betterAuthApiKeys.realtest.ts
+++ b/convex/betterAuthApiKeys.realtest.ts
@@ -21,12 +21,18 @@ type ComponentAwareTestConvex = ReturnType<typeof makeTestConvex> & {
   ) => Promise<Output>;
 };
 
-async function seedBetterAuthUser(t: ComponentAwareTestConvex): Promise<string> {
+async function seedBetterAuthUser(
+  t: ComponentAwareTestConvex,
+  user: { name: string; email: string } = {
+    name: 'Public API Owner',
+    email: 'public-api-owner@example.com',
+  }
+): Promise<string> {
   return await t.runInComponent('betterAuth', async (ctx) => {
     const now = Date.now();
     return await ctx.db.insert('user', {
-      name: 'Public API Owner',
-      email: 'public-api-owner@example.com',
+      name: user.name,
+      email: user.email,
       emailVerified: true,
       image: null,
       createdAt: now,
@@ -83,5 +89,54 @@ describe('betterAuthApiKeys', () => {
       kind: 'public-api',
       authUserId: ownerAuthUserId,
     });
-  });
+  }, 10_000);
+
+  it('stores the public tenant authUserId when the session owner differs', async () => {
+    const t = makeTestConvex() as ComponentAwareTestConvex;
+    t.registerComponent('betterAuth', betterAuthSchema, import.meta.glob('./betterAuth/**/*.ts'));
+    const sessionOwnerUserId = await seedBetterAuthUser(t, {
+      name: 'Session Owner',
+      email: 'session-owner@example.com',
+    });
+    const tenantAuthUserId = await seedBetterAuthUser(t, {
+      name: 'Public Tenant',
+      email: 'public-tenant@example.com',
+    });
+
+    const result = await t.mutation(api.betterAuthApiKeys.createApiKey, {
+      apiSecret: API_SECRET,
+      userId: sessionOwnerUserId,
+      authUserId: tenantAuthUserId,
+      name: 'Tenant public API key',
+      scopes: ['verification:read'],
+      expiresIn: null,
+    });
+
+    expect(result.apiKey.userId).toBe(tenantAuthUserId);
+    expect(result.apiKey.metadata).toEqual({
+      kind: 'public-api',
+      authUserId: tenantAuthUserId,
+    });
+
+    const storedKeys = await t.runInComponent('betterAuth', async (ctx) => {
+      return await ctx.db.query('apikey').collect();
+    });
+
+    expect(storedKeys).toHaveLength(1);
+    expect(storedKeys[0]?.userId).toBe(tenantAuthUserId);
+    expect(storedKeys[0]?.referenceId).toBe(tenantAuthUserId);
+
+    const verified = await t.mutation(api.betterAuthApiKeys.verifyApiKey, {
+      apiSecret: API_SECRET,
+      key: result.key,
+      scopes: ['verification:read'],
+    });
+
+    expect(verified.valid).toBe(true);
+    expect(verified.key?.userId).toBe(tenantAuthUserId);
+    expect(verified.key?.metadata).toEqual({
+      kind: 'public-api',
+      authUserId: tenantAuthUserId,
+    });
+  }, 10_000);
 });

--- a/convex/betterAuthApiKeys.realtest.ts
+++ b/convex/betterAuthApiKeys.realtest.ts
@@ -8,6 +8,7 @@ const API_SECRET = 'test-secret';
 type BetterAuthComponentCtx = {
   db: {
     insert: (table: string, value: Record<string, unknown>) => Promise<string>;
+    patch: (id: string, value: Record<string, unknown>) => Promise<void>;
     query: (table: string) => {
       collect: () => Promise<Array<Record<string, unknown>>>;
     };
@@ -129,6 +130,61 @@ describe('betterAuthApiKeys', () => {
     const verified = await t.mutation(api.betterAuthApiKeys.verifyApiKey, {
       apiSecret: API_SECRET,
       key: result.key,
+      scopes: ['verification:read'],
+    });
+
+    expect(verified.valid).toBe(true);
+    expect(verified.key?.userId).toBe(tenantAuthUserId);
+    expect(verified.key?.metadata).toEqual({
+      kind: 'public-api',
+      authUserId: tenantAuthUserId,
+    });
+  }, 10_000);
+
+  it('verifies legacy managed public API keys as the metadata tenant owner', async () => {
+    const t = makeTestConvex() as ComponentAwareTestConvex;
+    t.registerComponent('betterAuth', betterAuthSchema, import.meta.glob('./betterAuth/**/*.ts'));
+    const sessionOwnerUserId = await seedBetterAuthUser(t, {
+      name: 'Legacy Session Owner',
+      email: 'legacy-session-owner@example.com',
+    });
+    const tenantAuthUserId = await seedBetterAuthUser(t, {
+      name: 'Legacy Public Tenant',
+      email: 'legacy-public-tenant@example.com',
+    });
+
+    const created = await t.mutation(api.betterAuthApiKeys.createApiKey, {
+      apiSecret: API_SECRET,
+      userId: sessionOwnerUserId,
+      authUserId: tenantAuthUserId,
+      name: 'Legacy tenant public API key',
+      scopes: ['verification:read'],
+      expiresIn: null,
+    });
+
+    const legacyStoredKey = await t.runInComponent('betterAuth', async (ctx) => {
+      const [storedKey] = await ctx.db.query('apikey').collect();
+      if (!storedKey || typeof storedKey._id !== 'string') {
+        throw new Error('Expected the managed public API key to be stored');
+      }
+
+      await ctx.db.patch(storedKey._id, { userId: sessionOwnerUserId });
+      const [legacyKey] = await ctx.db.query('apikey').collect();
+      return legacyKey;
+    });
+
+    expect(legacyStoredKey).toMatchObject({
+      userId: sessionOwnerUserId,
+      referenceId: tenantAuthUserId,
+    });
+    expect(JSON.parse(String(legacyStoredKey?.metadata))).toEqual({
+      kind: 'public-api',
+      authUserId: tenantAuthUserId,
+    });
+
+    const verified = await t.mutation(api.betterAuthApiKeys.verifyApiKey, {
+      apiSecret: API_SECRET,
+      key: created.key,
       scopes: ['verification:read'],
     });
 

--- a/convex/betterAuthApiKeys.ts
+++ b/convex/betterAuthApiKeys.ts
@@ -363,11 +363,12 @@ export const createApiKey = mutation({
     const api = auth.api as unknown as BetterAuthServerApi;
     const created = await api.createApiKey({
       body: {
+        // Better Auth derives API-key referenceId from body.userId.
+        // Managed public keys are owned by the public tenant authUserId.
         userId: args.authUserId,
         name: args.name,
         prefix: PUBLIC_API_KEY_PREFIX,
         expiresIn: args.expiresIn,
-        referenceId: args.authUserId,
         metadata: {
           kind: PUBLIC_API_KEY_METADATA_KIND,
           authUserId: args.authUserId,
@@ -377,15 +378,11 @@ export const createApiKey = mutation({
         },
       },
     });
-    const stored = (await ctx.runMutation(components.betterAuth.adapter.updateOne, {
-      input: {
-        model: 'apikey',
-        update: {
-          referenceId: args.authUserId,
-        },
-        where: [{ field: '_id', operator: 'eq', value: created.id }],
-      },
-    })) as SerializableApiKeyRecord;
+    const stored = (await ctx.runQuery(components.betterAuth.adapter.findOne, {
+      model: 'apikey',
+      where: [{ field: '_id', operator: 'eq', value: created.id }],
+      select: API_KEY_SERIALIZATION_SELECT,
+    })) as SerializableApiKeyRecord | null;
     const serialized = serializeApiKeyRecord(stored);
     if (!serialized) {
       throw new Error('Better Auth returned an API key record without an owner');

--- a/convex/betterAuthApiKeys.ts
+++ b/convex/betterAuthApiKeys.ts
@@ -63,25 +63,46 @@ function parsePermissionStatements(value: unknown): Record<string, string[]> | n
   return Object.keys(normalized).length > 0 ? normalized : null;
 }
 
-function serializeApiKeyRecord(
-  value: {
-    id?: string;
-    _id?: string;
-    userId: string;
-    name: string | null;
-    start: string | null;
-    prefix: string | null;
-    enabled: boolean | null;
-    permissions?: unknown;
-    metadata?: unknown;
-    referenceId?: string | null;
-    lastRequest?: unknown;
-    expiresAt?: unknown;
-    createdAt?: unknown;
-    updatedAt?: unknown;
-  } | null
-) {
+type SerializableApiKeyRecord = {
+  id?: string;
+  _id?: string;
+  userId?: string;
+  name: string | null;
+  start: string | null;
+  prefix: string | null;
+  enabled: boolean | null;
+  permissions?: unknown;
+  metadata?: unknown;
+  referenceId?: string | null;
+  lastRequest?: unknown;
+  expiresAt?: unknown;
+  createdAt?: unknown;
+  updatedAt?: unknown;
+};
+
+const API_KEY_SERIALIZATION_SELECT = [
+  '_id',
+  'userId',
+  'name',
+  'start',
+  'prefix',
+  'enabled',
+  'permissions',
+  'metadata',
+  'lastRequest',
+  'expiresAt',
+  'createdAt',
+  'updatedAt',
+  'referenceId',
+];
+
+function serializeApiKeyRecord(value: SerializableApiKeyRecord | null) {
   if (!value) {
+    return null;
+  }
+
+  const id = value.id ?? value._id ?? '';
+  if (id.length === 0 || typeof value.userId !== 'string' || value.userId.length === 0) {
     return null;
   }
 
@@ -104,7 +125,7 @@ function serializeApiKeyRecord(
       : null;
 
   return {
-    id: value.id ?? value._id ?? '',
+    id,
     userId: value.userId,
     name: value.name,
     start: value.start,
@@ -144,7 +165,7 @@ interface BetterAuthServerApi {
   listApiKeys(): Promise<
     Array<{
       id: string;
-      userId: string;
+      userId?: string;
       name: string | null;
       start: string | null;
       prefix: string | null;
@@ -159,7 +180,7 @@ interface BetterAuthServerApi {
   >;
   getApiKey(args: { query: { id: string } }): Promise<{
     id: string;
-    userId: string;
+    userId?: string;
     name: string | null;
     start: string | null;
     prefix: string | null;
@@ -187,7 +208,7 @@ interface BetterAuthServerApi {
   }): Promise<{
     key: string;
     id: string;
-    userId: string;
+    userId?: string;
     name: string | null;
     start: string | null;
     prefix: string | null;
@@ -209,7 +230,7 @@ interface BetterAuthServerApi {
     error: { code: string; message?: string } | null;
     key: {
       id: string;
-      userId: string;
+      userId?: string;
       name: string | null;
       start: string | null;
       prefix: string | null;
@@ -229,7 +250,7 @@ interface BetterAuthServerApi {
     };
   }): Promise<{
     id: string;
-    userId: string;
+    userId?: string;
     name: string | null;
     start: string | null;
     prefix: string | null;
@@ -262,13 +283,18 @@ export const listApiKeys = query({
   returns: v.array(SerializedApiKey),
   handler: async (ctx, args) => {
     requireApiSecret(args.apiSecret);
-    const auth = createAuth(ctx);
-    const api = auth.api as unknown as BetterAuthServerApi;
-    const result = await api.listApiKeys();
-    return result.map((record) => {
+    const result = (await ctx.runQuery(components.betterAuth.adapter.findMany, {
+      model: 'apikey',
+      select: API_KEY_SERIALIZATION_SELECT,
+      paginationOpts: { cursor: null, numItems: 100 },
+    })) as {
+      page: SerializableApiKeyRecord[];
+    };
+
+    return result.page.map((record) => {
       const serialized = serializeApiKeyRecord(record);
       if (!serialized) {
-        throw new Error('Better Auth returned an empty API key record');
+        throw new Error('Better Auth returned an API key record without an owner');
       }
       return serialized;
     });
@@ -286,38 +312,10 @@ export const listApiKeysForAuthUser = query({
     const result = (await ctx.runQuery(components.betterAuth.adapter.findMany, {
       model: 'apikey',
       where: [{ field: 'referenceId', operator: 'eq', value: args.authUserId }],
-      select: [
-        '_id',
-        'userId',
-        'name',
-        'start',
-        'prefix',
-        'enabled',
-        'permissions',
-        'metadata',
-        'lastRequest',
-        'expiresAt',
-        'createdAt',
-        'updatedAt',
-        'referenceId',
-      ],
+      select: API_KEY_SERIALIZATION_SELECT,
       paginationOpts: { cursor: null, numItems: 100 },
     })) as {
-      page: Array<{
-        _id?: string;
-        userId: string;
-        name: string | null;
-        start: string | null;
-        prefix: string | null;
-        enabled: boolean | null;
-        permissions?: unknown;
-        metadata?: unknown;
-        referenceId?: string | null;
-        lastRequest?: unknown;
-        expiresAt?: unknown;
-        createdAt?: unknown;
-        updatedAt?: unknown;
-      }>;
+      page: SerializableApiKeyRecord[];
     };
 
     return result.page
@@ -337,13 +335,11 @@ export const getApiKey = query({
   returns: v.union(SerializedApiKey, v.null()),
   handler: async (ctx, args) => {
     requireApiSecret(args.apiSecret);
-    const auth = createAuth(ctx);
-    const api = auth.api as unknown as BetterAuthServerApi;
-    const result = await api.getApiKey({
-      query: {
-        id: args.keyId,
-      },
-    });
+    const result = (await ctx.runQuery(components.betterAuth.adapter.findOne, {
+      model: 'apikey',
+      where: [{ field: '_id', operator: 'eq', value: args.keyId }],
+      select: API_KEY_SERIALIZATION_SELECT,
+    })) as SerializableApiKeyRecord | null;
     return serializeApiKeyRecord(result);
   },
 });
@@ -381,7 +377,7 @@ export const createApiKey = mutation({
         },
       },
     });
-    await ctx.runMutation(components.betterAuth.adapter.updateOne, {
+    const stored = (await ctx.runMutation(components.betterAuth.adapter.updateOne, {
       input: {
         model: 'apikey',
         update: {
@@ -389,10 +385,10 @@ export const createApiKey = mutation({
         },
         where: [{ field: '_id', operator: 'eq', value: created.id }],
       },
-    });
-    const serialized = serializeApiKeyRecord(created);
+    })) as SerializableApiKeyRecord;
+    const serialized = serializeApiKeyRecord(stored);
     if (!serialized) {
-      throw new Error('Better Auth returned an empty API key record');
+      throw new Error('Better Auth returned an API key record without an owner');
     }
 
     return {
@@ -416,38 +412,10 @@ export const backfillApiKeyReferenceIds = mutation({
     const result = (await ctx.runQuery(components.betterAuth.adapter.findMany, {
       model: 'apikey',
       where: [{ field: 'userId', operator: 'eq', value: args.ownerUserId }],
-      select: [
-        '_id',
-        'userId',
-        'name',
-        'start',
-        'prefix',
-        'enabled',
-        'permissions',
-        'metadata',
-        'referenceId',
-        'lastRequest',
-        'expiresAt',
-        'createdAt',
-        'updatedAt',
-      ],
+      select: API_KEY_SERIALIZATION_SELECT,
       paginationOpts: { cursor: null, numItems: 100 },
     })) as {
-      page: Array<{
-        _id?: string;
-        userId: string;
-        name: string | null;
-        start: string | null;
-        prefix: string | null;
-        enabled: boolean | null;
-        permissions?: unknown;
-        metadata?: unknown;
-        referenceId?: string | null;
-        lastRequest?: unknown;
-        expiresAt?: unknown;
-        createdAt?: unknown;
-        updatedAt?: unknown;
-      }>;
+      page: SerializableApiKeyRecord[];
     };
 
     const legacyKeys = result.page
@@ -508,15 +476,26 @@ export const verifyApiKey = mutation({
       },
     });
 
+    const keyId = result.key?.id;
+    const stored =
+      result.valid && typeof keyId === 'string' && keyId.length > 0
+        ? ((await ctx.runQuery(components.betterAuth.adapter.findOne, {
+            model: 'apikey',
+            where: [{ field: '_id', operator: 'eq', value: keyId }],
+            select: API_KEY_SERIALIZATION_SELECT,
+          })) as SerializableApiKeyRecord | null)
+        : null;
+    const serializedKey = serializeApiKeyRecord(stored ?? result.key);
+
     return {
-      valid: result.valid,
+      valid: result.valid && serializedKey !== null,
       error: result.error
         ? {
             code: result.error.code,
             message: result.error.message ?? null,
           }
         : null,
-      key: serializeApiKeyRecord(result.key),
+      key: serializedKey,
     };
   },
 });
@@ -532,15 +511,20 @@ export const updateApiKey = mutation({
     requireApiSecret(args.apiSecret);
     const auth = createAuth(ctx);
     const api = auth.api as unknown as BetterAuthServerApi;
-    const updated = await api.updateApiKey({
+    await api.updateApiKey({
       body: {
         keyId: args.keyId,
         ...(args.enabled !== undefined ? { enabled: args.enabled } : {}),
       },
     });
+    const updated = (await ctx.runQuery(components.betterAuth.adapter.findOne, {
+      model: 'apikey',
+      where: [{ field: '_id', operator: 'eq', value: args.keyId }],
+      select: API_KEY_SERIALIZATION_SELECT,
+    })) as SerializableApiKeyRecord | null;
     const serialized = serializeApiKeyRecord(updated);
     if (!serialized) {
-      throw new Error('Better Auth returned an empty API key record');
+      throw new Error('Better Auth returned an API key record without an owner');
     }
     return serialized;
   },

--- a/convex/betterAuthApiKeys.ts
+++ b/convex/betterAuthApiKeys.ts
@@ -124,9 +124,18 @@ function serializeApiKeyRecord(value: SerializableApiKeyRecord | null) {
         }
       : null;
 
+  // Managed public keys are tenant-owned. Legacy rows retain the session owner
+  // in userId, so use the corroborating referenceId to recover the tenant
+  // without trusting metadata alone.
+  const ownerUserId =
+    metadata?.kind === PUBLIC_API_KEY_METADATA_KIND &&
+    value.referenceId === metadata.authUserId
+      ? metadata.authUserId
+      : value.userId;
+
   return {
     id,
-    userId: value.userId,
+    userId: ownerUserId,
     name: value.name,
     start: value.start,
     prefix: value.prefix,

--- a/convex/betterAuthApiKeys.ts
+++ b/convex/betterAuthApiKeys.ts
@@ -363,7 +363,7 @@ export const createApiKey = mutation({
     const api = auth.api as unknown as BetterAuthServerApi;
     const created = await api.createApiKey({
       body: {
-        userId: args.userId,
+        userId: args.authUserId,
         name: args.name,
         prefix: PUBLIC_API_KEY_PREFIX,
         expiresIn: args.expiresIn,


### PR DESCRIPTION
## Trace Verdict

- `@better-auth/api-key` 1.6.13 accepts server-side `userId` on create, but its create route does not accept `referenceId` as input. With default `references: user`, it derives `referenceId` from the session user or `body.userId` and builds the `apikey` insert with `referenceId`, not `userId`.
- For managed public API keys, this repo's public auth invariant is `metadata.kind === public-api`, `metadata.authUserId` matches the requested public tenant, and `key.userId === metadata.authUserId`.
- `connectApiAccess.ts` passes the signed-in session owner and requested `authUserId`. The reviewed edge case showed those can be distinct in the API layer, so the Better Auth create call must use the public `authUserId` as the API-key owner for this managed public-key path.

Chosen fix: A. `referenceId` is the owner id at the Better Auth insert boundary. The component adapter maps missing `apikey.userId` from `referenceId` before the strict component schema validates and inserts the row. The managed public-key wrapper now passes `authUserId` as Better Auth's server-side `userId`, so `referenceId`, stored `userId`, and `metadata.authUserId` stay aligned for public verification. The schema still requires `userId`; it was not weakened.

## Implementation Notes

- `convex/betterAuth/adapter.ts` wraps Better Auth component create and normalizes only `model === apikey` inserts with a missing `userId` and non-empty `referenceId`.
- `convex/betterAuthApiKeys.ts` serializes stored component rows for create/get/list/update/verify so public auth sees the persisted owner.
- The create path now derives ownership at insert time and does a read-only lookup for serialization. It no longer creates and then rewrites `referenceId`.
- `convex/betterAuthApiKeys.realtest.ts` covers both same-owner creation and a distinct session-owner/public-tenant case, including stored row and verify assertions.

## Verification

- RED focused realtest before fix: `convex/betterAuthApiKeys.realtest.ts` failed with Convex validator error because the Better Auth `apikey` insert payload contained `referenceId` but no `userId`.
- RED review regression before follow-up fix: distinct session owner/public tenant test failed with `expected 10001;user, received 10000;user`.
- GREEN focused realtest after final fix: 1 file passed, 2 tests passed.
- `bun run test:convex`: 46 files passed, 366 tests passed.
- `bun run lint`: passed.
- `bun run typecheck`: passed.
- `bun run test:external-integrations`: passed.
- `bun audit`: fails on existing `@better-auth/oauth-provider` advisory `GHSA-p2fr-6hmx-4528`; dependency policy update is outside this scoped prod hotfix.

## E2E Status

`apps/api/test/e2e/user-journeys.test.ts` has no `test.failing` gates to flip. I attempted local `bun run test:e2e:flows`; Docker came up and tore down cleanly, but Convex deploy failed before tests ran because `@polar-sh/sdk@0.46.6` has a zero-byte `dist/esm/funcs/licenseKeysDeactivate.js.map` and esbuild reported `Unexpected end of file in source map`. The GitHub `E2E User Flows` check is green on the final commit.

## Bot Status

All actionable review threads were replied to and resolved. CodeRabbit's status check remains failed because prepaid credits are exhausted, not because of a code finding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved API key ownership and tenant association during creation, verification, listing, retrieval, and updates.
  - Ensured API key details consistently reflect stored records, including legacy keys.
  - Improved handling of API keys created without a valid owner identifier.
  - Added validation to prevent incomplete or unidentifiable API key records from being returned.
- **Tests**
  - Added coverage for managed public keys, differing session and tenant owners, and legacy key verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->