### PR TITLE
fix(api): prevent package base URL regex backtracking

### DIFF
--- a/apps/api/src/routes/packages.backstage.test.ts
+++ b/apps/api/src/routes/packages.backstage.test.ts
@@ -217,7 +217,7 @@ mock.module('../internalRpc/router', () => ({
 
 const originalBackstageLiveSyncTimeoutMs = process.env.BACKSTAGE_LIVE_SYNC_TIMEOUT_MS;
 process.env.BACKSTAGE_LIVE_SYNC_TIMEOUT_MS = '25';
-const { createPackageRoutes } = await import('./packages');
+const { createPackageRoutes, trimTrailingForwardSlashes } = await import('./packages');
 if (originalBackstageLiveSyncTimeoutMs === undefined) {
   delete process.env.BACKSTAGE_LIVE_SYNC_TIMEOUT_MS;
 } else {
@@ -491,6 +491,18 @@ describe('package Backstage publishing routes', () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+  });
+
+  it('trims trailing URL slashes in linear time', () => {
+    expect(trimTrailingForwardSlashes('https://api.test///')).toBe('https://api.test');
+    expect(trimTrailingForwardSlashes('https://api.test')).toBe('https://api.test');
+    expect(trimTrailingForwardSlashes('/')).toBe('');
+
+    const adversarialInput = 'a'.repeat(100_000);
+    const startedAt = performance.now();
+
+    expect(trimTrailingForwardSlashes(adversarialInput)).toBe(adversarialInput);
+    expect(performance.now() - startedAt).toBeLessThan(100);
   });
 
   it('does not expose API-mediated Backstage package byte upload routes', () => {

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -282,6 +282,14 @@ function base64UrlDecode(input: string): string {
   return Buffer.from(input, 'base64url').toString('utf8');
 }
 
+export function trimTrailingForwardSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 0x2f) {
+    end -= 1;
+  }
+  return end === value.length ? value : value.slice(0, end);
+}
+
 function signBackstageUploadToken(payload: BackstageUploadTokenPayload, secret: string): string {
   const encodedPayload = base64UrlEncode(JSON.stringify(payload));
   const signature = createHmac('sha256', secret).update(encodedPayload).digest('base64url');
@@ -1711,7 +1719,7 @@ export function createPackageRoutes(auth: Auth, config: PackagesConfig) {
         },
         config.convexApiSecret
       );
-      const completeUrl = `${config.apiBaseUrl.replace(/\/+$/, '')}/api/packages/${encodeURIComponent(
+      const completeUrl = `${trimTrailingForwardSlashes(config.apiBaseUrl)}/api/packages/${encodeURIComponent(
         packageId
       )}/backstage/upload-session/complete`;
 


### PR DESCRIPTION
## Summary
- replace the CodeQL-flagged trailing-slash regex in the package upload completion URL builder with a manual linear scan
- add regression coverage for normal URL trimming and a 100,000-character non-slash input

## Validation
- un test apps/api/src/routes/packages.backstage.test.ts (35 passing)
- full repository CI checks attempted; local dependency installation timed out and baseline tools are unavailable (	sc, Biome, Vite, @edge-runtime/vm). un audit also reports the existing moderate Better Auth advisory. No package or lockfile changes were made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload completion URL handling when the API base URL includes trailing slashes.
  * Ensured URLs are generated correctly for edge cases, including a base URL consisting only of `/`.
  * Added safeguards for large inputs to maintain responsive processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->