### PR TITLE
fix: retry due webhook deliveries

### DIFF
--- a/convex/webhookDeliveries.ts
+++ b/convex/webhookDeliveries.ts
@@ -17,8 +17,9 @@ const BACKOFF_MS = [30_000, 300_000, 1_800_000, 7_200_000, 28_800_000];
 // ---------------------------------------------------------------------------
 
 /**
- * List deliveries with status='pending' that are ready for processing now.
- * A delivery is ready if nextRetryAt is absent (immediate) or in the past.
+ * List pending deliveries and failed deliveries whose retry time has elapsed.
+ * Pending deliveries are ready if nextRetryAt is absent (immediate) or in the past.
+ * Failed deliveries are retryable only before their max-attempts cap.
  * Used by the delivery worker cron.
  */
 export const listPending = internalQuery({
@@ -30,7 +31,22 @@ export const listPending = internalQuery({
       .query('webhook_deliveries')
       .withIndex('by_status_retry', (q) => q.eq('status', 'pending'))
       .collect();
-    return pending.filter((d) => d.nextRetryAt === undefined || d.nextRetryAt <= now).slice(0, 20);
+    const dueRetries = await ctx.db
+      .query('webhook_deliveries')
+      .withIndex('by_status_retry', (q) => q.eq('status', 'failed').lte('nextRetryAt', now))
+      .collect();
+
+    return [...pending, ...dueRetries]
+      .filter(
+        (delivery) =>
+          (delivery.status === 'pending' &&
+            (delivery.nextRetryAt === undefined || delivery.nextRetryAt <= now)) ||
+          (delivery.status === 'failed' &&
+            delivery.nextRetryAt !== undefined &&
+            delivery.nextRetryAt <= now &&
+            delivery.attemptCount < delivery.maxAttempts)
+      )
+      .slice(0, 20);
   },
 });
 

--- a/convex/webhookDeliveries.ts
+++ b/convex/webhookDeliveries.ts
@@ -46,22 +46,40 @@ export const listPending = internalQuery({
             delivery.nextRetryAt <= now &&
             delivery.attemptCount < delivery.maxAttempts)
       )
+      .sort((left, right) => {
+        const readyAtDifference = (left.nextRetryAt ?? now) - (right.nextRetryAt ?? now);
+        if (readyAtDifference !== 0) return readyAtDifference;
+
+        if (left.status !== right.status) {
+          return left.status === 'failed' ? -1 : 1;
+        }
+
+        return left.createdAt - right.createdAt;
+      })
       .slice(0, 20);
   },
 });
 
-/** Mark a delivery as in_progress at the start of a delivery attempt. */
+/**
+ * Atomically claim a pending or retryable delivery for one worker.
+ * Returns false when another worker has already claimed or completed it.
+ */
 export const markInProgress = internalMutation({
   args: {
     deliveryId: v.id('webhook_deliveries'),
   },
-  returns: v.null(),
+  returns: v.boolean(),
   handler: async (ctx, args) => {
+    const delivery = await ctx.db.get(args.deliveryId);
+    if (!delivery || (delivery.status !== 'pending' && delivery.status !== 'failed')) {
+      return false;
+    }
+
     await ctx.db.patch(args.deliveryId, {
       status: 'in_progress',
       updatedAt: Date.now(),
     });
-    return null;
+    return true;
   },
 });
 

