### PR TITLE
fix: bind backstage repo downloads to token capability

### DIFF
--- a/apps/api/src/routes/backstageRepos.test.ts
+++ b/apps/api/src/routes/backstageRepos.test.ts
@@ -537,6 +537,13 @@ describe('backstage repo routes', () => {
     expect(mutationCalls).toContainEqual({
       ref: 'backstageRepos.issueRepoTokenForApi',
       args: expect.objectContaining({
+        actor: expect.objectContaining({
+          payload: JSON.stringify({
+            authUserId: 'buyer-user-1',
+            source: 'session',
+          }),
+          signature: 'test-signature',
+        }),
         authUserId: 'creator-user-1',
         subjectAuthUserId: 'buyer-user-1',
         subjectId: 'subject_buyer_1',
@@ -745,6 +752,17 @@ describe('backstage repo routes', () => {
     expect(response?.status).toBe(302);
     expect(response?.headers.get('location')).toBe('https://downloads.example/package.zip');
     expect(response?.headers.get('cache-control')).toBe('no-store');
+    const repoAccessCall = convexQueryCalls.find(
+      (call) => call.reference === 'backstageRepos.getRepoAccessByTokenForApi'
+    );
+    const packageDownloadCall = convexQueryCalls.find(
+      (call) => call.reference === 'backstageRepos.resolvePackageDownloadForApi'
+    );
+    expect(packageDownloadCall?.args).toEqual(
+      expect.objectContaining({
+        tokenHash: (repoAccessCall?.args as { tokenHash?: string } | undefined)?.tokenHash,
+      })
+    );
   });
 
   it('redirects entitled package downloads through CDNgine when a deliverable reference exists', async () => {
@@ -2102,6 +2120,18 @@ describe('backstage repo routes', () => {
       }),
       signature: 'test-signature',
     });
+    expect(rawPackageResolutionCall?.args).toEqual(
+      expect.objectContaining({
+        actor: expect.objectContaining({
+          payload: JSON.stringify({
+            service: 'backstage-access',
+            scopes: ['creator:delegate'],
+            authUserId: 'creator-user-1',
+          }),
+          signature: 'test-signature',
+        }),
+      })
+    );
   });
 
   it('does not fall back to package URLs when CDNgine source authorization fails', async () => {

--- a/apps/api/src/routes/backstageRepos.test.ts
+++ b/apps/api/src/routes/backstageRepos.test.ts
@@ -765,6 +765,30 @@ describe('backstage repo routes', () => {
     );
   });
 
+  it('maps repo-token download authorization races to package not found responses', async () => {
+    const defaultQueryImpl = queryImpl;
+    queryImpl = async (ref: unknown, args?: unknown) => {
+      if (ref === 'backstageRepos.resolvePackageDownloadForApi') {
+        throw new Error('Unauthorized: Backstage repo token does not authorize this subject.');
+      }
+      return defaultQueryImpl(ref, args);
+    };
+
+    const response = await routes.handleRequest(
+      new Request(
+        'https://api.test/v1/backstage/repos/mapache/package?packageId=com.yucp.example&version=1.2.3&channel=stable',
+        {
+          headers: {
+            'X-YUCP-Repo-Token': 'ybt_example',
+          },
+        }
+      )
+    );
+
+    expect(response?.status).toBe(404);
+    await expect(response?.json()).resolves.toEqual({ error: 'Package not found' });
+  });
+
   it('redirects entitled package downloads through CDNgine when a deliverable reference exists', async () => {
     const fetchCalls: Array<{ input: string | URL | Request; init?: RequestInit }> = [];
     globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {

--- a/apps/api/src/routes/backstageRepos.ts
+++ b/apps/api/src/routes/backstageRepos.ts
@@ -230,6 +230,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function isUnauthorizedError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    /^Unauthorized(?::|$)/.test(message) ||
+    message.includes('ConvexError: Unauthorized') ||
+    message.includes('"Unauthorized:')
+  );
+}
+
 function extractForwardedToolchainPackages(repository: unknown): BackstageRepositoryPackages {
   if (!isRecord(repository) || !isRecord(repository.packages)) {
     throw new Error('Forwarded toolchain repository is missing a packages object.');
@@ -1862,15 +1871,23 @@ async function servePackageDownload(
   }
 
   const convex = getConvexClientFromUrl(config.convexUrl);
-  const resolved = (await convex.query(api.backstageRepos.resolvePackageDownloadForApi, {
-    apiSecret: config.convexApiSecret,
-    tokenHash: access.tokenHash,
-    authUserId: access.authUserId,
-    subjectId: access.subjectId,
-    packageId,
-    version,
-    channel,
-  })) as BackstagePackageDownloadRecord | null;
+  let resolved: BackstagePackageDownloadRecord | null;
+  try {
+    resolved = (await convex.query(api.backstageRepos.resolvePackageDownloadForApi, {
+      apiSecret: config.convexApiSecret,
+      tokenHash: access.tokenHash,
+      authUserId: access.authUserId,
+      subjectId: access.subjectId,
+      packageId,
+      version,
+      channel,
+    })) as BackstagePackageDownloadRecord | null;
+  } catch (error) {
+    if (isUnauthorizedError(error)) {
+      return errorResponse('Package not found', 404);
+    }
+    throw error;
+  }
   if (!resolved) {
     return errorResponse('Package not found', 404);
   }

--- a/apps/api/src/routes/backstageRepos.ts
+++ b/apps/api/src/routes/backstageRepos.ts
@@ -693,6 +693,7 @@ async function getAuthorizedAliasInstallPlanForViewer(
   }
 ): Promise<{
   convex: ReturnType<typeof getConvexClientFromUrl>;
+  actor: ApiActorBinding;
   plan: AuthorizedAliasInstallPlanRecord | null;
 }> {
   const actor = await resolveAliasInstallPlanActor(viewer, input.authUserId);
@@ -706,16 +707,18 @@ async function getAuthorizedAliasInstallPlanForViewer(
     productRef: input.productRef,
   })) as AuthorizedAliasInstallPlanRecord | null;
 
-  return { convex, plan };
+  return { convex, actor, plan };
 }
 
 async function getActiveSubjectId(
   convex: ReturnType<typeof getConvexClientFromUrl>,
   config: BackstageRepoConfig,
-  authUserId: string
+  authUserId: string,
+  actor: ApiActorBinding
 ): Promise<Id<'subjects'> | null> {
   const subject = await convex.query(api.backstageRepos.getSubjectByAuthUserForApi, {
     apiSecret: config.convexApiSecret,
+    actor,
     authUserId,
   });
   return subject?._id ?? null;
@@ -783,6 +786,7 @@ async function resolveRepoAccess(
   | {
       ok: true;
       rawToken: string;
+      tokenHash: string;
       tokenId: string;
       authUserId: string;
       subjectId: string;
@@ -796,9 +800,10 @@ async function resolveRepoAccess(
   }
 
   const convex = getConvexClientFromUrl(config.convexUrl);
+  const tokenHash = await sha256Hex(rawToken);
   const access = await convex.query(api.backstageRepos.getRepoAccessByTokenForApi, {
     apiSecret: config.convexApiSecret,
-    tokenHash: await sha256Hex(rawToken),
+    tokenHash,
   });
   if (!access) {
     return { ok: false };
@@ -827,6 +832,7 @@ async function resolveRepoAccess(
   return {
     ok: true,
     rawToken,
+    tokenHash,
     tokenId: access.tokenId,
     authUserId: access.authUserId,
     subjectId: access.subjectId,
@@ -845,7 +851,12 @@ async function issueRepoAccess(
   }
 
   const convex = getConvexClientFromUrl(config.convexUrl, viewer.actorBinding);
-  const subjectId = await getActiveSubjectId(convex, config, viewer.authUserId);
+  const subjectId = await getActiveSubjectId(
+    convex,
+    config,
+    viewer.authUserId,
+    viewer.actorBinding
+  );
   if (!subjectId) {
     return errorResponse('No active subject found for this account', 404);
   }
@@ -914,6 +925,7 @@ async function issueRepoAccess(
   const now = Date.now();
   const issued = await convex.mutation(api.backstageRepos.issueRepoTokenForApi, {
     apiSecret: config.convexApiSecret,
+    actor: viewer.actorBinding,
     authUserId: repoAuthUserId,
     subjectAuthUserId: viewer.authUserId,
     subjectId,
@@ -958,7 +970,12 @@ async function issueAuthorizedAliasInstallPlan(
 
   try {
     const convex = getConvexClientFromUrl(config.convexUrl, viewer.actorBinding);
-    const subjectId = await getActiveSubjectId(convex, config, viewer.authUserId);
+    const subjectId = await getActiveSubjectId(
+      convex,
+      config,
+      viewer.authUserId,
+      viewer.actorBinding
+    );
     if (!subjectId) {
       return errorResponse('No active subject found for this account', 404);
     }
@@ -973,16 +990,16 @@ async function issueAuthorizedAliasInstallPlan(
       return errorResponse('Alias install plan not found', 404);
     }
 
-    const { convex: planConvex, plan } = await getAuthorizedAliasInstallPlanForViewer(
-      config,
-      viewer,
-      {
-        authUserId: resolved.access.creatorAuthUserId,
-        subjectId,
-        creatorRef,
-        productRef,
-      }
-    );
+    const {
+      convex: planConvex,
+      actor: planActor,
+      plan,
+    } = await getAuthorizedAliasInstallPlanForViewer(config, viewer, {
+      authUserId: resolved.access.creatorAuthUserId,
+      subjectId,
+      creatorRef,
+      productRef,
+    });
     if (!plan) {
       return errorResponse('Alias install plan not found', 404);
     }
@@ -995,6 +1012,7 @@ async function issueAuthorizedAliasInstallPlan(
     return await buildAuthorizedAliasInstallPlanResponse(
       config,
       planConvex,
+      planActor,
       plan,
       subjectId,
       publicCatalogProductRef,
@@ -1045,7 +1063,12 @@ async function issueAuthorizedAliasInstallPlanForCatalogProduct(
 
   try {
     const convex = getConvexClientFromUrl(config.convexUrl, viewer.actorBinding);
-    const subjectId = await getActiveSubjectId(convex, config, viewer.authUserId);
+    const subjectId = await getActiveSubjectId(
+      convex,
+      config,
+      viewer.authUserId,
+      viewer.actorBinding
+    );
     if (!subjectId) {
       return errorResponse('No active subject found for this account', 404);
     }
@@ -1068,16 +1091,16 @@ async function issueAuthorizedAliasInstallPlanForCatalogProduct(
       throw new Error('Alias product access context was incomplete.');
     }
 
-    const { convex: planConvex, plan } = await getAuthorizedAliasInstallPlanForViewer(
-      config,
-      viewer,
-      {
-        authUserId: product.creatorAuthUserId,
-        subjectId,
-        creatorRef,
-        productRef,
-      }
-    );
+    const {
+      convex: planConvex,
+      actor: planActor,
+      plan,
+    } = await getAuthorizedAliasInstallPlanForViewer(config, viewer, {
+      authUserId: product.creatorAuthUserId,
+      subjectId,
+      creatorRef,
+      productRef,
+    });
     if (!plan) {
       return errorResponse('Alias install plan not found', 404);
     }
@@ -1085,6 +1108,7 @@ async function issueAuthorizedAliasInstallPlanForCatalogProduct(
     return await buildAuthorizedAliasInstallPlanResponse(
       config,
       planConvex,
+      planActor,
       plan,
       subjectId,
       productRef,
@@ -1104,6 +1128,7 @@ async function issueAuthorizedAliasInstallPlanForCatalogProduct(
 async function buildAuthorizedAliasInstallPlanResponse(
   config: BackstageRepoConfig,
   convex: ReturnType<typeof getConvexClientFromUrl>,
+  actor: ApiActorBinding,
   plan: AuthorizedAliasInstallPlanRecord,
   subjectId: string,
   publicCatalogProductRef: string,
@@ -1139,6 +1164,7 @@ async function buildAuthorizedAliasInstallPlanResponse(
           api.backstageRepos.resolveRawPackageDownloadForApi,
           {
             apiSecret: config.convexApiSecret,
+            actor,
             authUserId: plan.creatorAuthUserId,
             subjectId: subjectId as Id<'subjects'>,
             packageId: pkg.packageId,
@@ -1292,7 +1318,12 @@ async function issueAuthorizedPackageDownloadForCatalogProduct(
     const requestedVersion = readOptionalBodyString(body, 'version');
     const requestedChannel = readOptionalBodyString(body, 'channel');
     const convex = getConvexClientFromUrl(config.convexUrl, viewer.actorBinding);
-    const subjectId = await getActiveSubjectId(convex, config, viewer.authUserId);
+    const subjectId = await getActiveSubjectId(
+      convex,
+      config,
+      viewer.authUserId,
+      viewer.actorBinding
+    );
     if (!subjectId) {
       return errorResponse('No active subject found for this account', 404);
     }
@@ -1315,16 +1346,16 @@ async function issueAuthorizedPackageDownloadForCatalogProduct(
       throw new Error('Alias product access context was incomplete.');
     }
 
-    const { convex: planConvex, plan } = await getAuthorizedAliasInstallPlanForViewer(
-      config,
-      viewer,
-      {
-        authUserId: product.creatorAuthUserId,
-        subjectId,
-        creatorRef,
-        productRef,
-      }
-    );
+    const {
+      convex: planConvex,
+      actor: planActor,
+      plan,
+    } = await getAuthorizedAliasInstallPlanForViewer(config, viewer, {
+      authUserId: product.creatorAuthUserId,
+      subjectId,
+      creatorRef,
+      productRef,
+    });
     const planPackage = plan?.packages.find((pkg) => pkg.packageId === packageId);
     if (!planPackage) {
       return errorResponse('Package not found', 404);
@@ -1338,6 +1369,7 @@ async function issueAuthorizedPackageDownloadForCatalogProduct(
 
     const resolved = (await planConvex.query(api.backstageRepos.resolveRawPackageDownloadForApi, {
       apiSecret: config.convexApiSecret,
+      actor: planActor,
       authUserId: product.creatorAuthUserId,
       subjectId,
       packageId,
@@ -1430,7 +1462,12 @@ async function issueAuthorizedPackageMediaDownloadForCatalogProduct(
 
   try {
     const convex = getConvexClientFromUrl(config.convexUrl, viewer.actorBinding);
-    const subjectId = await getActiveSubjectId(convex, config, viewer.authUserId);
+    const subjectId = await getActiveSubjectId(
+      convex,
+      config,
+      viewer.authUserId,
+      viewer.actorBinding
+    );
     if (!subjectId) {
       return errorResponse('No active subject found for this account', 404);
     }
@@ -1827,6 +1864,7 @@ async function servePackageDownload(
   const convex = getConvexClientFromUrl(config.convexUrl);
   const resolved = (await convex.query(api.backstageRepos.resolvePackageDownloadForApi, {
     apiSecret: config.convexApiSecret,
+    tokenHash: access.tokenHash,
     authUserId: access.authUserId,
     subjectId: access.subjectId,
     packageId,

--- a/apps/api/src/routes/connectUserProductAccess.test.ts
+++ b/apps/api/src/routes/connectUserProductAccess.test.ts
@@ -37,11 +37,29 @@ mock.module('../../../../convex/_generated/api', () => ({
   internal: {},
 }));
 
+function applyExplicitActor(args: unknown, actor: unknown): unknown {
+  if (!actor || !args || typeof args !== 'object' || Array.isArray(args)) {
+    return args;
+  }
+
+  if (!('apiSecret' in (args as Record<string, unknown>))) {
+    return args;
+  }
+
+  return {
+    ...(args as Record<string, unknown>),
+    actor,
+  };
+}
+
 mock.module('../lib/convex', () => ({
-  getConvexClientFromUrl: () => ({
-    query: convexQueryMock,
-    mutation: convexMutationMock,
-    action: convexActionMock,
+  getConvexClientFromUrl: (_url: string, actor?: unknown) => ({
+    query: (reference: unknown, args?: unknown) =>
+      convexQueryMock(reference, applyExplicitActor(args, actor)),
+    mutation: (reference: unknown, args?: unknown) =>
+      convexMutationMock(reference, applyExplicitActor(args, actor)),
+    action: (reference: unknown, args?: unknown) =>
+      convexActionMock(reference, applyExplicitActor(args, actor)),
   }),
 }));
 

--- a/apps/api/src/routes/connectUserProductAccess.test.ts
+++ b/apps/api/src/routes/connectUserProductAccess.test.ts
@@ -211,6 +211,7 @@ describe('connect user product access routes', () => {
       if (reference === apiMock.backstageRepos.getSubjectByAuthUserForApi) {
         expect(args).toEqual({
           apiSecret: 'test-convex-secret',
+          actor: 'actor-binding',
           authUserId: 'buyer-auth-user',
         });
         return { _id: 'subject_buyer_1' };
@@ -358,6 +359,7 @@ describe('connect user product access routes', () => {
       if (reference === apiMock.backstageRepos.getSubjectByAuthUserForApi) {
         expect(args).toEqual({
           apiSecret: 'test-convex-secret',
+          actor: 'actor-binding',
           authUserId: 'buyer-auth-user',
         });
         return { _id: 'subject_buyer_1' };

--- a/apps/api/src/routes/connectUserProductAccess.ts
+++ b/apps/api/src/routes/connectUserProductAccess.ts
@@ -174,7 +174,13 @@ export function createConnectUserProductAccessRoutes({
     const session = await auth.getSession(request);
 
     try {
-      const convex = getConvexClientFromUrl(config.convexUrl);
+      const buyerActor = session
+        ? await createAuthUserActorBinding({
+            authUserId: session.user.id,
+            source: 'session',
+          })
+        : null;
+      const convex = getConvexClientFromUrl(config.convexUrl, buyerActor ?? undefined);
       const product = await resolveAccessProduct(catalogProductId);
       if (!product) {
         return Response.json({ error: 'Product access page not found' }, { status: 404 });
@@ -183,6 +189,7 @@ export function createConnectUserProductAccessRoutes({
       const buyerSubject = session
         ? ((await convex.query(api.backstageRepos.getSubjectByAuthUserForApi, {
             apiSecret: config.convexApiSecret,
+            actor: buyerActor,
             authUserId: session.user.id,
           })) as { _id: Id<'subjects'> } | null)
         : null;

--- a/apps/api/src/routes/connectUserProductAccess.ts
+++ b/apps/api/src/routes/connectUserProductAccess.ts
@@ -180,14 +180,14 @@ export function createConnectUserProductAccessRoutes({
             source: 'session',
           })
         : null;
-      const convex = getConvexClientFromUrl(config.convexUrl, buyerActor ?? undefined);
+      const buyerConvex = buyerActor ? getConvexClientFromUrl(config.convexUrl, buyerActor) : null;
       const product = await resolveAccessProduct(catalogProductId);
       if (!product) {
         return Response.json({ error: 'Product access page not found' }, { status: 404 });
       }
 
       const buyerSubject = session
-        ? ((await convex.query(api.backstageRepos.getSubjectByAuthUserForApi, {
+        ? ((await buyerConvex?.query(api.backstageRepos.getSubjectByAuthUserForApi, {
             apiSecret: config.convexApiSecret,
             actor: buyerActor,
             authUserId: session.user.id,
@@ -195,18 +195,22 @@ export function createConnectUserProductAccessRoutes({
         : null;
       const entitlementsResult =
         session && buyerSubject
-          ? await convex.query(api.entitlements.listByAuthUser, {
-              apiSecret: config.convexApiSecret,
-              actor: await createApiServiceActorBinding({
+          ? await (async () => {
+              const entitlementActor = await createApiServiceActorBinding({
                 service: 'api-server',
                 scopes: ['creator:delegate'],
-              }),
-              authUserId: product.creatorAuthUserId,
-              subjectId: buyerSubject._id,
-              productId: product.productId,
-              status: 'active',
-              limit: 20,
-            })
+              });
+              const entitlementConvex = getConvexClientFromUrl(config.convexUrl, entitlementActor);
+              return await entitlementConvex.query(api.entitlements.listByAuthUser, {
+                apiSecret: config.convexApiSecret,
+                actor: entitlementActor,
+                authUserId: product.creatorAuthUserId,
+                subjectId: buyerSubject._id,
+                productId: product.productId,
+                status: 'active',
+                limit: 20,
+              });
+            })()
           : { data: [] };
       const activeEntitlement =
         entitlementsResult.data?.find(

--- a/apps/api/src/routes/packages.backstage.test.ts
+++ b/apps/api/src/routes/packages.backstage.test.ts
@@ -955,6 +955,13 @@ describe('package Backstage publishing routes', () => {
     });
     expect(payload).not.toHaveProperty('repoToken');
     expect(payload).not.toHaveProperty('repoTokenHeader');
+    expect(lastActionArgs).toEqual(
+      expect.objectContaining({
+        actor: 'actor-binding',
+        authUserId: 'auth-user-1',
+        subjectId: 'subject_1',
+      })
+    );
   });
 
   it('falls back to generic repo labeling for synthetic creator names', async () => {

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -1065,6 +1065,7 @@ export function createPackageRoutes(auth: Auth, config: PackagesConfig) {
     try {
       const subject = await convex.query(api.backstageRepos.getSubjectByAuthUserForApi, {
         apiSecret: config.convexApiSecret,
+        actor: viewer.actorBinding,
         authUserId: viewer.authUserId,
       });
       if (!subject) {
@@ -1074,6 +1075,7 @@ export function createPackageRoutes(auth: Auth, config: PackagesConfig) {
       const now = Date.now();
       const issued = await convex.mutation(api.backstageRepos.issueRepoTokenForApi, {
         apiSecret: config.convexApiSecret,
+        actor: viewer.actorBinding,
         authUserId: viewer.authUserId,
         subjectId: subject._id,
         label: 'Dashboard Backstage Repos',

--- a/convex/backstageRepos.ts
+++ b/convex/backstageRepos.ts
@@ -5,10 +5,10 @@ import type {
   CdngineBackstageDeliveryReference,
   CdngineBackstageSourceReference,
 } from '@yucp/shared/cdngineBackstageDelivery';
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 import { internal } from './_generated/api';
 import type { Id } from './_generated/dataModel';
-import { internalQuery, mutation, query } from './_generated/server';
+import { internalQuery, mutation, query, type MutationCtx, type QueryCtx } from './_generated/server';
 import { ApiActorBindingV, requireDelegatedAuthUserActor } from './lib/apiActor';
 import { requireApiSecret } from './lib/apiAuth';
 
@@ -90,6 +90,55 @@ type BackstagePublishedReleaseRecord = {
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function unauthorized(message: string): never {
+  throw new ConvexError(`Unauthorized: ${message}`);
+}
+
+async function requireActiveSubjectOwner(
+  ctx: QueryCtx | MutationCtx,
+  args: {
+    authUserId: string;
+    subjectId: Id<'subjects'>;
+  }
+): Promise<void> {
+  const subject = await ctx.db.get(args.subjectId);
+  if (!subject || subject.status !== 'active' || subject.authUserId !== args.authUserId) {
+    unauthorized('subject does not belong to auth user');
+  }
+}
+
+async function requireBackstageRepoTokenBinding(
+  ctx: QueryCtx,
+  args: {
+    tokenHash: string;
+    authUserId: string;
+    subjectId: Id<'subjects'>;
+  }
+): Promise<BackstageRepoAccessRecord> {
+  const access = await ctx.runQuery(internal.packageRegistry.getBackstageRepoAccessByToken, {
+    tokenHash: args.tokenHash,
+  });
+  if (!access) {
+    unauthorized('repo token is inactive or expired');
+  }
+  if (access.status !== 'active') {
+    unauthorized('repo token is inactive or expired');
+  }
+  if (typeof access.expiresAt === 'number' && access.expiresAt <= Date.now()) {
+    unauthorized('repo token is inactive or expired');
+  }
+  if (access.authUserId !== args.authUserId || String(access.subjectId) !== String(args.subjectId)) {
+    unauthorized('repo token does not authorize this subject');
+  }
+
+  const subject = await ctx.db.get(args.subjectId);
+  if (!subject || subject.status !== 'active') {
+    unauthorized('subject is inactive');
+  }
+
+  return access;
 }
 
 function normalizeBackstageMetadataInput(input: {
@@ -217,11 +266,13 @@ export const resolveAliasContractMetadataForApi = query({
 export const getSubjectByAuthUserForApi = query({
   args: {
     apiSecret: v.string(),
+    actor: ApiActorBindingV,
     authUserId: v.string(),
   },
   returns: v.union(v.null(), v.object({ _id: v.id('subjects') })),
   handler: async (ctx, args): Promise<{ _id: Id<'subjects'> } | null> => {
     requireApiSecret(args.apiSecret);
+    await requireDelegatedAuthUserActor(args.actor, args.authUserId);
     return await ctx.runQuery(internal.yucpLicenses.getSubjectByAuthUser, {
       authUserId: args.authUserId,
     });
@@ -231,6 +282,7 @@ export const getSubjectByAuthUserForApi = query({
 export const issueRepoTokenForApi = mutation({
   args: {
     apiSecret: v.string(),
+    actor: ApiActorBindingV,
     authUserId: v.string(),
     subjectAuthUserId: v.optional(v.string()),
     subjectId: v.id('subjects'),
@@ -247,6 +299,12 @@ export const issueRepoTokenForApi = mutation({
     args
   ): Promise<{ token: string; tokenId: Id<'delivery_repo_tokens'>; expiresAt?: number }> => {
     requireApiSecret(args.apiSecret);
+    const subjectOwnerAuthUserId = args.subjectAuthUserId ?? args.authUserId;
+    await requireDelegatedAuthUserActor(args.actor, subjectOwnerAuthUserId);
+    await requireActiveSubjectOwner(ctx, {
+      authUserId: subjectOwnerAuthUserId,
+      subjectId: args.subjectId,
+    });
     return await ctx.runMutation(internal.packageRegistry.issueBackstageRepoToken, {
       authUserId: args.authUserId,
       subjectAuthUserId: args.subjectAuthUserId,
@@ -322,6 +380,7 @@ export const buildRepositoryForApi = query({
 export const resolvePackageDownloadForApi = query({
   args: {
     apiSecret: v.string(),
+    tokenHash: v.string(),
     authUserId: v.string(),
     subjectId: v.id('subjects'),
     packageId: v.string(),
@@ -348,6 +407,11 @@ export const resolvePackageDownloadForApi = query({
   ),
   handler: async (ctx, args): Promise<BackstagePackageDownloadRecord | null> => {
     requireApiSecret(args.apiSecret);
+    await requireBackstageRepoTokenBinding(ctx, {
+      tokenHash: args.tokenHash,
+      authUserId: args.authUserId,
+      subjectId: args.subjectId,
+    });
     return await ctx.runQuery(
       internal.packageRegistry.getResolvedEntitledPackageDownloadForSubject,
       {
@@ -364,6 +428,8 @@ export const resolvePackageDownloadForApi = query({
 export const resolveRawPackageDownloadForApi = query({
   args: {
     apiSecret: v.string(),
+    actor: v.optional(ApiActorBindingV),
+    tokenHash: v.optional(v.string()),
     authUserId: v.string(),
     subjectId: v.id('subjects'),
     packageId: v.string(),
@@ -386,6 +452,17 @@ export const resolveRawPackageDownloadForApi = query({
   ),
   handler: async (ctx, args): Promise<BackstageRawPackageDownloadRecord | null> => {
     requireApiSecret(args.apiSecret);
+    if (args.tokenHash) {
+      await requireBackstageRepoTokenBinding(ctx, {
+        tokenHash: args.tokenHash,
+        authUserId: args.authUserId,
+        subjectId: args.subjectId,
+      });
+    } else if (args.actor) {
+      await requireDelegatedAuthUserActor(args.actor, args.authUserId);
+    } else {
+      unauthorized('missing repo token or actor binding');
+    }
     return await ctx.runQuery(
       internal.packageRegistry.getResolvedEntitledRawPackageDownloadForSubject,
       {

--- a/convex/packageRegistry.realtest.ts
+++ b/convex/packageRegistry.realtest.ts
@@ -1818,6 +1818,7 @@ describe('packageRegistry', () => {
 
     const issued = await t.mutation(api.backstageRepos.issueRepoTokenForApi, {
       apiSecret: 'test-secret',
+      actor: await createAuthUserActorBinding('buyer-auth-flow'),
       authUserId: 'auth-user-1',
       subjectAuthUserId: 'buyer-auth-flow',
       subjectId,
@@ -1851,6 +1852,7 @@ describe('packageRegistry', () => {
 
     const rawDownload = await t.query(api.backstageRepos.resolveRawPackageDownloadForApi, {
       apiSecret: 'test-secret',
+      tokenHash: await sha256Hex(new TextEncoder().encode(issued.token)),
       authUserId: 'auth-user-1',
       subjectId,
       packageId: 'com.yucp.backstage.cdngineflow',
@@ -1929,6 +1931,174 @@ describe('packageRegistry', () => {
         variant: 'preserve-original',
       },
     });
+  });
+
+  it('rejects repo-token package download resolution when the token subject binding mismatches', async () => {
+    const t = makeTestConvex();
+    const now = Date.now();
+    const catalogProductId = await seedCatalogProduct(t, {
+      authUserId: 'auth-user-f24-u1',
+      productId: 'product-f24-binding',
+      providerProductRef: 'gumroad-product-f24-binding',
+      displayName: 'F24 Binding Product',
+    });
+
+    await t.mutation(internal.packageRegistry.registerPackage, {
+      packageId: 'com.yucp.backstage.f24binding',
+      packageName: 'F24 Binding Package',
+      publisherId: 'publisher-f24',
+      yucpUserId: 'auth-user-f24-u1',
+    });
+
+    await t.mutation(internal.packageRegistry.upsertDeliveryPackageForProduct, {
+      authUserId: 'auth-user-f24-u1',
+      catalogProductId,
+      packageId: 'com.yucp.backstage.f24binding',
+      packageName: 'F24 Binding Package',
+      displayName: 'F24 Binding Package',
+      repositoryVisibility: 'listed',
+      defaultChannel: 'stable',
+    });
+
+    const release = await t.mutation(internal.packageRegistry.recordDeliveryPackageRelease, {
+      authUserId: 'auth-user-f24-u1',
+      packageId: 'com.yucp.backstage.f24binding',
+      version: '1.0.0',
+      channel: 'stable',
+      releaseStatus: 'published',
+      repositoryVisibility: 'listed',
+      zipSha256: 'b'.repeat(64),
+    });
+
+    await t.run(async (ctx) => {
+      const rawArtifactId = await ctx.db.insert('delivery_release_artifacts', {
+        deliveryPackageReleaseId: release.deliveryPackageReleaseId,
+        artifactRole: 'raw_upload',
+        ownership: 'creator_upload',
+        contentType: 'application/octet-stream',
+        deliveryName: 'F24_Binding_1.0.0.unitypackage',
+        sha256: 'a'.repeat(64),
+        byteSize: 123,
+        status: 'active',
+        activatedAt: now,
+        createdAt: now,
+        updatedAt: now,
+        cdngineSource: {
+          assetId: 'ast_raw_f24_binding',
+          assetOwner: 'creator:auth-user-f24-u1',
+          byteSize: 123,
+          serviceNamespaceId: 'yucp-backstage',
+          sha256: 'a'.repeat(64),
+          uploadedAt: now,
+          versionId: 'ver_raw_f24_binding',
+        },
+      } as never);
+      await ctx.db.insert('delivery_release_artifacts', {
+        deliveryPackageReleaseId: release.deliveryPackageReleaseId,
+        artifactRole: 'server_deliverable',
+        ownership: 'server_materialized',
+        materializationStrategy: 'normalized_repack',
+        sourceArtifactId: rawArtifactId,
+        contentType: 'application/zip',
+        deliveryName: 'vrc-get-com.yucp.backstage.f24binding-1.0.0.zip',
+        sha256: 'b'.repeat(64),
+        byteSize: 456,
+        status: 'active',
+        activatedAt: now,
+        createdAt: now,
+        updatedAt: now,
+        cdngineDelivery: {
+          assetId: 'ast_deliverable_f24_binding',
+          assetOwner: 'creator:auth-user-f24-u1',
+          byteSize: 456,
+          deliveryScopeId: 'paid-downloads',
+          serviceNamespaceId: 'yucp-backstage',
+          sha256: 'b'.repeat(64),
+          uploadedAt: now,
+          variant: 'preserve-original',
+          versionId: 'ver_deliverable_f24_binding',
+        },
+      } as never);
+    });
+
+    const subjectS1 = await seedSubject(t, {
+      authUserId: 'auth-user-f24-u1',
+      primaryDiscordUserId: 'discord-f24-s1',
+    });
+    const subjectS2 = await seedSubject(t, {
+      authUserId: 'auth-user-f24-u2',
+      primaryDiscordUserId: 'discord-f24-s2',
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('entitlements', {
+        authUserId: 'auth-user-f24-u1',
+        subjectId: subjectS1,
+        productId: 'product-f24-binding',
+        sourceProvider: 'gumroad',
+        sourceReference: 'order-f24-s1',
+        catalogProductId,
+        status: 'active',
+        grantedAt: now,
+        updatedAt: now,
+      });
+    });
+
+    const issued = await t.mutation(api.backstageRepos.issueRepoTokenForApi, {
+      apiSecret: 'test-secret',
+      actor: await createAuthUserActorBinding('auth-user-f24-u1'),
+      authUserId: 'auth-user-f24-u1',
+      subjectId: subjectS1,
+      label: 'F24 binding token',
+      expiresAt: now + 30 * 24 * 60 * 60 * 1000,
+    });
+    expect(issued.token).toMatch(/^ybt_[0-9a-f]+$/);
+    const tokenHash = await sha256Hex(new TextEncoder().encode(issued.token));
+    const downloadArgs = {
+      apiSecret: 'test-secret',
+      authUserId: 'auth-user-f24-u1',
+      tokenHash,
+      packageId: 'com.yucp.backstage.f24binding',
+      version: '1.0.0',
+      channel: 'stable',
+    };
+
+    await expect(
+      t.query(api.backstageRepos.resolvePackageDownloadForApi, {
+        ...downloadArgs,
+        subjectId: subjectS1,
+      } as never)
+    ).resolves.toMatchObject({
+      deliveryName: 'vrc-get-com.yucp.backstage.f24binding-1.0.0.zip',
+      zipSha256: 'b'.repeat(64),
+      version: '1.0.0',
+      channel: 'stable',
+    });
+    await expect(
+      t.query(api.backstageRepos.resolveRawPackageDownloadForApi, {
+        ...downloadArgs,
+        subjectId: subjectS1,
+      } as never)
+    ).resolves.toMatchObject({
+      deliveryName: 'F24_Binding_1.0.0.unitypackage',
+      packageSha256: 'a'.repeat(64),
+      sourceKind: 'unitypackage',
+      version: '1.0.0',
+      channel: 'stable',
+    });
+
+    await expect(
+      t.query(api.backstageRepos.resolvePackageDownloadForApi, {
+        ...downloadArgs,
+        subjectId: subjectS2,
+      } as never)
+    ).rejects.toThrow('Unauthorized');
+    await expect(
+      t.query(api.backstageRepos.resolveRawPackageDownloadForApi, {
+        ...downloadArgs,
+        subjectId: subjectS2,
+      } as never)
+    ).rejects.toThrow('Unauthorized');
   });
 
   it('refuses ambiguous legacy alias synthesis when linked products resolve to different alias ids', async () => {

--- a/ops/backstage-live-download-e2e.ts
+++ b/ops/backstage-live-download-e2e.ts
@@ -211,11 +211,13 @@ async function describeDeliveryAuthorization(input: {
   config: Config;
   repoPackage: RepoPackage;
   subjectId: string;
+  tokenHash: string;
 }): Promise<string> {
   const packageUrl = new URL(input.repoPackage.url);
   const channel = packageUrl.searchParams.get('channel') ?? 'stable';
   const resolved = (await input.client.query(api.backstageRepos.resolvePackageDownloadForApi, {
     apiSecret: input.apiSecret,
+    tokenHash: input.tokenHash,
     authUserId: input.config.creatorAuthUserId,
     channel,
     packageId: input.config.packageId,
@@ -467,6 +469,7 @@ async function verifyRawPackageSourceDownload(input: {
   client: ConvexClient;
   config: Config;
   subjectId: string;
+  tokenHash: string;
 }): Promise<{
   bytes: number;
   deliveryArtifactId: string;
@@ -476,6 +479,7 @@ async function verifyRawPackageSourceDownload(input: {
 }> {
   const raw = (await input.client.query(api.backstageRepos.resolveRawPackageDownloadForApi, {
     apiSecret: input.apiSecret,
+    tokenHash: input.tokenHash,
     authUserId: input.config.creatorAuthUserId,
     channel: 'stable',
     packageId: input.config.packageId,
@@ -588,9 +592,11 @@ async function verifyInstallablePackageDownload(input: {
   client: ConvexClient;
   config: Config;
   subjectId: string;
+  tokenHash: string;
 }): Promise<{ bytes: number; deliveryArtifactId?: string; sourceKind: 'zip' }> {
   const resolved = (await input.client.query(api.backstageRepos.resolvePackageDownloadForApi, {
     apiSecret: input.apiSecret,
+    tokenHash: input.tokenHash,
     authUserId: input.config.creatorAuthUserId,
     channel: 'stable',
     packageId: input.config.packageId,
@@ -707,6 +713,7 @@ async function resolveSubjectWithEntitlement(input: {
 }): Promise<string> {
   const authSubject = (await input.client.query(api.backstageRepos.getSubjectByAuthUserForApi, {
     apiSecret: input.apiSecret,
+    actor: input.actor,
     authUserId: input.config.creatorAuthUserId,
   })) as { _id: string } | null;
   if (authSubject) {
@@ -764,6 +771,7 @@ async function resolveSubjectWithEntitlement(input: {
 }
 
 async function issueRepoToken(input: {
+  actor: Record<string, unknown>;
   apiSecret: string;
   client: ConvexClient;
   config: Config;
@@ -771,6 +779,7 @@ async function issueRepoToken(input: {
 }): Promise<string> {
   const issued = (await input.client.mutation(api.backstageRepos.issueRepoTokenForApi, {
     apiSecret: input.apiSecret,
+    actor: input.actor,
     authUserId: input.config.creatorAuthUserId,
     expiresAt: Date.now() + 5 * 60 * 1000,
     label: `Backstage live E2E ${input.config.packageId}`,
@@ -818,19 +827,22 @@ async function runOnce(config: Config): Promise<void> {
     context,
     subjectId,
   });
+  const token = await issueRepoToken({ actor, apiSecret, client, config, subjectId });
+  const tokenHash = sha256Hex(new TextEncoder().encode(token));
   const rawSource = await verifyRawPackageSourceDownload({
     apiSecret,
     client,
     config,
     subjectId,
+    tokenHash,
   });
   const installablePackage = await verifyInstallablePackageDownload({
     apiSecret,
     client,
     config,
     subjectId,
+    tokenHash,
   });
-  const token = await issueRepoToken({ apiSecret, client, config, subjectId });
   const repoHeaders = { 'X-YUCP-Repo-Token': token };
   const repositoryUrl = `${config.apiBaseUrl}/v1/backstage/repos/${encodeURIComponent(
     creatorRepoRef
@@ -859,6 +871,7 @@ async function runOnce(config: Config): Promise<void> {
       config,
       repoPackage,
       subjectId,
+      tokenHash,
     });
     throw new Error(
       `Package download failed for ${repoPackage.packageId}@${repoPackage.version}: ${response.status} ${response.statusText}. Body: ${body}. ${delivery}`


### PR DESCRIPTION
## Summary

Fixes F24 by moving the repo-token capability check into Convex for Backstage package download resolution.

## What changed

- `resolvePackageDownloadForApi` now requires the repo `tokenHash` and rejects unless the token resolves to an active, non-expired repo access record whose `authUserId` and `subjectId` match the requested download resource.
- `resolveRawPackageDownloadForApi` enforces the same token binding when called with a repo token. It also keeps the existing session/service-authorized alias raw-download flow by requiring an explicit actor when no repo token is present.
- `getSubjectByAuthUserForApi` is actor-bound because it is a session/user lookup, not a repo-token capability path.
- `issueRepoTokenForApi` is not token-bound because it mints a token. It is now bound to the caller's real subject principal via `actor` plus a Convex-side active subject ownership assertion. Alias creator access remains authorized by the existing alias plan check before token minting.
- API callers now thread the resolved `tokenHash` into repo-token package downloads and pass explicit actors for subject lookup/token mint/raw alias flows.

## Why not an actor on downloads

The paid package download path is authorized by possession of a repo token. Adding `requireDelegatedAuthUserActor` there would bind to the API service identity instead of the capability the caller actually presented. Convex now verifies the capability-to-resource binding directly: token hash to active token, token owner to `authUserId`, and token subject to `subjectId`.

## Behavior impact

Legitimate repo-token downloads keep the same HTTP contract and behavior. A miswired internal caller that combines token T1 with another subject now gets an explicit `Unauthorized` rejection instead of a nullable not-found-style result.

## Validation

- RED: `bun x vitest run --config convex/vitest.config.ts convex/packageRegistry.realtest.ts -t "rejects repo-token package download resolution"` failed with `promise resolved "null" instead of rejecting` before the fix.
- GREEN: focused Convex regression passed.
- `bun run test:convex`: 45 files, 365 tests passed.
- `bun test apps/api/src/routes/backstageRepos.test.ts`: 42 pass, 0 fail.
- `bun test apps/api/src/routes/packages.backstage.test.ts`: 34 pass, 0 fail.
- `bun run typecheck`: passed.
- `bun run lint`: passed.
- `bun run test:external-integrations`: passed.

Note: `bun audit` currently fails on the existing `@better-auth/oauth-provider` advisory present on this branch/default dependency set. I did not change dependency versions because F24 scope is limited to the Backstage Convex/API binding path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Backstage repo access and package download authorization using explicit actor bindings and computed token hashes.
  * Added support for more reliable repo-token-based downloads across entitled and raw package resolution paths.
* **Bug Fixes**
  * Prevented download resolution when the token isn’t bound to the requested subject.
  * Mapped unauthorized download resolution to a “Package not found” (404) response for safer client behavior.
* **Tests**
  * Expanded unit, real, and e2e coverage to validate actor/tokenHash propagation and authorization race-condition handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->