### PR TITLE
fix(convex): grant entitlements for manual license redeems

### DIFF
--- a/convex/verificationIntents.realtest.ts
+++ b/convex/verificationIntents.realtest.ts
@@ -92,7 +92,7 @@ async function seedCatalogProduct(
   overrides: {
     authUserId?: string;
     productId?: string;
-    provider?: 'gumroad' | 'itchio' | 'jinxxy' | 'vrchat' | 'payhip' | 'lemonsqueezy';
+    provider?: 'gumroad' | 'itchio' | 'jinxxy' | 'vrchat' | 'payhip' | 'lemonsqueezy' | 'manual';
     providerProductRef?: string;
     displayName?: string;
   } = {}
@@ -120,6 +120,25 @@ async function computeCodeChallenge(codeVerifier: string): Promise<string> {
     .replace(/\+/g, '-')
     .replace(/\//g, '_')
     .replace(/=+$/g, '');
+}
+
+async function hashManualLicenseKey(key: string): Promise<string> {
+  const encryptionSecret = process.env.ENCRYPTION_SECRET;
+  if (!encryptionSecret) {
+    throw new Error('ENCRYPTION_SECRET is required for manual-license realtests');
+  }
+  const encoder = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(encryptionSecret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const signature = await crypto.subtle.sign('HMAC', keyMaterial, encoder.encode(key));
+  return Array.from(new Uint8Array(signature))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
 }
 
 function decodeJwtPayload(jwt: string): Record<string, unknown> {
@@ -492,6 +511,102 @@ describe('verification intents buyer provider links', () => {
 
     expect(intent?.status).toBe('verified');
     expect(intent?.verifiedMethodKey).toBe('gumroad-license');
+  });
+
+  it('redeems a YUCP manual license through the intent action and grants its entitlement', async () => {
+    const t = makeTestConvex();
+    const creatorAuthUserId = 'auth-yucp-manual-license-creator';
+    const buyerAuthUserId = 'auth-yucp-manual-license-buyer';
+    const packageId = 'pkg.yucp-manual-license';
+    const productId = 'product-yucp-manual-license';
+    const licenseKey = 'YUCP-ABCD-EFGH-IJKL';
+    const subjectId = await seedSubject(t, {
+      authUserId: buyerAuthUserId,
+      primaryDiscordUserId: 'discord-yucp-manual-license-buyer',
+    });
+
+    await t.mutation(internal.packageRegistry.registerPackage, {
+      packageId,
+      packageName: 'YUCP Manual License Package',
+      publisherId: 'publisher-yucp-manual-license',
+      yucpUserId: creatorAuthUserId,
+    });
+    await seedCatalogProduct(t, {
+      authUserId: creatorAuthUserId,
+      productId,
+      provider: 'manual',
+      providerProductRef: productId,
+      displayName: 'YUCP Manual License Product',
+    });
+    const { licenseId } = await t.mutation(api.manualLicenses.create, {
+      apiSecret: API_SECRET,
+      authUserId: creatorAuthUserId,
+      licenseKeyHash: await hashManualLicenseKey(licenseKey),
+      productId,
+    });
+
+    const { intentId } = await t.mutation(api.verificationIntents.createVerificationIntent, {
+      apiSecret: API_SECRET,
+      authUserId: buyerAuthUserId,
+      packageId,
+      machineFingerprint: 'machine-yucp-manual-license',
+      codeChallenge: 'challenge-yucp-manual-license',
+      returnUrl: 'https://example.com/return',
+      requirements: [
+        {
+          methodKey: 'manual-license',
+          providerKey: 'manual',
+          kind: 'manual_license',
+          title: 'YUCP manual license',
+          providerProductRef: productId,
+          creatorAuthUserId,
+          productId,
+        },
+      ],
+    });
+
+    const result = await t.action(api.verificationIntents.verifyIntentWithManualLicense, {
+      apiSecret: API_SECRET,
+      authUserId: buyerAuthUserId,
+      intentId,
+      methodKey: 'manual-license',
+      licenseKey,
+    });
+
+    expect(result).toEqual({ success: true });
+    const entitlements = await t.run((ctx) =>
+      ctx.db
+        .query('entitlements')
+        .withIndex('by_auth_user_subject', (q) =>
+          q.eq('authUserId', creatorAuthUserId).eq('subjectId', subjectId)
+        )
+        .collect()
+    );
+    expect(entitlements).toEqual([
+      expect.objectContaining({
+        productId,
+        sourceProvider: 'manual',
+        sourceReference: `manual:${licenseId}`,
+        status: 'active',
+      }),
+    ]);
+    const evidence = await t.run((ctx) =>
+      ctx.db
+        .query('entitlement_evidence')
+        .withIndex('by_source_reference', (q) =>
+          q.eq('providerKey', 'manual').eq('sourceReference', `manual:${licenseId}`)
+        )
+        .filter((q) => q.eq(q.field('authUserId'), creatorAuthUserId))
+        .first()
+    );
+    expect(evidence).toMatchObject({
+      subjectId,
+      providerKey: 'manual',
+      sourceReference: `manual:${licenseId}`,
+      evidenceType: 'manual_license_redeemed',
+      status: 'active',
+      productId,
+    });
   });
 
   it('verifies manual-license intents through the public Convex action when Gumroad accepts product_id directly', async () => {

--- a/convex/verificationIntents.realtest.ts
+++ b/convex/verificationIntents.realtest.ts
@@ -555,6 +555,13 @@ describe('verification intents buyer provider links', () => {
       providerProductRef: productId,
       displayName: 'YUCP Manual License Product',
     });
+    await t.mutation(api.manualLicenses.create, {
+      apiSecret: API_SECRET,
+      authUserId: 'auth-yucp-manual-license-other-creator',
+      licenseKeyHash: await hashManualLicenseKey(licenseKey),
+      productId,
+      maxUses: 1,
+    });
     const { licenseId } = await t.mutation(api.manualLicenses.create, {
       apiSecret: API_SECRET,
       authUserId: creatorAuthUserId,
@@ -628,6 +635,42 @@ describe('verification intents buyer provider links', () => {
     });
     const consumedLicense = await t.run((ctx) => ctx.db.get(licenseId));
     expect(consumedLicense).toMatchObject({
+      currentUses: 1,
+      status: 'exhausted',
+    });
+
+    const { intentId: sameBuyerRetryIntentId } = await t.mutation(
+      api.verificationIntents.createVerificationIntent,
+      {
+        apiSecret: API_SECRET,
+        authUserId: buyerAuthUserId,
+        packageId,
+        machineFingerprint: 'machine-yucp-manual-license-same-buyer-retry',
+        codeChallenge: 'challenge-yucp-manual-license-same-buyer-retry',
+        returnUrl: 'https://example.com/return',
+        requirements: [
+          {
+            methodKey: 'manual-license',
+            providerKey: 'manual',
+            kind: 'manual_license',
+            title: 'YUCP manual license',
+            providerProductRef: productId,
+            creatorAuthUserId,
+            productId,
+          },
+        ],
+      }
+    );
+    expect(
+      await t.action(api.verificationIntents.verifyIntentWithManualLicense, {
+        apiSecret: API_SECRET,
+        authUserId: buyerAuthUserId,
+        intentId: sameBuyerRetryIntentId,
+        methodKey: 'manual-license',
+        licenseKey,
+      })
+    ).toEqual({ success: true });
+    expect(await t.run((ctx) => ctx.db.get(licenseId))).toMatchObject({
       currentUses: 1,
       status: 'exhausted',
     });

--- a/convex/verificationIntents.realtest.ts
+++ b/convex/verificationIntents.realtest.ts
@@ -811,6 +811,81 @@ describe('verification intents buyer provider links', () => {
     expect(secondBuyerEntitlements).toHaveLength(1);
   });
 
+  it('rejects an oversized valid manual license key before entitlement grant', async () => {
+    const t = makeTestConvex();
+    const creatorAuthUserId = 'auth-yucp-manual-license-oversized-creator';
+    const buyerAuthUserId = 'auth-yucp-manual-license-oversized-buyer';
+    const packageId = 'pkg.yucp-manual-license-oversized';
+    const productId = 'product-yucp-manual-license-oversized';
+    const licenseKey = 'x'.repeat(4097);
+    const subjectId = await seedSubject(t, {
+      authUserId: buyerAuthUserId,
+      primaryDiscordUserId: 'discord-yucp-manual-license-oversized-buyer',
+    });
+
+    await t.mutation(internal.packageRegistry.registerPackage, {
+      packageId,
+      packageName: 'YUCP Manual License Oversized Package',
+      publisherId: 'publisher-yucp-manual-license-oversized',
+      yucpUserId: creatorAuthUserId,
+    });
+    await seedCatalogProduct(t, {
+      authUserId: creatorAuthUserId,
+      productId,
+      provider: 'manual',
+      providerProductRef: productId,
+      displayName: 'YUCP Manual License Oversized Product',
+    });
+    await t.mutation(api.manualLicenses.create, {
+      apiSecret: API_SECRET,
+      authUserId: creatorAuthUserId,
+      licenseKeyHash: await hashManualLicenseKey(licenseKey),
+      productId,
+    });
+    const { intentId } = await t.mutation(api.verificationIntents.createVerificationIntent, {
+      apiSecret: API_SECRET,
+      authUserId: buyerAuthUserId,
+      packageId,
+      machineFingerprint: 'machine-yucp-manual-license-oversized',
+      codeChallenge: 'challenge-yucp-manual-license-oversized',
+      returnUrl: 'https://example.com/return',
+      requirements: [
+        {
+          methodKey: 'manual-license',
+          providerKey: 'manual',
+          kind: 'manual_license',
+          title: 'YUCP manual license',
+          providerProductRef: productId,
+          creatorAuthUserId,
+          productId,
+        },
+      ],
+    });
+
+    expect(
+      await t.action(api.verificationIntents.verifyIntentWithManualLicense, {
+        apiSecret: API_SECRET,
+        authUserId: buyerAuthUserId,
+        intentId,
+        methodKey: 'manual-license',
+        licenseKey,
+      })
+    ).toEqual({
+      success: false,
+      errorCode: 'invalid_proof',
+      errorMessage: 'License verification failed',
+    });
+    const entitlements = await t.run((ctx) =>
+      ctx.db
+        .query('entitlements')
+        .withIndex('by_auth_user_subject', (q) =>
+          q.eq('authUserId', creatorAuthUserId).eq('subjectId', subjectId)
+        )
+        .collect()
+    );
+    expect(entitlements).toEqual([]);
+  });
+
   it('verifies manual-license intents through the public Convex action when Gumroad accepts product_id directly', async () => {
     const t = makeTestConvex();
     const creatorAuthUserId = 'auth-manual-license-product-id-creator';

--- a/convex/verificationIntents.realtest.ts
+++ b/convex/verificationIntents.realtest.ts
@@ -9,6 +9,7 @@ import { getPublicKeyFromPrivate } from './lib/yucpCrypto';
 import { makeTestConvex, seedCreatorProfile, seedSubject } from './testHelpers';
 
 const API_SECRET = 'test-secret';
+const originalEncryptionSecret = process.env.ENCRYPTION_SECRET;
 
 async function seedExternalAccount(
   t: ReturnType<typeof makeTestConvex>,
@@ -169,6 +170,11 @@ async function configurePinnedTestRoot(): Promise<void> {
 
 afterEach(() => {
   setPinnedYucpRootsForTests(null);
+  if (originalEncryptionSecret === undefined) {
+    delete process.env.ENCRYPTION_SECRET;
+  } else {
+    process.env.ENCRYPTION_SECRET = originalEncryptionSecret;
+  }
 });
 
 describe('verification intents buyer provider links', () => {
@@ -519,7 +525,11 @@ describe('verification intents buyer provider links', () => {
     const buyerAuthUserId = 'auth-yucp-manual-license-buyer';
     const packageId = 'pkg.yucp-manual-license';
     const productId = 'product-yucp-manual-license';
-    const licenseKey = 'YUCP-ABCD-EFGH-IJKL';
+    const licenseKey = 'test-yucp-manual-license-key';
+    if (!originalEncryptionSecret) {
+      throw new Error('ENCRYPTION_SECRET is required for manual-license realtests');
+    }
+    process.env.ENCRYPTION_SECRET = `${originalEncryptionSecret}\n`;
     const subjectId = await seedSubject(t, {
       authUserId: buyerAuthUserId,
       primaryDiscordUserId: 'discord-yucp-manual-license-buyer',
@@ -543,7 +553,9 @@ describe('verification intents buyer provider links', () => {
       authUserId: creatorAuthUserId,
       licenseKeyHash: await hashManualLicenseKey(licenseKey),
       productId,
+      maxUses: 1,
     });
+    const sourceReference = `manual:${await sha256Hex(String(licenseId))}`;
 
     const { intentId } = await t.mutation(api.verificationIntents.createVerificationIntent, {
       apiSecret: API_SECRET,
@@ -586,7 +598,7 @@ describe('verification intents buyer provider links', () => {
       expect.objectContaining({
         productId,
         sourceProvider: 'manual',
-        sourceReference: `manual:${licenseId}`,
+        sourceReference,
         status: 'active',
       }),
     ]);
@@ -594,7 +606,7 @@ describe('verification intents buyer provider links', () => {
       ctx.db
         .query('entitlement_evidence')
         .withIndex('by_source_reference', (q) =>
-          q.eq('providerKey', 'manual').eq('sourceReference', `manual:${licenseId}`)
+          q.eq('providerKey', 'manual').eq('sourceReference', sourceReference)
         )
         .filter((q) => q.eq(q.field('authUserId'), creatorAuthUserId))
         .first()
@@ -602,11 +614,65 @@ describe('verification intents buyer provider links', () => {
     expect(evidence).toMatchObject({
       subjectId,
       providerKey: 'manual',
-      sourceReference: `manual:${licenseId}`,
+      sourceReference,
       evidenceType: 'manual_license_redeemed',
       status: 'active',
       productId,
     });
+    const consumedLicense = await t.run((ctx) => ctx.db.get(licenseId));
+    expect(consumedLicense).toMatchObject({
+      currentUses: 1,
+      status: 'exhausted',
+    });
+
+    const retryBuyerAuthUserId = 'auth-yucp-manual-license-retry-buyer';
+    const retrySubjectId = await seedSubject(t, {
+      authUserId: retryBuyerAuthUserId,
+      primaryDiscordUserId: 'discord-yucp-manual-license-retry-buyer',
+    });
+    const { intentId: retryIntentId } = await t.mutation(
+      api.verificationIntents.createVerificationIntent,
+      {
+        apiSecret: API_SECRET,
+        authUserId: retryBuyerAuthUserId,
+        packageId,
+        machineFingerprint: 'machine-yucp-manual-license-retry',
+        codeChallenge: 'challenge-yucp-manual-license-retry',
+        returnUrl: 'https://example.com/return',
+        requirements: [
+          {
+            methodKey: 'manual-license',
+            providerKey: 'manual',
+            kind: 'manual_license',
+            title: 'YUCP manual license',
+            providerProductRef: productId,
+            creatorAuthUserId,
+            productId,
+          },
+        ],
+      }
+    );
+    const retryResult = await t.action(api.verificationIntents.verifyIntentWithManualLicense, {
+      apiSecret: API_SECRET,
+      authUserId: retryBuyerAuthUserId,
+      intentId: retryIntentId,
+      methodKey: 'manual-license',
+      licenseKey,
+    });
+    expect(retryResult).toEqual({
+      success: false,
+      errorCode: 'invalid_proof',
+      errorMessage: 'License verification failed',
+    });
+    const retryEntitlements = await t.run((ctx) =>
+      ctx.db
+        .query('entitlements')
+        .withIndex('by_auth_user_subject', (q) =>
+          q.eq('authUserId', creatorAuthUserId).eq('subjectId', retrySubjectId)
+        )
+        .collect()
+    );
+    expect(retryEntitlements).toEqual([]);
   });
 
   it('verifies manual-license intents through the public Convex action when Gumroad accepts product_id directly', async () => {

--- a/convex/verificationIntents.realtest.ts
+++ b/convex/verificationIntents.realtest.ts
@@ -519,7 +519,7 @@ describe('verification intents buyer provider links', () => {
     expect(intent?.verifiedMethodKey).toBe('gumroad-license');
   });
 
-  it('redeems a YUCP manual license through the intent action and grants its entitlement', async () => {
+  it('allows an existing owner to retry an expired YUCP manual license without consuming another use', async () => {
     const t = makeTestConvex();
     const creatorAuthUserId = 'auth-yucp-manual-license-creator';
     const buyerAuthUserId = 'auth-yucp-manual-license-buyer';
@@ -638,6 +638,14 @@ describe('verification intents buyer provider links', () => {
       currentUses: 1,
       status: 'exhausted',
     });
+    const expiredAt = Date.now() - 1;
+    await t.run(async (ctx) => {
+      await ctx.db.patch(licenseId, {
+        status: 'expired',
+        expiresAt: expiredAt,
+        updatedAt: Date.now(),
+      });
+    });
 
     const { intentId: sameBuyerRetryIntentId } = await t.mutation(
       api.verificationIntents.createVerificationIntent,
@@ -672,7 +680,8 @@ describe('verification intents buyer provider links', () => {
     ).toEqual({ success: true });
     expect(await t.run((ctx) => ctx.db.get(licenseId))).toMatchObject({
       currentUses: 1,
-      status: 'exhausted',
+      status: 'expired',
+      expiresAt: expiredAt,
     });
 
     const retryBuyerAuthUserId = 'auth-yucp-manual-license-retry-buyer';

--- a/convex/verificationIntents.realtest.ts
+++ b/convex/verificationIntents.realtest.ts
@@ -542,6 +542,13 @@ describe('verification intents buyer provider links', () => {
       yucpUserId: creatorAuthUserId,
     });
     await seedCatalogProduct(t, {
+      authUserId: 'auth-yucp-manual-license-other-creator',
+      productId,
+      provider: 'manual',
+      providerProductRef: productId,
+      displayName: 'Different creator manual product',
+    });
+    await seedCatalogProduct(t, {
       authUserId: creatorAuthUserId,
       productId,
       provider: 'manual',
@@ -673,6 +680,135 @@ describe('verification intents buyer provider links', () => {
         .collect()
     );
     expect(retryEntitlements).toEqual([]);
+  });
+
+  it('does not consume another manual-license use when its entitlement is already active', async () => {
+    const t = makeTestConvex();
+    const creatorAuthUserId = 'auth-yucp-manual-license-redeem-creator';
+    const buyerAuthUserId = 'auth-yucp-manual-license-redeem-buyer';
+    const packageId = 'pkg.yucp-manual-license-redeem';
+    const productId = 'product-yucp-manual-license-redeem';
+    const licenseKey = 'test-yucp-manual-license-redeem-key';
+    const subjectId = await seedSubject(t, {
+      authUserId: buyerAuthUserId,
+      primaryDiscordUserId: 'discord-yucp-manual-license-redeem-buyer',
+    });
+
+    await t.mutation(internal.packageRegistry.registerPackage, {
+      packageId,
+      packageName: 'YUCP Manual License Redeem Package',
+      publisherId: 'publisher-yucp-manual-license-redeem',
+      yucpUserId: creatorAuthUserId,
+    });
+    await seedCatalogProduct(t, {
+      authUserId: creatorAuthUserId,
+      productId,
+      provider: 'manual',
+      providerProductRef: productId,
+      displayName: 'YUCP Manual License Redeem Product',
+    });
+    const { licenseId } = await t.mutation(api.manualLicenses.create, {
+      apiSecret: API_SECRET,
+      authUserId: creatorAuthUserId,
+      licenseKeyHash: await hashManualLicenseKey(licenseKey),
+      productId,
+      maxUses: 2,
+    });
+
+    const createIntent = async (authUserId: string, machineFingerprint: string) =>
+      await t.mutation(api.verificationIntents.createVerificationIntent, {
+        apiSecret: API_SECRET,
+        authUserId,
+        packageId,
+        machineFingerprint,
+        codeChallenge: `challenge-${machineFingerprint}`,
+        returnUrl: 'https://example.com/return',
+        requirements: [
+          {
+            methodKey: 'manual-license',
+            providerKey: 'manual',
+            kind: 'manual_license',
+            title: 'YUCP manual license',
+            providerProductRef: productId,
+            creatorAuthUserId,
+            productId,
+          },
+        ],
+      });
+
+    const { intentId: firstIntentId } = await createIntent(
+      buyerAuthUserId,
+      'machine-yucp-manual-license-redeem-first'
+    );
+    expect(
+      await t.action(api.verificationIntents.verifyIntentWithManualLicense, {
+        apiSecret: API_SECRET,
+        authUserId: buyerAuthUserId,
+        intentId: firstIntentId,
+        methodKey: 'manual-license',
+        licenseKey,
+      })
+    ).toEqual({ success: true });
+
+    const { intentId: repeatIntentId } = await createIntent(
+      buyerAuthUserId,
+      'machine-yucp-manual-license-redeem-repeat'
+    );
+    expect(
+      await t.action(api.verificationIntents.verifyIntentWithManualLicense, {
+        apiSecret: API_SECRET,
+        authUserId: buyerAuthUserId,
+        intentId: repeatIntentId,
+        methodKey: 'manual-license',
+        licenseKey,
+      })
+    ).toEqual({ success: true });
+
+    expect(await t.run((ctx) => ctx.db.get(licenseId))).toMatchObject({
+      currentUses: 1,
+      status: 'active',
+    });
+    const buyerEntitlements = await t.run((ctx) =>
+      ctx.db
+        .query('entitlements')
+        .withIndex('by_auth_user_subject', (q) =>
+          q.eq('authUserId', creatorAuthUserId).eq('subjectId', subjectId)
+        )
+        .collect()
+    );
+    expect(buyerEntitlements).toHaveLength(1);
+
+    const secondBuyerAuthUserId = 'auth-yucp-manual-license-redeem-second-buyer';
+    const secondSubjectId = await seedSubject(t, {
+      authUserId: secondBuyerAuthUserId,
+      primaryDiscordUserId: 'discord-yucp-manual-license-redeem-second-buyer',
+    });
+    const { intentId: secondBuyerIntentId } = await createIntent(
+      secondBuyerAuthUserId,
+      'machine-yucp-manual-license-redeem-second-buyer'
+    );
+    expect(
+      await t.action(api.verificationIntents.verifyIntentWithManualLicense, {
+        apiSecret: API_SECRET,
+        authUserId: secondBuyerAuthUserId,
+        intentId: secondBuyerIntentId,
+        methodKey: 'manual-license',
+        licenseKey,
+      })
+    ).toEqual({ success: true });
+    expect(await t.run((ctx) => ctx.db.get(licenseId))).toMatchObject({
+      currentUses: 2,
+      status: 'exhausted',
+    });
+    const secondBuyerEntitlements = await t.run((ctx) =>
+      ctx.db
+        .query('entitlements')
+        .withIndex('by_auth_user_subject', (q) =>
+          q.eq('authUserId', creatorAuthUserId).eq('subjectId', secondSubjectId)
+        )
+        .collect()
+    );
+    expect(secondBuyerEntitlements).toHaveLength(1);
   });
 
   it('verifies manual-license intents through the public Convex action when Gumroad accepts product_id directly', async () => {

--- a/convex/verificationIntents.realtest.ts
+++ b/convex/verificationIntents.realtest.ts
@@ -752,7 +752,7 @@ describe('verification intents buyer provider links', () => {
       publisherId: 'publisher-yucp-manual-license-redeem',
       yucpUserId: creatorAuthUserId,
     });
-    await seedCatalogProduct(t, {
+    const catalogProductId = await seedCatalogProduct(t, {
       authUserId: creatorAuthUserId,
       productId,
       provider: 'manual',
@@ -829,6 +829,7 @@ describe('verification intents buyer provider links', () => {
         .collect()
     );
     expect(buyerEntitlements).toHaveLength(1);
+    expect(buyerEntitlements[0]).toMatchObject({ catalogProductId });
 
     const secondBuyerAuthUserId = 'auth-yucp-manual-license-redeem-second-buyer';
     const secondSubjectId = await seedSubject(t, {

--- a/convex/verificationIntents.ts
+++ b/convex/verificationIntents.ts
@@ -14,6 +14,7 @@ import { api, internal } from './_generated/api';
 import type { Doc, Id } from './_generated/dataModel';
 import type { ActionCtx } from './_generated/server';
 import { action, internalMutation, mutation, query } from './_generated/server';
+import { grantEntitlementFromFunnel } from './entitlements';
 import {
   ApiActorBindingV,
   requireDelegatedAuthUserActor,
@@ -520,6 +521,104 @@ export const markIntentVerified = internalMutation({
       throw new Error(`Verification intent not found: ${args.intentId}`);
     }
     const now = Date.now();
+    await ctx.db.patch(args.intentId, {
+      status: 'verified',
+      verifiedMethodKey: args.methodKey,
+      verificationGrantJti: generateHex(16),
+      verificationGrantExpiresAt: now + GRANT_EXPIRY_MS,
+      errorCode: undefined,
+      errorMessage: undefined,
+      updatedAt: now,
+    });
+    return null;
+  },
+});
+
+export const completeManualLicenseIntent = internalMutation({
+  args: {
+    intentId: v.id('verification_intents'),
+    methodKey: v.string(),
+    subjectId: v.id('subjects'),
+    creatorAuthUserId: v.string(),
+    productId: v.string(),
+    manualLicenseId: v.id('manual_licenses'),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const intent = await ctx.db.get(args.intentId);
+    if (!intent) {
+      throw new Error(`Verification intent not found: ${args.intentId}`);
+    }
+    if (intent.status !== 'pending') {
+      throw new Error(`Verification intent is ${intent.status}`);
+    }
+    const subject = await ctx.db.get(args.subjectId);
+    if (!subject) {
+      throw new Error(`Verification subject not found: ${args.subjectId}`);
+    }
+
+    const now = Date.now();
+    const existingEntitlements = await ctx.db
+      .query('entitlements')
+      .withIndex('by_auth_user_subject', (q) =>
+        q.eq('authUserId', args.creatorAuthUserId).eq('subjectId', args.subjectId)
+      )
+      .collect();
+    const sourceReference = `manual:${args.manualLicenseId}`;
+
+    await grantEntitlementFromFunnel(ctx, {
+      authUserId: args.creatorAuthUserId,
+      subjectId: args.subjectId,
+      subject,
+      productId: args.productId,
+      sourceProvider: 'manual',
+      sourceReference,
+      policySnapshotVersion: existingEntitlements.length + 1,
+      grantedAt: now,
+      now,
+      existingLookup: {
+        mode: 'sourceReference',
+        sourceReferences: [sourceReference],
+        matchProduct: true,
+        matchProvider: true,
+      },
+      reactivation: {
+        allowTerminal: false,
+        refreshExistingFields: true,
+      },
+      roleSync: {
+        mode: 'roleSyncIdentity',
+        lifecycleAt: now,
+        requireDiscordUserId: true,
+        missingSubject: 'skip',
+      },
+      audit: {
+        emitForNew: true,
+        emitForReactivated: true,
+        correlationId: String(args.intentId),
+      },
+      evidence: {
+        authUserId: args.creatorAuthUserId,
+        subjectId: args.subjectId,
+        providerKey: 'manual',
+        sourceReference,
+        evidenceType: 'manual_license_redeemed',
+        status: 'active',
+        productId: args.productId,
+        metadata: { manualLicenseId: String(args.manualLicenseId) },
+        observedAt: now,
+        createdAt: now,
+        updatedAt: now,
+        lookupFilters: {
+          authUserId: true,
+          subjectId: true,
+          productId: true,
+          evidenceType: true,
+        },
+        patchEvidenceType: true,
+      },
+    });
+
     await ctx.db.patch(args.intentId, {
       status: 'verified',
       verifiedMethodKey: args.methodKey,
@@ -1174,17 +1273,20 @@ export const verifyIntentWithManualLicense = action({
       };
     }
 
-    const proof: { success: boolean; error?: string } = await ctx.runAction(
-      internal.yucpLicenses.verifyLicenseProof,
-      {
-        packageId: intent.packageId,
-        licenseKey: args.licenseKey,
-        provider: requirement.providerKey,
-        productPermalink: requirement.providerProductRef,
-        creatorAuthUserId: requirement.creatorAuthUserId,
-        productId: requirement.productId,
-      }
-    );
+    const proof: {
+      success: boolean;
+      error?: string;
+      manualLicenseId?: Id<'manual_licenses'>;
+      creatorAuthUserId?: string;
+      productId?: string;
+    } = await ctx.runAction(internal.yucpLicenses.verifyLicenseProof, {
+      packageId: intent.packageId,
+      licenseKey: args.licenseKey,
+      provider: requirement.providerKey,
+      productPermalink: requirement.providerProductRef,
+      creatorAuthUserId: requirement.creatorAuthUserId,
+      productId: requirement.productId,
+    });
 
     if (!proof.success) {
       await ctx.runMutation(internal.verificationIntents.markIntentFailed, {
@@ -1197,6 +1299,32 @@ export const verifyIntentWithManualLicense = action({
         errorCode: 'invalid_proof',
         errorMessage: proof.error ?? 'License verification failed',
       };
+    }
+
+    if (proof.manualLicenseId && proof.creatorAuthUserId && proof.productId) {
+      const subjectId = await resolveIntentSubjectId(ctx, intent, args.authUserId);
+      if (!subjectId) {
+        await ctx.runMutation(internal.verificationIntents.markIntentFailed, {
+          intentId: args.intentId,
+          errorCode: 'subject_not_found',
+          errorMessage: 'No linked buyer subject was found for this YUCP account.',
+        });
+        return {
+          success: false,
+          errorCode: 'subject_not_found',
+          errorMessage: 'No linked buyer subject was found for this YUCP account.',
+        };
+      }
+
+      await ctx.runMutation(internal.verificationIntents.completeManualLicenseIntent, {
+        intentId: args.intentId,
+        methodKey: args.methodKey,
+        subjectId,
+        creatorAuthUserId: proof.creatorAuthUserId,
+        productId: proof.productId,
+        manualLicenseId: proof.manualLicenseId,
+      });
+      return { success: true };
     }
 
     await ctx.runMutation(internal.verificationIntents.markIntentVerified, {

--- a/convex/verificationIntents.ts
+++ b/convex/verificationIntents.ts
@@ -562,15 +562,33 @@ export const completeManualLicenseIntent = internalMutation({
     if (
       !manualLicense ||
       manualLicense.authUserId !== args.creatorAuthUserId ||
-      manualLicense.productId !== args.productId ||
-      manualLicense.status !== 'active' ||
-      (manualLicense.expiresAt !== undefined && now > manualLicense.expiresAt) ||
-      (manualLicense.maxUses !== undefined && manualLicense.currentUses >= manualLicense.maxUses)
+      manualLicense.productId !== args.productId
     ) {
       return { success: false };
     }
 
     const sourceReference = `manual:${await sha256Hex(String(args.manualLicenseId))}`;
+    const existingEntitlement = await ctx.db
+      .query('entitlements')
+      .withIndex('by_auth_user_subject', (q) =>
+        q.eq('authUserId', args.creatorAuthUserId).eq('subjectId', args.subjectId)
+      )
+      .filter((q) =>
+        q.and(
+          q.eq(q.field('productId'), args.productId),
+          q.eq(q.field('sourceProvider'), 'manual'),
+          q.eq(q.field('sourceReference'), sourceReference),
+          q.eq(q.field('status'), 'active')
+        )
+      )
+      .first();
+    const canConsume =
+      manualLicense.status === 'active' &&
+      (manualLicense.expiresAt === undefined || now <= manualLicense.expiresAt) &&
+      (manualLicense.maxUses === undefined || manualLicense.currentUses < manualLicense.maxUses);
+    if (!canConsume && !existingEntitlement) {
+      return { success: false };
+    }
 
     const grantResult = await grantEntitlementFromFunnel(ctx, {
       authUserId: args.creatorAuthUserId,
@@ -625,6 +643,9 @@ export const completeManualLicenseIntent = internalMutation({
     });
 
     if (grantResult.isNew || grantResult.reason === 'reactivated') {
+      if (!canConsume) {
+        throw new Error('Manual license grant must have an available use');
+      }
       const currentUses = manualLicense.currentUses + 1;
       await ctx.db.patch(args.manualLicenseId, {
         currentUses,

--- a/convex/verificationIntents.ts
+++ b/convex/verificationIntents.ts
@@ -542,6 +542,7 @@ export const completeManualLicenseIntent = internalMutation({
     creatorAuthUserId: v.string(),
     productId: v.string(),
     manualLicenseId: v.id('manual_licenses'),
+    catalogProductId: v.optional(v.id('product_catalog')),
   },
   returns: v.object({ success: v.boolean() }),
   handler: async (ctx, args) => {
@@ -595,6 +596,7 @@ export const completeManualLicenseIntent = internalMutation({
       subjectId: args.subjectId,
       subject,
       productId: args.productId,
+      catalogProductId: args.catalogProductId,
       sourceProvider: 'manual',
       sourceReference,
       policySnapshotVersion: 1,
@@ -1317,6 +1319,7 @@ export const verifyIntentWithManualLicense = action({
       manualLicenseId?: Id<'manual_licenses'>;
       creatorAuthUserId?: string;
       productId?: string;
+      catalogProductId?: Id<'product_catalog'>;
     } = await ctx.runAction(internal.yucpLicenses.verifyLicenseProof, {
       packageId: intent.packageId,
       licenseKey: args.licenseKey,
@@ -1363,6 +1366,7 @@ export const verifyIntentWithManualLicense = action({
           creatorAuthUserId: proof.creatorAuthUserId,
           productId: proof.productId,
           manualLicenseId: proof.manualLicenseId,
+          catalogProductId: proof.catalogProductId,
         }
       );
       if (!completion.success) {

--- a/convex/verificationIntents.ts
+++ b/convex/verificationIntents.ts
@@ -570,32 +570,16 @@ export const completeManualLicenseIntent = internalMutation({
       return { success: false };
     }
 
-    const currentUses = manualLicense.currentUses + 1;
-    await ctx.db.patch(args.manualLicenseId, {
-      currentUses,
-      status:
-        manualLicense.maxUses !== undefined && currentUses >= manualLicense.maxUses
-          ? 'exhausted'
-          : 'active',
-      updatedAt: now,
-    });
-
-    const existingEntitlements = await ctx.db
-      .query('entitlements')
-      .withIndex('by_auth_user_subject', (q) =>
-        q.eq('authUserId', args.creatorAuthUserId).eq('subjectId', args.subjectId)
-      )
-      .collect();
     const sourceReference = `manual:${await sha256Hex(String(args.manualLicenseId))}`;
 
-    await grantEntitlementFromFunnel(ctx, {
+    const grantResult = await grantEntitlementFromFunnel(ctx, {
       authUserId: args.creatorAuthUserId,
       subjectId: args.subjectId,
       subject,
       productId: args.productId,
       sourceProvider: 'manual',
       sourceReference,
-      policySnapshotVersion: existingEntitlements.length + 1,
+      policySnapshotVersion: 1,
       grantedAt: now,
       now,
       existingLookup: {
@@ -639,6 +623,18 @@ export const completeManualLicenseIntent = internalMutation({
         patchEvidenceType: true,
       },
     });
+
+    if (grantResult.isNew || grantResult.reason === 'reactivated') {
+      const currentUses = manualLicense.currentUses + 1;
+      await ctx.db.patch(args.manualLicenseId, {
+        currentUses,
+        status:
+          manualLicense.maxUses !== undefined && currentUses >= manualLicense.maxUses
+            ? 'exhausted'
+            : 'active',
+        updatedAt: now,
+      });
+    }
 
     await ctx.db.patch(args.intentId, {
       status: 'verified',

--- a/convex/verificationIntents.ts
+++ b/convex/verificationIntents.ts
@@ -543,7 +543,7 @@ export const completeManualLicenseIntent = internalMutation({
     productId: v.string(),
     manualLicenseId: v.id('manual_licenses'),
   },
-  returns: v.null(),
+  returns: v.object({ success: v.boolean() }),
   handler: async (ctx, args) => {
     const intent = await ctx.db.get(args.intentId);
     if (!intent) {
@@ -558,13 +558,35 @@ export const completeManualLicenseIntent = internalMutation({
     }
 
     const now = Date.now();
+    const manualLicense = await ctx.db.get(args.manualLicenseId);
+    if (
+      !manualLicense ||
+      manualLicense.authUserId !== args.creatorAuthUserId ||
+      manualLicense.productId !== args.productId ||
+      manualLicense.status !== 'active' ||
+      (manualLicense.expiresAt !== undefined && now > manualLicense.expiresAt) ||
+      (manualLicense.maxUses !== undefined && manualLicense.currentUses >= manualLicense.maxUses)
+    ) {
+      return { success: false };
+    }
+
+    const currentUses = manualLicense.currentUses + 1;
+    await ctx.db.patch(args.manualLicenseId, {
+      currentUses,
+      status:
+        manualLicense.maxUses !== undefined && currentUses >= manualLicense.maxUses
+          ? 'exhausted'
+          : 'active',
+      updatedAt: now,
+    });
+
     const existingEntitlements = await ctx.db
       .query('entitlements')
       .withIndex('by_auth_user_subject', (q) =>
         q.eq('authUserId', args.creatorAuthUserId).eq('subjectId', args.subjectId)
       )
       .collect();
-    const sourceReference = `manual:${args.manualLicenseId}`;
+    const sourceReference = `manual:${await sha256Hex(String(args.manualLicenseId))}`;
 
     await grantEntitlementFromFunnel(ctx, {
       authUserId: args.creatorAuthUserId,
@@ -605,7 +627,6 @@ export const completeManualLicenseIntent = internalMutation({
         evidenceType: 'manual_license_redeemed',
         status: 'active',
         productId: args.productId,
-        metadata: { manualLicenseId: String(args.manualLicenseId) },
         observedAt: now,
         createdAt: now,
         updatedAt: now,
@@ -628,7 +649,7 @@ export const completeManualLicenseIntent = internalMutation({
       errorMessage: undefined,
       updatedAt: now,
     });
-    return null;
+    return { success: true };
   },
 });
 
@@ -1316,14 +1337,29 @@ export const verifyIntentWithManualLicense = action({
         };
       }
 
-      await ctx.runMutation(internal.verificationIntents.completeManualLicenseIntent, {
-        intentId: args.intentId,
-        methodKey: args.methodKey,
-        subjectId,
-        creatorAuthUserId: proof.creatorAuthUserId,
-        productId: proof.productId,
-        manualLicenseId: proof.manualLicenseId,
-      });
+      const completion = await ctx.runMutation(
+        internal.verificationIntents.completeManualLicenseIntent,
+        {
+          intentId: args.intentId,
+          methodKey: args.methodKey,
+          subjectId,
+          creatorAuthUserId: proof.creatorAuthUserId,
+          productId: proof.productId,
+          manualLicenseId: proof.manualLicenseId,
+        }
+      );
+      if (!completion.success) {
+        await ctx.runMutation(internal.verificationIntents.markIntentFailed, {
+          intentId: args.intentId,
+          errorCode: 'invalid_proof',
+          errorMessage: 'License verification failed',
+        });
+        return {
+          success: false,
+          errorCode: 'invalid_proof',
+          errorMessage: 'License verification failed',
+        };
+      }
       return { success: true };
     }
 

--- a/convex/yucpLicenses.ts
+++ b/convex/yucpLicenses.ts
@@ -84,7 +84,7 @@ const CONTENT_HASH_RE = /^[0-9a-f]{64}$/;
 
 type ManualLicenseHashVerificationResult =
   | { valid: true; licenseId: Id<'manual_licenses'> }
-  | { valid: false; reason: string };
+  | { valid: false };
 
 type LicenseProofResult = {
   success: boolean;
@@ -95,7 +95,7 @@ type LicenseProofResult = {
 };
 
 async function hashManualLicenseKey(licenseKey: string): Promise<string> {
-  const encryptionSecret = process.env.ENCRYPTION_SECRET?.trim();
+  const encryptionSecret = process.env.ENCRYPTION_SECRET;
   if (!encryptionSecret) {
     throw new Error('ENCRYPTION_SECRET is required for manual license verification');
   }
@@ -211,7 +211,7 @@ export const verifyManualLicenseByHash = internalQuery({
   },
   returns: v.union(
     v.object({ valid: v.literal(true), licenseId: v.id('manual_licenses') }),
-    v.object({ valid: v.literal(false), reason: v.string() })
+    v.object({ valid: v.literal(false) })
   ),
   handler: async (ctx, args): Promise<ManualLicenseHashVerificationResult> => {
     const license = await ctx.db
@@ -220,19 +220,19 @@ export const verifyManualLicenseByHash = internalQuery({
       .first();
 
     if (!license || license.authUserId !== args.authUserId) {
-      return { valid: false as const, reason: 'License verification failed' };
+      return { valid: false as const };
     }
     if (license.productId !== args.productId) {
-      return { valid: false as const, reason: 'License does not match this product' };
+      return { valid: false as const };
     }
-    if (license.status === 'revoked') {
-      return { valid: false as const, reason: 'License has been revoked' };
+    if (license.status !== 'active') {
+      return { valid: false as const };
     }
     if (license.expiresAt && Date.now() > license.expiresAt) {
-      return { valid: false as const, reason: 'License has expired' };
+      return { valid: false as const };
     }
     if (license.maxUses !== undefined && license.currentUses >= license.maxUses) {
-      return { valid: false as const, reason: 'License has reached its usage limit' };
+      return { valid: false as const };
     }
 
     return { valid: true as const, licenseId: license._id };
@@ -649,7 +649,7 @@ export const verifyLicenseProof = internalAction({
           licenseKeyHash: await hashManualLicenseKey(args.licenseKey),
         });
         if (!manualLicense.valid) {
-          return { success: false, error: manualLicense.reason };
+          return { success: false, error: 'License verification failed' };
         }
         return {
           success: true,

--- a/convex/yucpLicenses.ts
+++ b/convex/yucpLicenses.ts
@@ -93,6 +93,7 @@ type LicenseProofResult = {
   manualLicenseId?: Id<'manual_licenses'>;
   creatorAuthUserId?: string;
   productId?: string;
+  catalogProductId?: Id<'product_catalog'>;
 };
 
 async function hashManualLicenseKey(licenseKey: string): Promise<string> {
@@ -136,6 +137,7 @@ async function getPinnedSigningRoot(configuredKeyId?: string | null): Promise<{
 type ProductByProviderRefResult = {
   authUserId: string;
   productId: string;
+  catalogProductId: Id<'product_catalog'>;
   displayName?: string;
 } | null;
 const PROTECTED_ASSET_REGISTRATION = v.object({
@@ -163,6 +165,7 @@ export const getProductByProviderRef = internalQuery({
     v.object({
       authUserId: v.string(),
       productId: v.string(),
+      catalogProductId: v.id('product_catalog'),
       displayName: v.optional(v.string()),
     })
   ),
@@ -177,7 +180,12 @@ export const getProductByProviderRef = internalQuery({
       .filter((q) => q.eq(q.field('status'), 'active'))
       .first();
     if (!row) return null;
-    return { authUserId: row.authUserId, productId: row.productId, displayName: row.displayName };
+    return {
+      authUserId: row.authUserId,
+      productId: row.productId,
+      catalogProductId: row._id,
+      displayName: row.displayName,
+    };
   },
 });
 
@@ -199,6 +207,7 @@ export const getProductByProviderRefForCreator = internalQuery({
     v.object({
       authUserId: v.string(),
       productId: v.string(),
+      catalogProductId: v.id('product_catalog'),
       displayName: v.optional(v.string()),
     })
   ),
@@ -215,7 +224,12 @@ export const getProductByProviderRefForCreator = internalQuery({
       )
       .first();
     if (!row) return null;
-    return { authUserId: row.authUserId, productId: row.productId, displayName: row.displayName };
+    return {
+      authUserId: row.authUserId,
+      productId: row.productId,
+      catalogProductId: row._id,
+      displayName: row.displayName,
+    };
   },
 });
 
@@ -230,6 +244,7 @@ export const lookupProductByProviderRef = query({
     v.object({
       authUserId: v.string(),
       productId: v.string(),
+      catalogProductId: v.id('product_catalog'),
       displayName: v.optional(v.string()),
     })
   ),
@@ -253,13 +268,14 @@ export const verifyManualLicenseByHash = internalQuery({
     v.object({ valid: v.literal(false) })
   ),
   handler: async (ctx, args): Promise<ManualLicenseHashVerificationResult> => {
-    const license = await ctx.db
+    const licenses = await ctx.db
       .query('manual_licenses')
-      .withIndex('by_auth_user_product', (q) =>
-        q.eq('authUserId', args.authUserId).eq('productId', args.productId)
-      )
-      .filter((q) => q.eq(q.field('licenseKeyHash'), args.licenseKeyHash))
-      .first();
+      .withIndex('by_license_key_hash', (q) => q.eq('licenseKeyHash', args.licenseKeyHash))
+      .collect();
+    const license = licenses.find(
+      (candidate) =>
+        candidate.authUserId === args.authUserId && candidate.productId === args.productId
+    );
 
     if (!license) {
       return { valid: false as const };
@@ -645,6 +661,7 @@ export const verifyLicenseProof = internalAction({
     manualLicenseId: v.optional(v.id('manual_licenses')),
     creatorAuthUserId: v.optional(v.string()),
     productId: v.optional(v.string()),
+    catalogProductId: v.optional(v.id('product_catalog')),
   }),
   handler: async (ctx, args): Promise<LicenseProofResult> => {
     if (!args.packageId || !args.licenseKey || !args.provider || !args.productPermalink) {
@@ -702,6 +719,7 @@ export const verifyLicenseProof = internalAction({
           manualLicenseId: manualLicense.licenseId,
           creatorAuthUserId: product.authUserId,
           productId: product.productId,
+          catalogProductId: product.catalogProductId,
         };
       }
 

--- a/convex/yucpLicenses.ts
+++ b/convex/yucpLicenses.ts
@@ -255,22 +255,19 @@ export const verifyManualLicenseByHash = internalQuery({
   handler: async (ctx, args): Promise<ManualLicenseHashVerificationResult> => {
     const license = await ctx.db
       .query('manual_licenses')
-      .withIndex('by_license_key_hash', (q) => q.eq('licenseKeyHash', args.licenseKeyHash))
+      .withIndex('by_auth_user_product', (q) =>
+        q.eq('authUserId', args.authUserId).eq('productId', args.productId)
+      )
+      .filter((q) => q.eq(q.field('licenseKeyHash'), args.licenseKeyHash))
       .first();
 
-    if (!license || license.authUserId !== args.authUserId) {
+    if (!license) {
       return { valid: false as const };
     }
-    if (license.productId !== args.productId) {
-      return { valid: false as const };
-    }
-    if (license.status !== 'active') {
+    if (license.status !== 'active' && license.status !== 'exhausted') {
       return { valid: false as const };
     }
     if (license.expiresAt && Date.now() > license.expiresAt) {
-      return { valid: false as const };
-    }
-    if (license.maxUses !== undefined && license.currentUses >= license.maxUses) {
       return { valid: false as const };
     }
 

--- a/convex/yucpLicenses.ts
+++ b/convex/yucpLicenses.ts
@@ -32,6 +32,7 @@
 import { sha256Hex } from '@yucp/shared/crypto';
 import { ConvexError, v } from 'convex/values';
 import { internal } from './_generated/api';
+import type { Id } from './_generated/dataModel';
 import {
   action,
   internalAction,
@@ -80,6 +81,38 @@ const PROTECTED_ASSET_ID_RE = /^[a-f0-9]{32}$/;
 const MACHINE_FINGERPRINT_RE = /^[a-z0-9:_-]{16,256}$/i;
 const PROJECT_ID_RE = /^[a-f0-9]{32}$/;
 const CONTENT_HASH_RE = /^[0-9a-f]{64}$/;
+
+type ManualLicenseHashVerificationResult =
+  | { valid: true; licenseId: Id<'manual_licenses'> }
+  | { valid: false; reason: string };
+
+type LicenseProofResult = {
+  success: boolean;
+  error?: string;
+  manualLicenseId?: Id<'manual_licenses'>;
+  creatorAuthUserId?: string;
+  productId?: string;
+};
+
+async function hashManualLicenseKey(licenseKey: string): Promise<string> {
+  const encryptionSecret = process.env.ENCRYPTION_SECRET?.trim();
+  if (!encryptionSecret) {
+    throw new Error('ENCRYPTION_SECRET is required for manual license verification');
+  }
+
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(encryptionSecret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(licenseKey));
+  return Array.from(new Uint8Array(signature))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
 
 async function getPinnedSigningRoot(configuredKeyId?: string | null): Promise<{
   keyId: string;
@@ -167,6 +200,42 @@ export const lookupProductByProviderRef = query({
       provider: args.provider,
       providerProductRef: args.providerProductRef,
     });
+  },
+});
+
+export const verifyManualLicenseByHash = internalQuery({
+  args: {
+    authUserId: v.string(),
+    productId: v.string(),
+    licenseKeyHash: v.string(),
+  },
+  returns: v.union(
+    v.object({ valid: v.literal(true), licenseId: v.id('manual_licenses') }),
+    v.object({ valid: v.literal(false), reason: v.string() })
+  ),
+  handler: async (ctx, args): Promise<ManualLicenseHashVerificationResult> => {
+    const license = await ctx.db
+      .query('manual_licenses')
+      .withIndex('by_license_key_hash', (q) => q.eq('licenseKeyHash', args.licenseKeyHash))
+      .first();
+
+    if (!license || license.authUserId !== args.authUserId) {
+      return { valid: false as const, reason: 'License verification failed' };
+    }
+    if (license.productId !== args.productId) {
+      return { valid: false as const, reason: 'License does not match this product' };
+    }
+    if (license.status === 'revoked') {
+      return { valid: false as const, reason: 'License has been revoked' };
+    }
+    if (license.expiresAt && Date.now() > license.expiresAt) {
+      return { valid: false as const, reason: 'License has expired' };
+    }
+    if (license.maxUses !== undefined && license.currentUses >= license.maxUses) {
+      return { valid: false as const, reason: 'License has reached its usage limit' };
+    }
+
+    return { valid: true as const, licenseId: license._id };
   },
 });
 
@@ -537,8 +606,11 @@ export const verifyLicenseProof = internalAction({
   returns: v.object({
     success: v.boolean(),
     error: v.optional(v.string()),
+    manualLicenseId: v.optional(v.id('manual_licenses')),
+    creatorAuthUserId: v.optional(v.string()),
+    productId: v.optional(v.string()),
   }),
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<LicenseProofResult> => {
     if (!args.packageId || !args.licenseKey || !args.provider || !args.productPermalink) {
       return { success: false, error: 'Missing required fields' };
     }
@@ -568,6 +640,23 @@ export const verifyLicenseProof = internalAction({
             error: 'Package not found or not registered to the product owner',
           };
         }
+      }
+
+      if (args.provider === 'manual') {
+        const manualLicense = await ctx.runQuery(internal.yucpLicenses.verifyManualLicenseByHash, {
+          authUserId: product.authUserId,
+          productId: product.productId,
+          licenseKeyHash: await hashManualLicenseKey(args.licenseKey),
+        });
+        if (!manualLicense.valid) {
+          return { success: false, error: manualLicense.reason };
+        }
+        return {
+          success: true,
+          manualLicenseId: manualLicense.licenseId,
+          creatorAuthUserId: product.authUserId,
+          productId: product.productId,
+        };
       }
 
       verifyResult = await verifyLicenseWithProviderRuntime(ctx, {

--- a/convex/yucpLicenses.ts
+++ b/convex/yucpLicenses.ts
@@ -74,6 +74,7 @@ const TOKEN_TTL_SECONDS = 3600; // 1 hour -- kept short; disk cache handles offl
 const PROTECTED_UNLOCK_TTL_SECONDS = 10 * 60;
 const COUPLING_ASSET_PATH_MAX_LENGTH = 512;
 const MAX_PROTECTED_ASSETS_PER_REQUEST = 100;
+const MAX_MANUAL_LICENSE_KEY_LENGTH = 4_096;
 const COUPLING_SEED_RELAY_TIMEOUT_MS = 5_000;
 const COUPLING_SEED_RELAY_RESPONSE_MAX_CHARS = 256 * 1024;
 const PACKAGE_ID_RE = /^[a-z0-9\-_./:]{1,128}$/;
@@ -651,6 +652,9 @@ export const verifyLicenseProof = internalAction({
   handler: async (ctx, args): Promise<LicenseProofResult> => {
     if (!args.packageId || !args.licenseKey || !args.provider || !args.productPermalink) {
       return { success: false, error: 'Missing required fields' };
+    }
+    if (args.provider === 'manual' && args.licenseKey.length > MAX_MANUAL_LICENSE_KEY_LENGTH) {
+      return { success: false, error: 'License verification failed' };
     }
 
     let verifyResult: { valid: boolean; reason?: string } | null = null;

--- a/convex/yucpLicenses.ts
+++ b/convex/yucpLicenses.ts
@@ -180,6 +180,44 @@ export const getProductByProviderRef = internalQuery({
   },
 });
 
+/**
+ * Find a creator-owned product by its provider reference.
+ *
+ * Manual license intent requirements already identify the creator and local
+ * product. Querying through that owner scope prevents another creator's
+ * matching provider reference from changing the proof target.
+ */
+export const getProductByProviderRefForCreator = internalQuery({
+  args: {
+    authUserId: v.string(),
+    provider: v.string(),
+    providerProductRef: v.string(),
+  },
+  returns: v.union(
+    v.null(),
+    v.object({
+      authUserId: v.string(),
+      productId: v.string(),
+      displayName: v.optional(v.string()),
+    })
+  ),
+  handler: async (ctx, args): Promise<ProductByProviderRefResult> => {
+    const row = await ctx.db
+      .query('product_catalog')
+      .withIndex('by_auth_user', (q) => q.eq('authUserId', args.authUserId))
+      .filter((q) =>
+        q.and(
+          q.eq(q.field('provider'), args.provider),
+          q.eq(q.field('providerProductRef'), args.providerProductRef),
+          q.eq(q.field('status'), 'active')
+        )
+      )
+      .first();
+    if (!row) return null;
+    return { authUserId: row.authUserId, productId: row.productId, displayName: row.displayName };
+  },
+});
+
 export const lookupProductByProviderRef = query({
   args: {
     apiSecret: v.string(),
@@ -617,10 +655,17 @@ export const verifyLicenseProof = internalAction({
 
     let verifyResult: { valid: boolean; reason?: string } | null = null;
 
-    const product = await ctx.runQuery(internal.yucpLicenses.getProductByProviderRef, {
-      provider: args.provider,
-      providerProductRef: args.productPermalink,
-    });
+    const product =
+      args.provider === 'manual' && args.creatorAuthUserId && args.productId
+        ? await ctx.runQuery(internal.yucpLicenses.getProductByProviderRefForCreator, {
+            authUserId: args.creatorAuthUserId,
+            provider: args.provider,
+            providerProductRef: args.productPermalink,
+          })
+        : await ctx.runQuery(internal.yucpLicenses.getProductByProviderRef, {
+            provider: args.provider,
+            providerProductRef: args.productPermalink,
+          });
 
     if (product) {
       if (args.creatorAuthUserId || args.productId) {

--- a/convex/yucpLicenses.ts
+++ b/convex/yucpLicenses.ts
@@ -264,13 +264,13 @@ export const verifyManualLicenseByHash = internalQuery({
     if (!license) {
       return { valid: false as const };
     }
-    if (license.status !== 'active' && license.status !== 'exhausted') {
-      return { valid: false as const };
-    }
-    if (license.expiresAt && Date.now() > license.expiresAt) {
+    if (license.status === 'revoked') {
       return { valid: false as const };
     }
 
+    // Exhausted and expired licenses can prove an existing redemption only.
+    // The atomic completion mutation rechecks consumability and permits these
+    // rows exclusively when this buyer already has the matching entitlement.
     return { valid: true as const, licenseId: license._id };
   },
 });


### PR DESCRIPTION
## Root cause

The session-auth manual-license route reaches `verificationIntents.verifyIntentWithManualLicense`, but issued YUCP manual licenses use provider key `manual`. `yucpLicenses.verifyLicenseProof` sent that key to the external provider-runtime registry, which has no `manual` runtime. It therefore returned `License verification failed`, which the intent action mapped to `invalid_proof`.

Manual issuance stores the canonical `licenseKeyHash`, an HMAC-SHA-256 of the key using the exact raw `ENCRYPTION_SECRET` bytes. The redeem boundary now derives that same hash and looks it up creator-and-product scoped, avoiding both legacy `hashedKey` drift and same-hash cross-creator collisions.

## Fix

- Add shared manual-license proof validation in `convex/yucpLicenses.ts`.
- Complete the manual redemption atomically in `convex/verificationIntents.ts`.
- Grant through `grantEntitlementFromFunnel` with explicit `sourceProvider: 'manual'`, deterministic hashed source reference, evidence, audit, and role-sync handling.
- Consume a seat only for a new or reactivated entitlement. An exhausted key can re-prove only the holder's existing active entitlement and cannot mint another buyer's entitlement.
- Bound manual proof input before HMAC hashing.
- Add real redeem regressions for the full journey, exact-secret hashing, exhaustion, same-buyer retry, cross-creator product/hash collisions, and oversized keys.

## Validation

- RED: the focused realtest on the original chain returned `invalid_proof` / `License verification failed`.
- GREEN: all focused manual redeem regressions pass.
- `bun run test:convex`: 45 files, 367 tests passed.
- `bun run lint`, `bun run typecheck`, `bun run test:external-integrations`, and `bun run test:ci` passed locally.
- GitHub CI checks pass. CodeRabbit is the sole non-passing check because prepaid review credits are exhausted.
- `bun audit` reports the pre-existing pinned `@better-auth/oauth-provider@1.6.13` advisory. No dependency or lockfile changes were made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for redeeming manual license keys through verification intents, including entitlement grants and redemption evidence.
  * Implemented manual license usage tracking with exhaustion and expiration checks, plus replay protection.
* **Bug Fixes**
  * Prevented unauthorized manual license reuse by additional buyers.
  * Ensured invalid or oversized manual license keys fail verification without granting entitlements.
  * Verified that replays and revalidation scenarios don’t incorrectly consume extra license uses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->