### PR TITLE
fix: reject backslash auth redirects

### DIFF
--- a/packages/shared/src/authRedirects.ts
+++ b/packages/shared/src/authRedirects.ts
@@ -14,7 +14,9 @@ function hasDashboardBootstrapHash(url: URL): boolean {
 
 function resolvesToAuthRedirectOrigin(value: string): boolean {
   try {
-    return new URL(value.replaceAll('\\', '/'), AUTH_REDIRECT_ORIGIN).origin === AUTH_REDIRECT_ORIGIN;
+    return (
+      new URL(value.replaceAll('\\', '/'), AUTH_REDIRECT_ORIGIN).origin === AUTH_REDIRECT_ORIGIN
+    );
   } catch {
     return false;
   }

--- a/packages/shared/src/authRedirects.ts
+++ b/packages/shared/src/authRedirects.ts
@@ -1,4 +1,5 @@
 const DEFAULT_AUTH_REDIRECT_TARGET = '/dashboard';
+const AUTH_REDIRECT_ORIGIN = 'https://auth.invalid';
 const AUTH_LOOP_PATHS = new Set(['/sign-in', '/sign-in-redirect']);
 const DASHBOARD_QUERY_KEYS_TO_STRIP = ['guild_id', 'guildId', 'tenant_id', 'authUserId'] as const;
 
@@ -11,6 +12,14 @@ function hasDashboardBootstrapHash(url: URL): boolean {
   return Boolean(hashParams.get('s') || hashParams.get('token'));
 }
 
+function resolvesToAuthRedirectOrigin(value: string): boolean {
+  try {
+    return new URL(value.replaceAll('\\', '/'), AUTH_REDIRECT_ORIGIN).origin === AUTH_REDIRECT_ORIGIN;
+  } catch {
+    return false;
+  }
+}
+
 // Source: https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html
 export function getSafeRelativeRedirectTarget(value: string | null | undefined): string | null {
   if (!value) {
@@ -21,7 +30,15 @@ export function getSafeRelativeRedirectTarget(value: string | null | undefined):
     return null;
   }
 
-  if (value.startsWith('//')) {
+  if (!resolvesToAuthRedirectOrigin(value)) {
+    return null;
+  }
+
+  try {
+    if (!resolvesToAuthRedirectOrigin(decodeURIComponent(value))) {
+      return null;
+    }
+  } catch {
     return null;
   }
 
@@ -37,7 +54,7 @@ export function normalizeAuthRedirectTarget(
     return fallback;
   }
 
-  const url = new URL(safeTarget, 'https://auth.invalid');
+  const url = new URL(safeTarget, AUTH_REDIRECT_ORIGIN);
 
   if (AUTH_LOOP_PATHS.has(url.pathname)) {
     return fallback;

--- a/packages/shared/test/authRedirects.test.ts
+++ b/packages/shared/test/authRedirects.test.ts
@@ -4,6 +4,15 @@ import { getSafeRelativeRedirectTarget, normalizeAuthRedirectTarget } from '../s
 describe('auth redirect targets', () => {
   it('rejects open redirects', () => {
     expect(getSafeRelativeRedirectTarget('//evil.example/steal')).toBeNull();
+    expect(getSafeRelativeRedirectTarget('/\\evil.example/steal')).toBeNull();
+    expect(getSafeRelativeRedirectTarget('/\\\\evil.example/steal')).toBeNull();
+    expect(getSafeRelativeRedirectTarget('\\/evil.example/steal')).toBeNull();
+    expect(getSafeRelativeRedirectTarget('\\\\evil.example/steal')).toBeNull();
+    expect(getSafeRelativeRedirectTarget('/%5Cevil.example/steal')).toBeNull();
+  });
+
+  it('keeps relative redirect targets', () => {
+    expect(getSafeRelativeRedirectTarget('/dashboard?x=1')).toBe('/dashboard?x=1');
   });
 
   it('keeps dashboard auth independent from guild selection', () => {


### PR DESCRIPTION
## Summary
- reject raw and percent-decoded backslash variants that WHATWG URL resolution could turn into authority-bearing redirects
- retain legitimate relative redirect targets
- add regression coverage for slash/backslash variants

## Validation
- RED: Run test packages/shared/test/authRedirects.test.ts failed on /\\evil.example/steal, returning the unsafe input
- GREEN: focused test passes, 7 tests
- Full gates were attempted but the fresh worktree install timed out and required binaries/dependencies are unavailable. Run audit also reports the existing moderate @better-auth/oauth-provider advisory. No dependency changes were made.