### PR TITLE
fix: make manual redemption reachable in hosted flows

### DIFF
--- a/apps/api/src/providers/index.ts
+++ b/apps/api/src/providers/index.ts
@@ -14,6 +14,7 @@ import gumroad from './gumroad/index';
 import itchio from './itchio/index';
 import jinxxy from './jinxxy/index';
 import lemonsqueezy from './lemonsqueezy/index';
+import manual from './manual/index';
 import patreon from './patreon/index';
 import payhip from './payhip/index';
 import type {
@@ -49,12 +50,18 @@ const PROVIDER_ENTRIES = defineProviderRegistry({
   vrchat,
 });
 
+const VERIFICATION_ONLY_PROVIDER_ENTRIES = {
+  manual,
+};
+
 export const ALL_PROVIDER_RUNTIMES = Object.freeze(
   Object.values(PROVIDER_ENTRIES).map((entry) => entry.runtime)
 );
 
 export const PROVIDER_RUNTIMES: ReadonlyMap<string, ProviderRuntime> = new Map(
-  Object.entries(PROVIDER_ENTRIES).map(([providerKey, entry]) => [providerKey, entry.runtime])
+  [...Object.entries(PROVIDER_ENTRIES), ...Object.entries(VERIFICATION_ONLY_PROVIDER_ENTRIES)].map(
+    ([providerKey, entry]) => [providerKey, entry.runtime]
+  )
 );
 
 const PROVIDER_HOOK_ENTRIES: ReadonlyArray<readonly [string, ApiProviderHooks]> = [

--- a/apps/api/src/providers/manual/index.ts
+++ b/apps/api/src/providers/manual/index.ts
@@ -1,0 +1,9 @@
+import { createManualProviderModule } from '@yucp/providers/manual/module';
+import { defineApiProviderEntry } from '../types';
+
+const manualProvider = defineApiProviderEntry({
+  runtime: createManualProviderModule(),
+  hooks: {},
+});
+
+export default manualProvider;

--- a/apps/api/src/providers/registry.test.ts
+++ b/apps/api/src/providers/registry.test.ts
@@ -92,12 +92,28 @@ describe('provider plugin registry', () => {
 
   it('keeps provider registry keys aligned with provider ids', () => {
     const providerIds = [...ALL_PROVIDER_RUNTIMES.map((provider) => provider.id)].sort();
-    const registryKeys = [...PROVIDER_RUNTIMES.keys()].sort();
+    const registryKeys = [...PROVIDER_RUNTIMES.keys()]
+      .filter((providerKey) => RUNTIME_PROVIDER_KEYS.includes(providerKey as never))
+      .sort();
     expect(registryKeys).toEqual(providerIds);
   });
 
   it('covers every provider-owned runtime provider key exactly once', () => {
-    expect([...PROVIDER_RUNTIMES.keys()].sort()).toEqual([...RUNTIME_PROVIDER_KEYS].sort());
+    expect([...PROVIDER_RUNTIMES.keys()].sort()).toEqual(
+      [...RUNTIME_PROVIDER_KEYS, 'manual'].sort()
+    );
+  });
+
+  it('exposes the manual license input through its verification-only runtime', () => {
+    const manual = PROVIDER_RUNTIMES.get('manual');
+
+    expect(manual?.hostedVerification?.describeManualLicenseCapability()).toMatchObject({
+      methodKind: 'manual_license',
+      input: {
+        kind: 'license_key',
+        masked: true,
+      },
+    });
   });
 
   it('routes VRChat account linking through the connect-mode setup flow', () => {

--- a/apps/api/src/verification/hostedIntents.ts
+++ b/apps/api/src/verification/hostedIntents.ts
@@ -26,9 +26,14 @@ function resolveHostedVerificationProvider(
     supportsHostedBuyerAccountLink: Boolean(
       descriptor.supportsBuyerOAuthLink && getVerificationConfig(providerKey)
     ),
-    describeManualLicenseCapability: () =>
-      getProviderRuntime(providerKey)?.buyerVerification?.describeCapability('manual_license') ??
-      null,
+    describeManualLicenseCapability: () => {
+      const runtime = getProviderRuntime(providerKey);
+      return (
+        runtime?.hostedVerification?.describeManualLicenseCapability() ??
+        runtime?.buyerVerification?.describeCapability('manual_license') ??
+        null
+      );
+    },
   };
 }
 

--- a/apps/api/test/e2e/support/realApiHarness.ts
+++ b/apps/api/test/e2e/support/realApiHarness.ts
@@ -12,6 +12,7 @@ import {
 import { type BuiltApiApp, buildApp } from '../../support/buildApp';
 
 export const E2E_ENCRYPTION_SECRET = `e2e-${crypto.randomUUID()}`;
+export const E2E_BETTER_AUTH_SECRET = 'test-better-auth-secret-32-chars!!';
 
 type HarnessState = {
   app: BuiltApiApp;
@@ -214,6 +215,8 @@ export function installRealApiHarness(): void {
       backfillApiUrl,
       getRealBackendAdminKey
     );
+    await runConvexEnvSet('ENCRYPTION_SECRET', E2E_ENCRYPTION_SECRET, getRealBackendAdminKey);
+    await runConvexEnvSet('BETTER_AUTH_SECRET', E2E_BETTER_AUTH_SECRET, getRealBackendAdminKey);
     const app = buildApp({
       baseUrl: 'http://127.0.0.1:3001',
       frontendUrl: 'http://127.0.0.1:3000',
@@ -221,6 +224,7 @@ export function installRealApiHarness(): void {
       convexSiteUrl: SITE_URL,
       convexApiSecret: API_SECRET,
       encryptionSecret: E2E_ENCRYPTION_SECRET,
+      betterAuthSecret: E2E_BETTER_AUTH_SECRET,
       internalServiceAuthSecret: INTERNAL_SERVICE_AUTH_SECRET,
       internalRpcSharedSecret: `e2e-rpc-${crypto.randomUUID()}`,
     });
@@ -296,6 +300,35 @@ export async function createBetterAuthUser(
 
   seededAuthUserIds.add(authUserId);
   return { authUserId, email, name };
+}
+
+export async function createBetterAuthSession(authUserId: string): Promise<string> {
+  const token = crypto.randomUUID();
+  const now = Date.now();
+  await callBetterAuthComponent('adapter:create', {
+    input: {
+      model: 'session',
+      data: {
+        token,
+        userId: authUserId,
+        expiresAt: now + 60 * 60 * 1000,
+        createdAt: now,
+        updatedAt: now,
+      },
+    },
+    select: ['token'],
+  });
+
+  const signingKey = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(E2E_BETTER_AUTH_SECRET),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const signature = await crypto.subtle.sign('HMAC', signingKey, new TextEncoder().encode(token));
+  const encodedSignature = btoa(String.fromCharCode(...new Uint8Array(signature)));
+  return `${token}.${encodedSignature}`;
 }
 
 export async function createPublicApiKey(

--- a/apps/api/test/e2e/user-journeys.test.ts
+++ b/apps/api/test/e2e/user-journeys.test.ts
@@ -13,10 +13,6 @@ import { createAuthUserActorBinding } from '../../src/lib/apiActor';
 import { encrypt } from '../../src/lib/encrypt';
 import { getProviderRuntime, resolveWebhookPlugin } from '../../src/providers';
 import {
-  decorateHostedVerificationRequirement,
-  normalizeHostedVerificationRequirements,
-} from '../../src/verification/hostedIntents';
-import {
   apiJson,
   createBetterAuthSession,
   createBetterAuthUser,
@@ -956,6 +952,24 @@ describe('real API user journeys against self-hosted Convex', () => {
       publisherId: uniqueRef('hosted_manual_publisher'),
       yucpUserId: creator.authUserId,
     });
+    await harness.convex.mutation(internal.packageRegistry.upsertDeliveryPackageForProduct, {
+      authUserId: creator.authUserId,
+      catalogProductId,
+      packageId,
+      packageName: 'Hosted Manual Redemption Package',
+      displayName: 'Hosted Manual Redemption Package',
+      repositoryVisibility: 'listed',
+      defaultChannel: 'stable',
+    });
+    await harness.convex.mutation(internal.packageRegistry.recordDeliveryPackageRelease, {
+      authUserId: creator.authUserId,
+      packageId,
+      version: '1.0.0',
+      channel: 'stable',
+      releaseStatus: 'published',
+      repositoryVisibility: 'listed',
+      artifactKey: uniqueRef('hosted_manual_release'),
+    });
     const { licenseId } = await harness.convex.mutation<{ licenseId: string }>(
       api.manualLicenses.create,
       {
@@ -967,50 +981,9 @@ describe('real API user journeys against self-hosted Convex', () => {
       }
     );
 
-    const requirements = normalizeHostedVerificationRequirements([
-      {
-        methodKey: 'manual-license',
-        providerKey: 'manual',
-        kind: 'manual_license',
-        providerProductRef: productId,
-        creatorAuthUserId: creator.authUserId,
-        productId,
-      },
-    ]);
-    expect(requirements).toHaveLength(1);
-    expect(decorateHostedVerificationRequirement(requirements[0])).toEqual(
-      expect.objectContaining({
-        methodKey: 'manual-license',
-        providerKey: 'manual',
-        kind: 'manual_license',
-        capability: expect.objectContaining({
-          input: expect.objectContaining({ kind: 'license_key', masked: true }),
-        }),
-      })
-    );
-    const buyerActor = await createAuthUserActorBinding({
-      authUserId: buyer.authUserId,
-      source: 'api_key',
-      scopes: PUBLIC_API_SCOPES,
-    });
-    const { intentId } = await harness.convex.mutation<{ intentId: string }>(
-      api.verificationIntents.createVerificationIntent,
-      {
-        apiSecret: API_SECRET,
-        actor: buyerActor,
-        authUserId: buyer.authUserId,
-        packageId,
-        packageName: 'Hosted Manual Redemption Package',
-        machineFingerprint: 'hosted-manual-redemption-machine',
-        codeChallenge: 'hosted-manual-redemption-challenge',
-        returnUrl: 'http://127.0.0.1:3000/account/verify',
-        requirements,
-      }
-    );
-
     const sessionToken = await createBetterAuthSession(buyer.authUserId);
-    const redemptionResponse = await harness.app.fetch(
-      `/api/connect/user/verification-intents/${intentId}/manual-license`,
+    const intentResponse = await harness.app.fetch(
+      `/api/connect/user/product-access/${catalogProductId}`,
       {
         method: 'POST',
         headers: {
@@ -1018,7 +991,49 @@ describe('real API user journeys against self-hosted Convex', () => {
           cookie: `yucp.session_token=${sessionToken}`,
           origin: 'http://127.0.0.1:3001',
         },
-        body: JSON.stringify({ methodKey: 'manual-license', licenseKey }),
+        body: JSON.stringify({ returnTo: `/access/${catalogProductId}` }),
+      }
+    );
+
+    expect(intentResponse.status).toBe(200);
+    const intent = (await intentResponse.json()) as {
+      intentId: string;
+      requirements: Array<{
+        methodKey: string;
+        providerKey: string;
+        kind: string;
+        capability: { input?: { kind: string; masked: boolean } };
+      }>;
+    };
+    const manualRequirements = intent.requirements.filter(
+      (requirement) => requirement.kind === 'manual_license'
+    );
+    expect(manualRequirements).toHaveLength(1);
+    const manualRequirement = manualRequirements[0];
+    expect(manualRequirement).toEqual(
+      expect.objectContaining({
+        methodKey: 'manual-manual-license',
+        providerKey: 'manual',
+        kind: 'manual_license',
+        capability: expect.objectContaining({
+          input: expect.objectContaining({ kind: 'license_key', masked: true }),
+        }),
+      })
+    );
+    if (!manualRequirement) {
+      throw new Error('Hosted manual license capability was not returned');
+    }
+
+    const redemptionResponse = await harness.app.fetch(
+      `/api/connect/user/verification-intents/${intent.intentId}/manual-license`,
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          cookie: `yucp.session_token=${sessionToken}`,
+          origin: 'http://127.0.0.1:3001',
+        },
+        body: JSON.stringify({ methodKey: manualRequirement.methodKey, licenseKey }),
       }
     );
 

--- a/apps/api/test/e2e/user-journeys.test.ts
+++ b/apps/api/test/e2e/user-journeys.test.ts
@@ -13,7 +13,12 @@ import { createAuthUserActorBinding } from '../../src/lib/apiActor';
 import { encrypt } from '../../src/lib/encrypt';
 import { getProviderRuntime, resolveWebhookPlugin } from '../../src/providers';
 import {
+  decorateHostedVerificationRequirement,
+  normalizeHostedVerificationRequirements,
+} from '../../src/verification/hostedIntents';
+import {
   apiJson,
+  createBetterAuthSession,
   createBetterAuthUser,
   E2E_ENCRYPTION_SECRET,
   getRealApiHarness,
@@ -925,6 +930,128 @@ async function expectNoEntitlements(): Promise<void> {
 }
 
 describe('real API user journeys against self-hosted Convex', () => {
+  test('manual products stay reachable through hosted intent creation and session-backed redemption', async () => {
+    const harness = getRealApiHarness();
+    const creator = await createBetterAuthUser({ name: 'Hosted Manual Redemption Creator' });
+    const buyer = await createBetterAuthUser({ name: 'Hosted Manual Redemption Buyer' });
+    const subjectId = await seedSubject(buyer.authUserId);
+    const packageId = uniqueRef('hosted_manual_package');
+    const productId = uniqueRef('hosted_manual_product');
+    const licenseKey = uniqueRef('hosted_manual_license');
+
+    await seedCreatorProfile({
+      authUserId: creator.authUserId,
+      name: 'Hosted Manual Redemption Creator',
+    });
+    const catalogProductId = await seedProductCatalog({
+      authUserId: creator.authUserId,
+      productId,
+      provider: 'manual',
+      providerProductRef: productId,
+      displayName: 'Hosted Manual Redemption Product',
+    });
+    await harness.convex.mutation(internal.packageRegistry.registerPackage, {
+      packageId,
+      packageName: 'Hosted Manual Redemption Package',
+      publisherId: uniqueRef('hosted_manual_publisher'),
+      yucpUserId: creator.authUserId,
+    });
+    const { licenseId } = await harness.convex.mutation<{ licenseId: string }>(
+      api.manualLicenses.create,
+      {
+        apiSecret: API_SECRET,
+        authUserId: creator.authUserId,
+        licenseKeyHash: await hashLicenseKey(licenseKey),
+        productId,
+        maxUses: 1,
+      }
+    );
+
+    const requirements = normalizeHostedVerificationRequirements([
+      {
+        methodKey: 'manual-license',
+        providerKey: 'manual',
+        kind: 'manual_license',
+        providerProductRef: productId,
+        creatorAuthUserId: creator.authUserId,
+        productId,
+      },
+    ]);
+    expect(requirements).toHaveLength(1);
+    expect(decorateHostedVerificationRequirement(requirements[0])).toEqual(
+      expect.objectContaining({
+        methodKey: 'manual-license',
+        providerKey: 'manual',
+        kind: 'manual_license',
+        capability: expect.objectContaining({
+          input: expect.objectContaining({ kind: 'license_key', masked: true }),
+        }),
+      })
+    );
+    const buyerActor = await createAuthUserActorBinding({
+      authUserId: buyer.authUserId,
+      source: 'api_key',
+      scopes: PUBLIC_API_SCOPES,
+    });
+    const { intentId } = await harness.convex.mutation<{ intentId: string }>(
+      api.verificationIntents.createVerificationIntent,
+      {
+        apiSecret: API_SECRET,
+        actor: buyerActor,
+        authUserId: buyer.authUserId,
+        packageId,
+        packageName: 'Hosted Manual Redemption Package',
+        machineFingerprint: 'hosted-manual-redemption-machine',
+        codeChallenge: 'hosted-manual-redemption-challenge',
+        returnUrl: 'http://127.0.0.1:3000/account/verify',
+        requirements,
+      }
+    );
+
+    const sessionToken = await createBetterAuthSession(buyer.authUserId);
+    const redemptionResponse = await harness.app.fetch(
+      `/api/connect/user/verification-intents/${intentId}/manual-license`,
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          cookie: `yucp.session_token=${sessionToken}`,
+          origin: 'http://127.0.0.1:3001',
+        },
+        body: JSON.stringify({ methodKey: 'manual-license', licenseKey }),
+      }
+    );
+
+    expect(redemptionResponse.status).toBe(200);
+    await expect(redemptionResponse.json()).resolves.toEqual({ success: true });
+
+    const sourceReference = `manual:${await sha256Hex(licenseId)}`;
+    const entitlements = await harness.convex.collect('entitlements');
+    expect(entitlements).toEqual([
+      expect.objectContaining({
+        authUserId: creator.authUserId,
+        subjectId,
+        productId,
+        catalogProductId,
+        sourceProvider: 'manual',
+        sourceReference,
+        status: 'active',
+      }),
+    ]);
+    const evidence = await harness.convex.collect('entitlement_evidence');
+    expect(evidence).toEqual([
+      expect.objectContaining({
+        authUserId: creator.authUserId,
+        subjectId,
+        providerKey: 'manual',
+        sourceReference,
+        evidenceType: 'manual_license_redeemed',
+        status: 'active',
+        productId,
+      }),
+    ]);
+  });
+
   test('manual-license reachable layer stores only HMAC and validates by hash', async () => {
     const creator = await createBetterAuthUser({ name: 'Manual License Convex Creator' });
     const actor = await createAuthUserActorBinding({

--- a/ops/production-regression-loop.ts
+++ b/ops/production-regression-loop.ts
@@ -84,7 +84,7 @@ export const PRODUCTION_REGRESSION_SURFACES: ProductionRegressionSurface[] = [
     id: 'verification',
     label: 'Verification flows',
     invariant:
-      'Verification must resolve the buyer subject, keep creator-scoped session context separate from buyer auth ownership, write entitlements and account-link records for the canonical buyer auth user, expose entitlements through stable read DTOs instead of raw persisted rows, preserve degraded or failure signals all the way to the public surface, keep provider source idempotency scoped to the granted product so multi-product orders can assign every role, complete role-sync jobs only after every configured product role is satisfied, surface role-sync failures even when product-driven jobs discover the guild during processing, keep actor-protected Convex helper contracts aligned with the API service actor envelope, and route API-originated verification state changes through public validated Convex actions instead of calling internal functions over the client boundary.',
+      'Verification must resolve the buyer subject, keep creator-scoped session context separate from buyer auth ownership, write entitlements and account-link records for the canonical buyer auth user, expose entitlements through stable read DTOs instead of raw persisted rows, preserve degraded or failure signals all the way to the public surface, advertise provider-owned manual license proof through actual hosted product requirements so a manual buyer can reach the entitlement funnel, keep provider source idempotency scoped to the granted product so multi-product orders can assign every role, complete role-sync jobs only after every configured product role is satisfied, surface role-sync failures even when product-driven jobs discover the guild during processing, keep actor-protected Convex helper contracts aligned with the API service actor envelope, and route API-originated verification state changes through public validated Convex actions instead of calling internal functions over the client boundary.',
     primaryRegressionHomes: [
       'convex/entitlements.realtest.ts',
       'convex/outboxJobs.realtest.ts',
@@ -96,6 +96,7 @@ export const PRODUCTION_REGRESSION_SURFACES: ProductionRegressionSurface[] = [
       'apps/api/src/verification/completeLicense.test.ts',
       'apps/api/src/verification/sessionManager.accountLink.test.ts',
       'apps/api/src/routes/connect.user-verify.behavior.test.ts',
+      'apps/api/test/e2e/user-journeys.test.ts',
     ],
     secondaryRegressionHomes: [
       'apps/bot/test/commands/verify.test.ts',

--- a/packages/providers/src/contracts.ts
+++ b/packages/providers/src/contracts.ts
@@ -156,6 +156,14 @@ export interface BuyerVerificationAdapter<
   ): Promise<BuyerVerificationResult>;
 }
 
+/**
+ * Describes provider-owned input for hosted verification flows whose proof is
+ * completed by the verification-intent action rather than a provider adapter.
+ */
+export interface HostedVerificationPlugin {
+  describeManualLicenseCapability(): BuyerVerificationCapabilityDescriptor | null;
+}
+
 export interface ConnectDisplayMeta {
   readonly dashboardSetupExperience: 'automatic' | 'guided' | 'manual';
   readonly dashboardSetupHint: string;
@@ -189,6 +197,7 @@ export interface ProviderRuntimeModule<
   readonly backfill?: BackfillPlugin<TBackfillFact>;
   readonly verification?: LicenseVerificationPlugin<TClient>;
   readonly buyerVerification?: BuyerVerificationAdapter<TClient>;
+  readonly hostedVerification?: HostedVerificationPlugin;
   readonly supportsCollab?: boolean;
   readonly productCredentialPurpose?: string;
   readonly displayMeta?: ConnectDisplayMeta;

--- a/packages/providers/src/descriptors/manual.ts
+++ b/packages/providers/src/descriptors/manual.ts
@@ -9,9 +9,13 @@ export const manual = {
   emojiKey: 'PersonKey',
   addProductDescription: 'Manually issued license key',
   creatorAuthModes: ['none'],
-  buyerVerificationMethods: ['manual'],
+  buyerVerificationMethods: ['manual', 'license_key'],
   capabilities: ['license_verification'],
   setupRequirements: [],
-  verificationMethods: ['manual'],
+  verificationMethods: ['manual', 'license_key'],
   supportsCredentialLogin: false,
+  licenseKey: {
+    inputLabel: 'Manual License Key',
+    placeholder: 'Enter the license key from your creator',
+  },
 } as const satisfies ProviderDescriptorInput;

--- a/packages/providers/src/manual/index.ts
+++ b/packages/providers/src/manual/index.ts
@@ -74,6 +74,8 @@ export {
   normalizeLicenseKey,
 } from './manager';
 
+export { createManualProviderModule, MANUAL_PURPOSES } from './module';
+
 // Types
 export type {
   BulkImportInput,

--- a/packages/providers/src/manual/module.ts
+++ b/packages/providers/src/manual/module.ts
@@ -1,0 +1,46 @@
+import type { BuyerVerificationCapabilityDescriptor, ProviderRuntimeModule } from '../contracts';
+import { getProviderDescriptor } from '../providerMetadata';
+
+export const MANUAL_PURPOSES = {
+  credential: 'manual-license',
+} as const;
+
+function describeManualLicenseCapability(): BuyerVerificationCapabilityDescriptor | null {
+  const descriptor = getProviderDescriptor('manual');
+  if (!descriptor?.buyerVerificationMethods.includes('license_key') || !descriptor.licenseKey) {
+    return null;
+  }
+
+  return {
+    methodKind: 'manual_license',
+    completion: 'immediate',
+    actionLabel: 'Verify license',
+    defaultTitle: `${descriptor.label} license`,
+    defaultDescription: `Enter the ${descriptor.label.toLowerCase()} key you received for this product.`,
+    input: {
+      kind: 'license_key',
+      label: descriptor.licenseKey.inputLabel,
+      placeholder: descriptor.licenseKey.placeholder,
+      masked: true,
+      submitLabel: 'Verify license',
+    },
+  };
+}
+
+export function createManualProviderModule(): ProviderRuntimeModule<never> {
+  return {
+    id: 'manual',
+    purposes: MANUAL_PURPOSES,
+    needsCredential: false,
+    async getCredential() {
+      return null;
+    },
+    async fetchProducts() {
+      // Manual products live in the local catalog and have no provider-side listing endpoint.
+      return [];
+    },
+    hostedVerification: {
+      describeManualLicenseCapability,
+    },
+  };
+}

--- a/packages/providers/test/manual.test.ts
+++ b/packages/providers/test/manual.test.ts
@@ -9,7 +9,9 @@ import {
   ManualLicenseManager,
   normalizeLicenseKey,
 } from '../src/manual/manager';
+import { createManualProviderModule } from '../src/manual/module';
 import type { CreateLicenseInput, ManualLicense, ManualLicenseStorage } from '../src/manual/types';
+import { getProviderDescriptor } from '../src/providerMetadata';
 
 // In-memory storage implementation for testing
 class InMemoryStorage implements ManualLicenseStorage {
@@ -131,6 +133,26 @@ describe('generateLicenseKey', () => {
     expect(normalizeLicenseKey('  yucp-abcd-efgh-ijkl')).toBe('YUCP-ABCD-EFGH-IJKL');
     expect(normalizeLicenseKey('  YUCP-ABCD-EFGH-IJKL  ')).toBe('YUCP-ABCD-EFGH-IJKL');
     expect(normalizeLicenseKey('  yucp abcd efgh ijkl ')).toBe('YUCP-ABCD-EFGH-IJKL');
+  });
+});
+
+describe('manual hosted verification capability', () => {
+  it('derives a license-key input from the manual provider descriptor', () => {
+    const runtime = createManualProviderModule();
+    const descriptor = getProviderDescriptor('manual');
+
+    expect(descriptor?.buyerVerificationMethods).toContain('license_key');
+    expect(runtime.hostedVerification?.describeManualLicenseCapability()).toEqual(
+      expect.objectContaining({
+        methodKind: 'manual_license',
+        input: expect.objectContaining({
+          kind: 'license_key',
+          label: descriptor?.licenseKey?.inputLabel,
+          placeholder: descriptor?.licenseKey?.placeholder,
+          masked: true,
+        }),
+      })
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- advertise manual products as license-key capable and supply their hosted input metadata
- register a verification-only manual runtime capability without changing dashboard/connect providers
- cover hosted requirement decoration, session-backed manual redemption, and the existing F22 entitlement funnel on self-hosted Convex

## Verification
- bun run test:e2e:flows:run
- bun test ./packages/providers/test/manual.test.ts ./apps/api/src/providers/registry.test.ts ./apps/api/src/verification/hostedIntents.test.ts
- bun run lint
- bun run typecheck
- bun run test:external-integrations
- bun run test:ci

un audit is blocked by the existing moderate @better-auth/oauth-provider advisory; this task does not change dependencies or the lockfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added hosted verification support for manual provider products using creator-issued license keys.
  - Manual license keys are collected through a clearly labeled, masked input and can be redeemed through hosted access flows.
  - Manual products now remain accessible through hosted intent creation and entitlement redemption.

- **Bug Fixes**
  - Improved capability detection so hosted verification uses the appropriate manual license configuration when available.

- **Tests**
  - Added end-to-end coverage for manual license creation, verification, redemption, and entitlement activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->