--- a/convex/webhookDeliveryWorker.realtest.ts
+++ b/convex/webhookDeliveryWorker.realtest.ts
@@ -49,6 +49,81 @@ async function seedFailedDelivery(
 }
 
 describe('processWebhookDeliveries retry scheduling', () => {
+  it('includes a due failed retry when the pending backlog reaches the batch limit', async () => {
+    const t = makeTestConvex();
+    const now = Date.now();
+    const dueRetryId = await t.run(async (ctx) => {
+      const subscriptionId = await ctx.db.insert('webhook_subscriptions', {
+        authUserId: AUTH_USER_ID,
+        url: 'https://example.com/webhooks/backlog-test',
+        events: ['ping'],
+        enabled: true,
+        signingSecretEnc: 'invalid-ciphertext',
+        signingSecretPrefix: 'whsec_test',
+        status: 'active',
+        createdAt: now,
+        updatedAt: now,
+      });
+      const eventId = await ctx.db.insert('creator_events', {
+        authUserId: AUTH_USER_ID,
+        eventType: 'ping',
+        resourceType: 'test',
+        resourceId: 'backlog-test',
+        data: { ok: true },
+        createdAt: now,
+      });
+
+      for (let index = 0; index < 20; index++) {
+        await ctx.db.insert('webhook_deliveries', {
+          authUserId: AUTH_USER_ID,
+          subscriptionId,
+          eventId,
+          status: 'pending',
+          attemptCount: 0,
+          maxAttempts: 5,
+          createdAt: now,
+          updatedAt: now,
+        });
+      }
+
+      return await ctx.db.insert('webhook_deliveries', {
+        authUserId: AUTH_USER_ID,
+        subscriptionId,
+        eventId,
+        status: 'failed',
+        attemptCount: 1,
+        maxAttempts: 5,
+        nextRetryAt: now - 1,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    const deliveries = await t.run(async (ctx) =>
+      ctx.runQuery(internal.webhookDeliveries.listPending, {})
+    );
+
+    expect(deliveries).toHaveLength(20);
+    expect(deliveries.map((delivery) => delivery._id)).toContain(dueRetryId);
+  });
+
+  it('atomically claims a due delivery once', async () => {
+    const t = makeTestConvex();
+    const deliveryId = await seedFailedDelivery(t);
+
+    const firstClaim = await t.run(async (ctx) =>
+      ctx.runMutation(internal.webhookDeliveries.markInProgress, { deliveryId })
+    );
+    const secondClaim = await t.run(async (ctx) =>
+      ctx.runMutation(internal.webhookDeliveries.markInProgress, { deliveryId })
+    );
+
+    expect(firstClaim).toBe(true);
+    expect(secondClaim).toBe(false);
+    const delivery = await t.run(async (ctx) => await ctx.db.get(deliveryId));
+    expect(delivery).toMatchObject({ status: 'in_progress', attemptCount: 1 });
+  });
+
   it('re-attempts a failed delivery whose retry time has elapsed', async () => {
     const t = makeTestConvex();
     const deliveryId = await seedFailedDelivery(t);

--- a/convex/webhookDeliveryWorker.realtest.ts
+++ b/convex/webhookDeliveryWorker.realtest.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { internal } from './_generated/api';
+import { makeTestConvex } from './testHelpers';
+
+const AUTH_USER_ID = 'auth-webhook-delivery-worker';
+
+async function seedFailedDelivery(
+  t: ReturnType<typeof makeTestConvex>,
+  overrides: {
+    attemptCount?: number;
+    maxAttempts?: number;
+    nextRetryAt?: number;
+    status?: 'failed' | 'dead_letter';
+  } = {}
+) {
+  const now = Date.now();
+  return await t.run(async (ctx) => {
+    const subscriptionId = await ctx.db.insert('webhook_subscriptions', {
+      authUserId: AUTH_USER_ID,
+      url: 'https://example.com/webhooks/retry-test',
+      events: ['ping'],
+      enabled: true,
+      signingSecretEnc: 'invalid-ciphertext',
+      signingSecretPrefix: 'whsec_test',
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+    });
+    const eventId = await ctx.db.insert('creator_events', {
+      authUserId: AUTH_USER_ID,
+      eventType: 'ping',
+      resourceType: 'test',
+      resourceId: 'retry-test',
+      data: { ok: true },
+      createdAt: now,
+    });
+    return await ctx.db.insert('webhook_deliveries', {
+      authUserId: AUTH_USER_ID,
+      subscriptionId,
+      eventId,
+      status: overrides.status ?? 'failed',
+      attemptCount: overrides.attemptCount ?? 1,
+      maxAttempts: overrides.maxAttempts ?? 5,
+      nextRetryAt: overrides.nextRetryAt ?? now - 1,
+      createdAt: now,
+      updatedAt: now,
+    });
+  });
+}
+
+describe('processWebhookDeliveries retry scheduling', () => {
+  it('re-attempts a failed delivery whose retry time has elapsed', async () => {
+    const t = makeTestConvex();
+    const deliveryId = await seedFailedDelivery(t);
+
+    const result = await t.action(internal.webhookDeliveryWorker.processWebhookDeliveries, {});
+
+    expect(result).toMatchObject({ processed: 0, failed: 1 });
+    const delivery = await t.run(async (ctx) => await ctx.db.get(deliveryId));
+    expect(delivery).toMatchObject({
+      status: 'failed',
+      attemptCount: 2,
+      lastError: 'Failed to decrypt signing secret',
+    });
+    expect(delivery?.nextRetryAt).toBeGreaterThan(Date.now());
+  });
+
+  it('does not retry a dead-lettered delivery at the max-attempt cap', async () => {
+    const t = makeTestConvex();
+    const deliveryId = await seedFailedDelivery(t, {
+      attemptCount: 4,
+      maxAttempts: 5,
+    });
+
+    await t.run(async (ctx) =>
+      ctx.runMutation(internal.webhookDeliveries.markFailed, { deliveryId })
+    );
+
+    const result = await t.action(internal.webhookDeliveryWorker.processWebhookDeliveries, {});
+
+    expect(result).toEqual({ processed: 0, failed: 0, errors: [] });
+    const delivery = await t.run(async (ctx) => await ctx.db.get(deliveryId));
+    expect(delivery).toMatchObject({ status: 'dead_letter', attemptCount: 5 });
+  });
+
+  it('does not retry a failed delivery before its retry time', async () => {
+    const t = makeTestConvex();
+    const deliveryId = await seedFailedDelivery(t, { nextRetryAt: Date.now() + 60_000 });
+
+    const result = await t.action(internal.webhookDeliveryWorker.processWebhookDeliveries, {});
+
+    expect(result).toEqual({ processed: 0, failed: 0, errors: [] });
+    const delivery = await t.run(async (ctx) => await ctx.db.get(deliveryId));
+    expect(delivery).toMatchObject({ status: 'failed', attemptCount: 1 });
+  });
+});

--- a/convex/webhookDeliveryWorker.ts
+++ b/convex/webhookDeliveryWorker.ts
@@ -73,9 +73,10 @@ export const processWebhookDeliveries = internalAction({
 
     for (const delivery of deliveries) {
       try {
-        await ctx.runMutation(internal.webhookDeliveries.markInProgress, {
+        const claimed = await ctx.runMutation(internal.webhookDeliveries.markInProgress, {
           deliveryId: delivery._id as any,
         });
+        if (!claimed) continue;
 
         const subscription = (await ctx.runQuery(internal.webhookSubscriptions.getByIdInternal, {
           subscriptionId: delivery.subscriptionId as any,


### PR DESCRIPTION
## Summary
- process failed webhook deliveries once their configured retry time has elapsed
- exclude deliveries at their maximum attempt cap from retry selection
- cover due retries, dead-letter exclusion, and not-yet-due failures with an action-level Convex regression

## Verification
- bun run lint
- bun run typecheck
- bun run test:external-integrations
- bun run test:convex
- bun run test:ci

## Notes
- No schema index or dependency change was required; the existing by_status_retry index covers due retry lookup.



## Follow-up
- Add a stale in_progress reaper. A delivery can remain claimed indefinitely if the worker fails after claiming it and before a terminal status is recorded.

