### PR TITLE
fix: enforce managed public API key ownership

### DIFF
--- a/apps/api/src/routes/publicV2/auth.test.ts
+++ b/apps/api/src/routes/publicV2/auth.test.ts
@@ -46,9 +46,11 @@ function makeRequest(headers: Record<string, string> = {}): Request {
 
 function validKeyResult(scopes: string[] = []) {
   return {
+    valid: true,
     key: {
       id: 'key_id_abc',
-      metadata: { authUserId: 'user_abc' },
+      userId: 'user_abc',
+      metadata: { kind: 'public-api', authUserId: 'user_abc' },
       permissions: { publicApi: scopes },
       expiresAt: null,
     },
@@ -116,9 +118,46 @@ describe('resolveAuth', () => {
 
     it('returns 401 when the key object has no authUserId in metadata', async () => {
       mutationImpl = async () => ({
+        valid: true,
         key: { id: 'key_id', metadata: {}, permissions: { publicApi: [] } },
       });
       const result = await resolveAuth(makeRequest({ 'x-api-key': VALID_API_KEY }), config, []);
+      expect((result as Response).status).toBe(401);
+    });
+
+    it('returns 401 when the key metadata owner differs from the stored key owner', async () => {
+      mutationImpl = async () => ({
+        valid: true,
+        key: {
+          id: 'key_id',
+          userId: 'attacker_user',
+          metadata: { kind: 'public-api', authUserId: 'victim_user' },
+          permissions: { publicApi: ['subjects:read'] },
+        },
+      });
+
+      const result = await resolveAuth(makeRequest({ 'x-api-key': VALID_API_KEY }), config, [
+        'subjects:read',
+      ]);
+
+      expect((result as Response).status).toBe(401);
+    });
+
+    it('returns 401 when the key is not a managed public API key', async () => {
+      mutationImpl = async () => ({
+        valid: true,
+        key: {
+          id: 'key_id',
+          userId: 'user_abc',
+          metadata: { kind: 'other-api', authUserId: 'user_abc' },
+          permissions: { publicApi: ['subjects:read'] },
+        },
+      });
+
+      const result = await resolveAuth(makeRequest({ 'x-api-key': VALID_API_KEY }), config, [
+        'subjects:read',
+      ]);
+
       expect((result as Response).status).toBe(401);
     });
 
@@ -167,9 +206,11 @@ describe('resolveAuth', () => {
 
     it('includes keyId and expiresAt in the returned AuthResult', async () => {
       mutationImpl = async () => ({
+        valid: true,
         key: {
           id: 'key_id_xyz',
-          metadata: { authUserId: 'user_abc' },
+          userId: 'user_abc',
+          metadata: { kind: 'public-api', authUserId: 'user_abc' },
           permissions: { publicApi: [] },
           expiresAt: 9_999_999_999,
         },

--- a/apps/api/src/routes/publicV2/auth.ts
+++ b/apps/api/src/routes/publicV2/auth.ts
@@ -95,20 +95,27 @@ export async function resolveAuth(
             key: apiKey,
           });
 
-      if (!result?.key) {
+      if (!result?.valid || !result.key) {
         return buildErrorResponse('unauthorized', 'Invalid or expired API key', 401);
       }
 
       const keyData = result.key as {
         id?: string;
+        userId?: string;
         metadata?: Record<string, unknown>;
         permissions?: Record<string, unknown>;
         expiresAt?: number | null;
       };
 
-      const authUserId = keyData.metadata?.authUserId as string | undefined;
-      if (!authUserId) {
-        return buildErrorResponse('unauthorized', 'API key has no associated user', 401);
+      const authUserId =
+        typeof keyData.metadata?.authUserId === 'string' ? keyData.metadata.authUserId : undefined;
+      if (
+        !authUserId ||
+        keyData.metadata?.kind !== 'public-api' ||
+        typeof keyData.userId !== 'string' ||
+        keyData.userId !== authUserId
+      ) {
+        return buildErrorResponse('unauthorized', 'Invalid or expired API key', 401);
       }
 
       const scopes = getPublicApiKeyScopes((keyData.permissions as Record<string, unknown>) ?? {});

--- a/convex/betterAuthApiKeys.realtest.ts
+++ b/convex/betterAuthApiKeys.realtest.ts
@@ -141,7 +141,52 @@ describe('betterAuthApiKeys', () => {
     });
   }, 10_000);
 
-  it('verifies legacy managed public API keys as the metadata tenant owner', async () => {
+  it('rejects a managed public API key when metadata names a different owner', async () => {
+    const t = makeTestConvex() as ComponentAwareTestConvex;
+    t.registerComponent('betterAuth', betterAuthSchema, import.meta.glob('./betterAuth/**/*.ts'));
+    const attackerAuthUserId = await seedBetterAuthUser(t, {
+      name: 'Attacker',
+      email: 'attacker@example.com',
+    });
+    const victimAuthUserId = await seedBetterAuthUser(t, {
+      name: 'Victim',
+      email: 'victim@example.com',
+    });
+
+    const created = await t.mutation(api.betterAuthApiKeys.createApiKey, {
+      apiSecret: API_SECRET,
+      userId: attackerAuthUserId,
+      authUserId: attackerAuthUserId,
+      name: 'Forged public API key',
+      scopes: ['verification:read'],
+      expiresIn: null,
+    });
+
+    await t.runInComponent('betterAuth', async (ctx) => {
+      const [storedKey] = await ctx.db.query('apikey').collect();
+      if (!storedKey || typeof storedKey._id !== 'string') {
+        throw new Error('Expected the managed public API key to be stored');
+      }
+
+      await ctx.db.patch(storedKey._id, {
+        metadata: JSON.stringify({
+          kind: 'public-api',
+          authUserId: victimAuthUserId,
+        }),
+      });
+    });
+
+    const verified = await t.mutation(api.betterAuthApiKeys.verifyApiKey, {
+      apiSecret: API_SECRET,
+      key: created.key,
+      scopes: ['verification:read'],
+    });
+
+    expect(verified.valid).toBe(false);
+    expect(verified.key).toBeNull();
+  }, 10_000);
+
+  it('rejects legacy managed public API keys whose stored owner differs from metadata', async () => {
     const t = makeTestConvex() as ComponentAwareTestConvex;
     t.registerComponent('betterAuth', betterAuthSchema, import.meta.glob('./betterAuth/**/*.ts'));
     const sessionOwnerUserId = await seedBetterAuthUser(t, {
@@ -188,11 +233,7 @@ describe('betterAuthApiKeys', () => {
       scopes: ['verification:read'],
     });
 
-    expect(verified.valid).toBe(true);
-    expect(verified.key?.userId).toBe(tenantAuthUserId);
-    expect(verified.key?.metadata).toEqual({
-      kind: 'public-api',
-      authUserId: tenantAuthUserId,
-    });
+    expect(verified.valid).toBe(false);
+    expect(verified.key).toBeNull();
   }, 10_000);
 });

--- a/convex/betterAuthApiKeys.ts
+++ b/convex/betterAuthApiKeys.ts
@@ -124,18 +124,9 @@ function serializeApiKeyRecord(value: SerializableApiKeyRecord | null) {
         }
       : null;
 
-  // Managed public keys are tenant-owned. Legacy rows retain the session owner
-  // in userId, so use the corroborating referenceId to recover the tenant
-  // without trusting metadata alone.
-  const ownerUserId =
-    metadata?.kind === PUBLIC_API_KEY_METADATA_KIND &&
-    value.referenceId === metadata.authUserId
-      ? metadata.authUserId
-      : value.userId;
-
   return {
     id,
-    userId: ownerUserId,
+    userId: value.userId,
     name: value.name,
     start: value.start,
     prefix: value.prefix,
@@ -273,15 +264,24 @@ interface BetterAuthServerApi {
   }>;
 }
 
+function isManagedPublicApiKey(
+  value: ReturnType<typeof serializeApiKeyRecord>
+): value is NonNullable<ReturnType<typeof serializeApiKeyRecord>> {
+  return (
+    value !== null &&
+    value.metadata?.kind === PUBLIC_API_KEY_METADATA_KIND &&
+    value.metadata.authUserId === value.userId
+  );
+}
+
 function isManagedPublicApiKeyForAuthUser(
   value: ReturnType<typeof serializeApiKeyRecord>,
   authUserId: string
 ): value is NonNullable<ReturnType<typeof serializeApiKeyRecord>> {
   return (
-    value !== null &&
+    isManagedPublicApiKey(value) &&
     value.id.length > 0 &&
-    value.metadata?.kind === PUBLIC_API_KEY_METADATA_KIND &&
-    value.metadata.authUserId === authUserId
+    value.metadata?.authUserId === authUserId
   );
 }
 
@@ -491,17 +491,23 @@ export const verifyApiKey = mutation({
             select: API_KEY_SERIALIZATION_SELECT,
           })) as SerializableApiKeyRecord | null)
         : null;
-    const serializedKey = serializeApiKeyRecord(stored ?? result.key);
+    const serializedKey = serializeApiKeyRecord(stored);
+    const valid = result.valid && isManagedPublicApiKey(serializedKey);
 
     return {
-      valid: result.valid && serializedKey !== null,
+      valid,
       error: result.error
         ? {
             code: result.error.code,
             message: result.error.message ?? null,
           }
-        : null,
-      key: serializedKey,
+        : valid
+          ? null
+          : {
+              code: 'invalid_api_key',
+              message: 'API key failed managed public key validation',
+            },
+      key: valid ? serializedKey : null,
     };
   },
 });

--- a/ops/production-regression-loop.ts
+++ b/ops/production-regression-loop.ts
@@ -65,14 +65,16 @@ export const PRODUCTION_REGRESSION_SURFACES: ProductionRegressionSurface[] = [
     id: 'identity',
     label: 'Identity and ownership boundaries',
     invariant:
-      'Buyer and creator identities must stay explicit at every helper, route, and persistence boundary so one actor can never materialize or mutate another actor’s state.',
+      'Buyer and creator identities must stay explicit at every helper, route, and persistence boundary so one actor can never materialize or mutate another actor’s state. Public API-key verification must authenticate only managed public-api records whose stored Better Auth owner matches the metadata auth user, so key metadata can never impersonate another tenant.',
     primaryRegressionHomes: [
       'apps/api/src/lib/subjectIdentity.test.ts',
       'apps/api/src/routes/providerPlatform.test.ts',
       'convex/identitySync.realtest.ts',
+      'convex/betterAuthApiKeys.realtest.ts',
     ],
     secondaryRegressionHomes: [
       'apps/api/src/verification/completeLicense.test.ts',
+      'apps/api/src/routes/publicV2/auth.test.ts',
       'convex/licenseVerification.realtest.ts',
     ],
     remediationHomes: [
@@ -152,6 +154,7 @@ export const EXTERNAL_INTEGRATION_GATE_STEPS: ExternalIntegrationGateStep[] = [
       'convex/vitest.config.ts',
       './convex/identitySync.realtest.ts',
       './convex/attestation.realtest.ts',
+      './convex/betterAuthApiKeys.realtest.ts',
     ],
     covers: ['identity', 'attestation'],
   },
@@ -213,6 +216,7 @@ export const EXTERNAL_INTEGRATION_GATE_STEPS: ExternalIntegrationGateStep[] = [
       './src/verification/completeLicense.test.ts',
       './src/verification/sessionManager.accountLink.test.ts',
       './src/routes/suite.test.ts',
+      './src/routes/publicV2/auth.test.ts',
     ],
     covers: ['identity', 'verification', 'account', 'backfill'],
   },


### PR DESCRIPTION
## Summary
- require public API-key verification to use a stored managed `public-api` record whose actual Better Auth owner matches `metadata.authUserId`
- reject invalid managed-key records again at the public V2 authentication boundary
- add source, consumer, and production-regression-loop coverage for tenant impersonation attempts

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run test:external-integrations`
- `bun run test:convex -- --maxWorkers=1 --no-file-parallelism --testTimeout=30000`
- `bun run test:api:integration`
- `bun run test:ci` with serial Vitest workers

`bun audit` remains blocked by the existing moderate `@better-auth/oauth-provider` advisory; no dependency changes were made.