### PR TITLE
fix(api): correct public v2 actor and pagination handling

### DIFF
--- a/apps/api/src/routes/publicV2/actor-binding.contract.test.ts
+++ b/apps/api/src/routes/publicV2/actor-binding.contract.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'bun:test';
+
+const protectedRouteModules = [
+  'audit-log',
+  'bindings',
+  'collaborators',
+  'connections',
+  'downloads',
+  'entitlements',
+  'events',
+  'guilds',
+  'manual-licenses',
+  'me',
+  'products',
+  'role-rules',
+  'settings',
+  'subjects',
+  'transactions',
+  'verification',
+  'verification-sessions',
+  'webhooks',
+] as const;
+
+describe('publicV2 protected route actor binding contract', () => {
+  for (const moduleName of protectedRouteModules) {
+    it(`${moduleName} creates its Convex client with the caller actor binding`, async () => {
+      const source = await Bun.file(new URL(`./${moduleName}.ts`, import.meta.url)).text();
+
+      expect(source).not.toContain('getConvexClientFromUrl(config.convexUrl);');
+      expect(source).toContain('getConvexClientFromUrl(config.convexUrl, auth.actorBinding)');
+    });
+  }
+});

--- a/apps/api/src/routes/publicV2/actor-binding.contract.test.ts
+++ b/apps/api/src/routes/publicV2/actor-binding.contract.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'bun:test';
 
+const convexClientConstructionPattern = /\bgetConvexClientFromUrl\s*\(/g;
+const actorBoundConvexClientConstructionPattern =
+  /\bgetConvexClientFromUrl\s*\(\s*config\.convexUrl\s*,\s*auth\.actorBinding\s*\)/g;
+
 const protectedRouteModules = [
   'audit-log',
   'bindings',
@@ -17,6 +21,7 @@ const protectedRouteModules = [
   'subjects',
   'transactions',
   'verification',
+  'verification-intents',
   'verification-sessions',
   'webhooks',
 ] as const;
@@ -25,9 +30,13 @@ describe('publicV2 protected route actor binding contract', () => {
   for (const moduleName of protectedRouteModules) {
     it(`${moduleName} creates its Convex client with the caller actor binding`, async () => {
       const source = await Bun.file(new URL(`./${moduleName}.ts`, import.meta.url)).text();
+      const clientConstructionCount = (source.match(convexClientConstructionPattern) ?? []).length;
+      const actorBoundClientConstructionCount = (
+        source.match(actorBoundConvexClientConstructionPattern) ?? []
+      ).length;
 
-      expect(source).not.toContain('getConvexClientFromUrl(config.convexUrl);');
-      expect(source).toContain('getConvexClientFromUrl(config.convexUrl, auth.actorBinding)');
+      expect(clientConstructionCount).toBeGreaterThan(0);
+      expect(actorBoundClientConstructionCount).toBe(clientConstructionCount);
     });
   }
 });

--- a/apps/api/src/routes/publicV2/audit-log.ts
+++ b/apps/api/src/routes/publicV2/audit-log.ts
@@ -18,7 +18,6 @@ export async function handleAuditLogRoutes(
 ): Promise<Response> {
   const reqId = generateRequestId();
   const url = new URL(request.url);
-  const convex = getConvexClientFromUrl(config.convexUrl);
 
   if (subPath !== '/audit-log') {
     return errorResponse('not_found', 'Route not found', 404, reqId);
@@ -30,6 +29,7 @@ export async function handleAuditLogRoutes(
 
   const auth = await resolveAuth(request, config, ['audit-log:read'], reqId);
   if (auth instanceof Response) return auth;
+  const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
   const { limit, cursor } = parsePagination(url);
   const type = url.searchParams.get('type') ?? undefined;

--- a/apps/api/src/routes/publicV2/bindings.ts
+++ b/apps/api/src/routes/publicV2/bindings.ts
@@ -19,7 +19,6 @@ export async function handleBindingsRoutes(
 ): Promise<Response> {
   const reqId = generateRequestId();
   const url = new URL(request.url);
-  const convex = getConvexClientFromUrl(config.convexUrl);
 
   if (subPath === '/bindings') {
     if (request.method !== 'GET') {
@@ -27,6 +26,7 @@ export async function handleBindingsRoutes(
     }
     const auth = await resolveAuth(request, config, ['subjects:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const { limit, cursor } = parsePagination(url);
     const subjectId = url.searchParams.get('subject_id') ?? undefined;
@@ -58,6 +58,7 @@ export async function handleBindingsRoutes(
     }
     const auth = await resolveAuth(request, config, ['subjects:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const bindingId = idMatch[1];
     try {

--- a/apps/api/src/routes/publicV2/collaborators.ts
+++ b/apps/api/src/routes/publicV2/collaborators.ts
@@ -19,7 +19,6 @@ export async function handleCollaboratorsRoutes(
 ): Promise<Response> {
   const reqId = generateRequestId();
   const url = new URL(request.url);
-  const convex = getConvexClientFromUrl(config.convexUrl);
 
   if (subPath === '/collaborators') {
     if (request.method !== 'GET') {
@@ -27,6 +26,7 @@ export async function handleCollaboratorsRoutes(
     }
     const auth = await resolveAuth(request, config, ['collaborators:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const { limit, cursor } = parsePagination(url);
     const provider = url.searchParams.get('provider') ?? undefined;
@@ -56,6 +56,7 @@ export async function handleCollaboratorsRoutes(
     }
     const auth = await resolveAuth(request, config, ['collaborators:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const connectionId = idMatch[1];
     try {

--- a/apps/api/src/routes/publicV2/connections.ts
+++ b/apps/api/src/routes/publicV2/connections.ts
@@ -19,7 +19,6 @@ export async function handleConnectionsRoutes(
 ): Promise<Response> {
   const reqId = generateRequestId();
   const url = new URL(request.url);
-  const convex = getConvexClientFromUrl(config.convexUrl);
 
   if (subPath === '/connections') {
     if (request.method !== 'GET') {
@@ -27,6 +26,7 @@ export async function handleConnectionsRoutes(
     }
     const auth = await resolveAuth(request, config, ['connections:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const { limit, cursor } = parsePagination(url);
     const provider = url.searchParams.get('provider') ?? undefined;
@@ -56,6 +56,7 @@ export async function handleConnectionsRoutes(
     }
     const auth = await resolveAuth(request, config, ['connections:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const connectionId = idMatch[1];
     try {

--- a/apps/api/src/routes/publicV2/downloads.ts
+++ b/apps/api/src/routes/publicV2/downloads.ts
@@ -19,7 +19,6 @@ export async function handleDownloadsRoutes(
 ): Promise<Response> {
   const reqId = generateRequestId();
   const url = new URL(request.url);
-  const convex = getConvexClientFromUrl(config.convexUrl);
 
   // --- Download Routes ---
 
@@ -29,6 +28,7 @@ export async function handleDownloadsRoutes(
     }
     const auth = await resolveAuth(request, config, ['downloads:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const { limit, cursor } = parsePagination(url);
     const guildId = url.searchParams.get('guild_id') ?? undefined;
@@ -59,6 +59,7 @@ export async function handleDownloadsRoutes(
     }
     const auth = await resolveAuth(request, config, ['downloads:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const routeId = routeIdMatch[1];
     try {
@@ -90,6 +91,7 @@ export async function handleDownloadsRoutes(
     }
     const auth = await resolveAuth(request, config, ['downloads:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const { limit, cursor } = parsePagination(url);
     const routeId = url.searchParams.get('route_id') ?? undefined;
@@ -121,6 +123,7 @@ export async function handleDownloadsRoutes(
     }
     const auth = await resolveAuth(request, config, ['downloads:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const artifactId = artifactIdMatch[1];
     try {

--- a/apps/api/src/routes/publicV2/entitlements.ts
+++ b/apps/api/src/routes/publicV2/entitlements.ts
@@ -19,7 +19,6 @@ export async function handleEntitlementsRoutes(
 ): Promise<Response> {
   const reqId = generateRequestId();
   const url = new URL(request.url);
-  const convex = getConvexClientFromUrl(config.convexUrl);
 
   // GET /entitlements
   if (subPath === '/entitlements') {
@@ -28,6 +27,7 @@ export async function handleEntitlementsRoutes(
     }
     const auth = await resolveAuth(request, config, ['entitlements:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const { limit, cursor } = parsePagination(url);
     const subjectId = url.searchParams.get('subject_id') ?? undefined;
@@ -62,6 +62,7 @@ export async function handleEntitlementsRoutes(
     }
     const auth = await resolveAuth(request, config, ['entitlements:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const entitlementId = idMatch[1];
     try {

--- a/apps/api/src/routes/publicV2/events.ts
+++ b/apps/api/src/routes/publicV2/events.ts
@@ -19,7 +19,6 @@ export async function handleEventsRoutes(
 ): Promise<Response> {
   const reqId = generateRequestId();
   const url = new URL(request.url);
-  const convex = getConvexClientFromUrl(config.convexUrl);
 
   if (subPath === '/events') {
     if (request.method !== 'GET') {
@@ -27,11 +26,11 @@ export async function handleEventsRoutes(
     }
     const auth = await resolveAuth(request, config, ['events:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const { limit, cursor } = parsePagination(url);
     const eventType = url.searchParams.get('type') ?? undefined;
     const resourceId = url.searchParams.get('resource_id') ?? undefined;
-    const resourceType = url.searchParams.get('resource_type') ?? undefined;
 
     try {
       const result = await convex.query(api.creatorEvents.listByAuthUser, {
@@ -39,7 +38,6 @@ export async function handleEventsRoutes(
         authUserId: auth.authUserId,
         eventType,
         resourceId,
-        resourceType,
         cursor,
         limit,
       });
@@ -58,6 +56,7 @@ export async function handleEventsRoutes(
     }
     const auth = await resolveAuth(request, config, ['events:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const eventId = idMatch[1];
     try {

--- a/apps/api/src/routes/publicV2/guilds.ts
+++ b/apps/api/src/routes/publicV2/guilds.ts
@@ -19,7 +19,6 @@ export async function handleGuildsRoutes(
 ): Promise<Response> {
   const reqId = generateRequestId();
   const url = new URL(request.url);
-  const convex = getConvexClientFromUrl(config.convexUrl);
 
   // GET /guilds/:id/role-rules
   const rrMatch = subPath.match(/^\/guilds\/([^/]+)\/role-rules$/);
@@ -29,6 +28,7 @@ export async function handleGuildsRoutes(
     }
     const auth = await resolveAuth(request, config, ['guilds:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     try {
       const result = await convex.query(api.role_rules.listByAuthUser, {
@@ -52,6 +52,7 @@ export async function handleGuildsRoutes(
     }
     const auth = await resolveAuth(request, config, ['guilds:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const { limit, cursor } = parsePagination(url);
     try {
@@ -77,6 +78,7 @@ export async function handleGuildsRoutes(
     }
     const auth = await resolveAuth(request, config, ['guilds:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const status = url.searchParams.get('status') ?? undefined;
 
@@ -102,6 +104,7 @@ export async function handleGuildsRoutes(
     }
     const auth = await resolveAuth(request, config, ['guilds:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const guildId = idMatch[1];
     try {

--- a/apps/api/src/routes/publicV2/helpers.test.ts
+++ b/apps/api/src/routes/publicV2/helpers.test.ts
@@ -197,6 +197,18 @@ describe('extractListData', () => {
     expect(result).toEqual({ data, hasMore: false, nextCursor: null });
   });
 
+  it('handles keyed Convex event results with nextCursor', () => {
+    const events = [{ _id: 'event_1' }];
+    const result = extractListData({ events, hasMore: true, nextCursor: 'event_1' });
+    expect(result).toEqual({ data: events, hasMore: true, nextCursor: 'event_1' });
+  });
+
+  it('handles keyed Convex delivery results with nextCursor', () => {
+    const deliveries = [{ _id: 'delivery_1' }];
+    const result = extractListData({ deliveries, hasMore: true, nextCursor: 'delivery_1' });
+    expect(result).toEqual({ data: deliveries, hasMore: true, nextCursor: 'delivery_1' });
+  });
+
   it('returns empty result for null input', () => {
     expect(extractListData(null)).toEqual({ data: [], hasMore: false, nextCursor: null });
   });

--- a/apps/api/src/routes/publicV2/helpers.ts
+++ b/apps/api/src/routes/publicV2/helpers.ts
@@ -82,14 +82,20 @@ export function extractListData(result: unknown): {
       ? r.items
       : Array.isArray(r.data)
         ? r.data
-        : [];
+        : Array.isArray(r.events)
+          ? r.events
+          : Array.isArray(r.deliveries)
+            ? r.deliveries
+            : [];
   const hasMore =
     typeof r.isDone === 'boolean' ? !r.isDone : typeof r.hasMore === 'boolean' ? r.hasMore : false;
   const nextCursor =
-    typeof r.continueCursor === 'string'
-      ? r.continueCursor
-      : typeof r.cursor === 'string'
-        ? r.cursor
-        : null;
+    typeof r.nextCursor === 'string'
+      ? r.nextCursor
+      : typeof r.continueCursor === 'string'
+        ? r.continueCursor
+        : typeof r.cursor === 'string'
+          ? r.cursor
+          : null;
   return { data, hasMore, nextCursor };
 }

--- a/apps/api/src/routes/publicV2/manual-licenses.test.ts
+++ b/apps/api/src/routes/publicV2/manual-licenses.test.ts
@@ -4,19 +4,32 @@ const apiMock = {
   manualLicenses: {
     create: 'manualLicenses.create',
     bulkCreate: 'manualLicenses.bulkCreate',
+    listByTenant: 'manualLicenses.listByTenant',
+  },
+  subjects: {
+    resolveSubjectForPublicApi: 'subjects.resolveSubjectForPublicApi',
+  },
+  entitlements: {
+    getEntitlementsBySubject: 'entitlements.getEntitlementsBySubject',
   },
 } as const;
 
 let mutationImpl: (fn: unknown, args: unknown) => Promise<unknown>;
+let queryImpl: (fn: unknown, args: unknown) => Promise<unknown>;
 
 const mutationMock = mock((fn: unknown, args: unknown) => mutationImpl(fn, args));
+const queryMock = mock((fn: unknown, args: unknown) => queryImpl(fn, args));
+const convexFactoryCalls: unknown[][] = [];
 
 mock.module('../../../../../convex/_generated/api', () => ({
   api: apiMock,
 }));
 
 mock.module('../../lib/convex', () => ({
-  getConvexClientFromUrl: () => ({ mutation: mutationMock }),
+  getConvexClientFromUrl: (...args: unknown[]) => {
+    convexFactoryCalls.push(args);
+    return { mutation: mutationMock, query: queryMock };
+  },
 }));
 
 mock.module('./auth', () => ({
@@ -31,6 +44,8 @@ mock.module('./auth', () => ({
 }));
 
 const { handleManualLicensesRoutes } = await import('./manual-licenses');
+const { handleSubjectsRoutes } = await import('./subjects');
+const { handleVerificationRoutes } = await import('./verification');
 
 const config = {
   apiBaseUrl: 'https://api.test',
@@ -55,12 +70,20 @@ function makeRequest(method: string, subPath: string, body?: unknown): Request {
 
 beforeEach(() => {
   mutationMock.mockClear();
+  queryMock.mockClear();
+  convexFactoryCalls.length = 0;
   mutationImpl = async (fn) => {
     if (fn === apiMock.manualLicenses.create) return { licenseId: 'license_001' };
     if (fn === apiMock.manualLicenses.bulkCreate) {
       return { created: 1, licenseIds: ['license_001'] };
     }
     throw new Error(`Unhandled mutation: ${String(fn)}`);
+  };
+  queryImpl = async (fn) => {
+    if (fn === apiMock.manualLicenses.listByTenant) {
+      return { data: [{ _id: 'license_001' }], hasMore: true, nextCursor: 'license_001' };
+    }
+    throw new Error(`Unhandled query: ${String(fn)}`);
   };
 });
 
@@ -111,6 +134,46 @@ describe('hashKey (SHA-256 hex)', () => {
 });
 
 describe('handleManualLicensesRoutes', () => {
+  it('GET /manual-licenses passes list pagination through the caller-bound Convex client', async () => {
+    const res = await handleManualLicensesRoutes(
+      new Request(
+        'http://localhost/api/public/v2/manual-licenses?limit=1&starting_after=license_000',
+        {
+          headers: { authorization: 'Bearer test-token' },
+        }
+      ),
+      '/manual-licenses',
+      config
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      data: [{ _id: 'license_001' }],
+      hasMore: true,
+      nextCursor: 'license_001',
+    });
+    expect(queryMock.mock.calls[0]).toEqual([
+      apiMock.manualLicenses.listByTenant,
+      {
+        apiSecret: 'test-secret',
+        authUserId: 'user_abc',
+        productId: undefined,
+        status: undefined,
+        cursor: 'license_000',
+        limit: 1,
+      },
+    ]);
+    expect(convexFactoryCalls).toEqual([
+      [
+        config.convexUrl,
+        {
+          payload: 'test-payload',
+          signature: 'test-signature',
+        },
+      ],
+    ]);
+  });
+
   it('POST /manual-licenses sends canonical licenseKeyHash to Convex create', async () => {
     const res = await handleManualLicensesRoutes(
       makeRequest('POST', '/manual-licenses', {
@@ -199,5 +262,76 @@ describe('handleManualLicensesRoutes', () => {
 
     expect(res.status).toBe(400);
     expect(mutationMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('public subject resolution', () => {
+  it('returns 404 when the subject resolver reports found:false', async () => {
+    queryImpl = async () => ({ found: false, subject: null });
+
+    const response = await handleSubjectsRoutes(
+      makeRequest('GET', '/subjects/subject_missing'),
+      '/subjects/subject_missing',
+      config
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('returns the resolved subject rather than the resolver wrapper', async () => {
+    const subject = { _id: 'subject_123', displayName: 'Test subject' };
+    queryImpl = async () => ({ found: true, subject });
+
+    const response = await handleSubjectsRoutes(
+      makeRequest('GET', '/subjects/subject_123'),
+      '/subjects/subject_123',
+      config
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(subject);
+  });
+
+  it('treats found:false as an absent verification-status subject', async () => {
+    queryImpl = async () => ({ found: false, subject: null });
+
+    const response = await handleVerificationRoutes(
+      makeRequest('GET', '/verification/status'),
+      '/verification/status',
+      config
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      object: 'verification_status',
+      subject: null,
+      entitlements: [],
+    });
+    expect(queryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the unwrapped subject for verification checks', async () => {
+    const subject = { _id: 'subject_123', displayName: 'Test subject' };
+    queryImpl = async (fn) => {
+      if (fn === apiMock.subjects.resolveSubjectForPublicApi) {
+        return { found: true, subject };
+      }
+      return [{ productId: 'product_123', status: 'active' }];
+    };
+
+    const response = await handleVerificationRoutes(
+      makeRequest('POST', '/verification/check', {
+        subject: { subjectId: 'subject_123' },
+        productIds: ['product_123'],
+      }),
+      '/verification/check',
+      config
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      subject,
+      results: [{ productId: 'product_123', entitled: true }],
+    });
   });
 });

--- a/apps/api/src/routes/publicV2/manual-licenses.ts
+++ b/apps/api/src/routes/publicV2/manual-licenses.ts
@@ -42,7 +42,6 @@ export async function handleManualLicensesRoutes(
 ): Promise<Response> {
   const reqId = generateRequestId();
   const url = new URL(request.url);
-  const convex = getConvexClientFromUrl(config.convexUrl);
 
   // POST /manual-licenses/bulk, must check before /:id
   if (subPath === '/manual-licenses/bulk') {
@@ -51,6 +50,7 @@ export async function handleManualLicensesRoutes(
     }
     const auth = await resolveAuth(request, config, ['licenses:manage'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     let body: Record<string, unknown>;
     try {
@@ -118,6 +118,7 @@ export async function handleManualLicensesRoutes(
     }
     const auth = await resolveAuth(request, config, ['licenses:manage'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     let body: Record<string, unknown>;
     try {
@@ -149,6 +150,7 @@ export async function handleManualLicensesRoutes(
   if (subPath === '/manual-licenses/stats' && request.method === 'GET') {
     const auth = await resolveAuth(request, config, ['licenses:manage'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     try {
       const result = await convex.query(api.manualLicenses.getStats, {
@@ -170,6 +172,7 @@ export async function handleManualLicensesRoutes(
     }
     const auth = await resolveAuth(request, config, ['licenses:manage'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const licenseId = revokeMatch[1];
     let body: Record<string, unknown> = {};
@@ -198,6 +201,7 @@ export async function handleManualLicensesRoutes(
     if (request.method === 'GET') {
       const auth = await resolveAuth(request, config, ['licenses:manage'], reqId);
       if (auth instanceof Response) return auth;
+      const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
       const { limit, cursor } = parsePagination(url);
       const productId = url.searchParams.get('product_id') ?? undefined;
@@ -223,6 +227,7 @@ export async function handleManualLicensesRoutes(
     if (request.method === 'POST') {
       const auth = await resolveAuth(request, config, ['licenses:manage'], reqId);
       if (auth instanceof Response) return auth;
+      const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
       let body: Record<string, unknown>;
       try {
@@ -268,6 +273,7 @@ export async function handleManualLicensesRoutes(
     }
     const auth = await resolveAuth(request, config, ['licenses:manage'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const licenseId = idMatch[1];
     try {

--- a/apps/api/src/routes/publicV2/me.ts
+++ b/apps/api/src/routes/publicV2/me.ts
@@ -41,7 +41,7 @@ export async function handleMeRoutes(
     const auth = await resolveAuth(request, config, ['profile:read'], reqId);
     if (auth instanceof Response) return auth;
 
-    const convex = getConvexClientFromUrl(config.convexUrl);
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
     try {
       const viewer = await convex.query(api.authViewer.getViewerByAuthUser, {
         apiSecret: config.convexApiSecret,

--- a/apps/api/src/routes/publicV2/products.ts
+++ b/apps/api/src/routes/publicV2/products.ts
@@ -20,7 +20,6 @@ export async function handleProductsRoutes(
 ): Promise<Response> {
   const reqId = generateRequestId();
   const url = new URL(request.url);
-  const convex = getConvexClientFromUrl(config.convexUrl);
   const timing = new RouteTimingCollector();
   const respond = (
     buildResponse: () => Response,
@@ -35,6 +34,7 @@ export async function handleProductsRoutes(
     }
     const auth = await resolveAuth(request, config, ['products:read'], reqId, timing);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const { limit, cursor } = parsePagination(url);
     try {
@@ -68,6 +68,7 @@ export async function handleProductsRoutes(
     }
     const auth = await resolveAuth(request, config, ['products:read'], reqId, timing);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     try {
       const result = await timing.measure(
@@ -97,6 +98,7 @@ export async function handleProductsRoutes(
     }
     const auth = await resolveAuth(request, config, ['products:read'], reqId, timing);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const { limit, cursor } = parsePagination(url);
     const provider = url.searchParams.get('provider') ?? undefined;
@@ -134,6 +136,7 @@ export async function handleProductsRoutes(
     }
     const auth = await resolveAuth(request, config, ['products:read'], reqId, timing);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const catalogProductId = idMatch[1];
     try {

--- a/apps/api/src/routes/publicV2/role-rules.ts
+++ b/apps/api/src/routes/publicV2/role-rules.ts
@@ -18,7 +18,6 @@ export async function handleRoleRulesRoutes(
 ): Promise<Response> {
   const reqId = generateRequestId();
   const url = new URL(request.url);
-  const convex = getConvexClientFromUrl(config.convexUrl);
 
   if (subPath === '/role-rules') {
     if (request.method !== 'GET') {
@@ -26,6 +25,7 @@ export async function handleRoleRulesRoutes(
     }
     const auth = await resolveAuth(request, config, ['guilds:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const guildId = url.searchParams.get('guild_id') ?? undefined;
     const productId = url.searchParams.get('product_id') ?? undefined;
@@ -55,6 +55,7 @@ export async function handleRoleRulesRoutes(
     }
     const auth = await resolveAuth(request, config, ['guilds:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const ruleId = idMatch[1];
     try {

--- a/apps/api/src/routes/publicV2/settings.ts
+++ b/apps/api/src/routes/publicV2/settings.ts
@@ -11,7 +11,6 @@ export async function handleSettingsRoutes(
   config: PublicV2Config
 ): Promise<Response> {
   const reqId = generateRequestId();
-  const convex = getConvexClientFromUrl(config.convexUrl);
 
   if (subPath !== '/settings') {
     return errorResponse('not_found', 'Route not found', 404, reqId);
@@ -20,6 +19,7 @@ export async function handleSettingsRoutes(
   if (request.method === 'GET') {
     const auth = await resolveAuth(request, config, ['settings:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     try {
       const result = await convex.query(api.creatorProfiles.getByAuthUser, {
@@ -39,6 +39,7 @@ export async function handleSettingsRoutes(
   if (request.method === 'PATCH') {
     const auth = await resolveAuth(request, config, ['settings:write'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     let body: Record<string, unknown>;
     try {

--- a/apps/api/src/routes/publicV2/subjects.ts
+++ b/apps/api/src/routes/publicV2/subjects.ts
@@ -19,7 +19,6 @@ export async function handleSubjectsRoutes(
 ): Promise<Response> {
   const reqId = generateRequestId();
   const url = new URL(request.url);
-  const convex = getConvexClientFromUrl(config.convexUrl);
 
   // GET /subjects
   if (subPath === '/subjects') {
@@ -28,6 +27,7 @@ export async function handleSubjectsRoutes(
     }
     const auth = await resolveAuth(request, config, ['subjects:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const { limit, cursor } = parsePagination(url);
     const status = url.searchParams.get('status') ?? undefined;
@@ -58,6 +58,7 @@ export async function handleSubjectsRoutes(
     }
     const auth = await resolveAuth(request, config, ['subjects:read', 'entitlements:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const { limit, cursor } = parsePagination(url);
     try {
@@ -84,6 +85,7 @@ export async function handleSubjectsRoutes(
     }
     const auth = await resolveAuth(request, config, ['subjects:read', 'transactions:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const { limit, cursor } = parsePagination(url);
     try {
@@ -112,6 +114,7 @@ export async function handleSubjectsRoutes(
     }
     const auth = await resolveAuth(request, config, ['subjects:read', 'transactions:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const { limit, cursor } = parsePagination(url);
     try {
@@ -140,6 +143,7 @@ export async function handleSubjectsRoutes(
     }
     const auth = await resolveAuth(request, config, ['subjects:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const { limit, cursor } = parsePagination(url);
     try {
@@ -166,6 +170,7 @@ export async function handleSubjectsRoutes(
     }
     const auth = await resolveAuth(request, config, ['subjects:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const subjectId = idMatch[1];
     try {
@@ -174,10 +179,10 @@ export async function handleSubjectsRoutes(
         authUserId: auth.authUserId,
         selector: { subjectId },
       });
-      if (!result) {
+      if (!result.found) {
         return errorResponse('not_found', `Subject with ID ${subjectId} was not found`, 404, reqId);
       }
-      return jsonResponse(result, 200, reqId);
+      return jsonResponse(result.subject, 200, reqId);
     } catch (err) {
       logger.error('subjects.resolveSubjectForPublicApi failed', { error: String(err) });
       return errorResponse('internal_error', 'An internal error occurred', 500, reqId);

--- a/apps/api/src/routes/publicV2/transactions.ts
+++ b/apps/api/src/routes/publicV2/transactions.ts
@@ -19,7 +19,6 @@ export async function handleTransactionRoutes(
 ): Promise<Response> {
   const reqId = generateRequestId();
   const url = new URL(request.url);
-  const convex = getConvexClientFromUrl(config.convexUrl);
 
   // --- Transactions ---
 
@@ -29,6 +28,7 @@ export async function handleTransactionRoutes(
     }
     const auth = await resolveAuth(request, config, ['transactions:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const { limit, cursor } = parsePagination(url);
     const provider = url.searchParams.get('provider') ?? undefined;
@@ -60,6 +60,7 @@ export async function handleTransactionRoutes(
     }
     const auth = await resolveAuth(request, config, ['transactions:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const transactionId = txIdMatch[1];
     try {
@@ -91,6 +92,7 @@ export async function handleTransactionRoutes(
     }
     const auth = await resolveAuth(request, config, ['transactions:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const { limit, cursor } = parsePagination(url);
     const provider = url.searchParams.get('provider') ?? undefined;
@@ -122,6 +124,7 @@ export async function handleTransactionRoutes(
     }
     const auth = await resolveAuth(request, config, ['transactions:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const membershipId = memIdMatch[1];
     try {
@@ -153,6 +156,7 @@ export async function handleTransactionRoutes(
     }
     const auth = await resolveAuth(request, config, ['transactions:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const { limit, cursor } = parsePagination(url);
     const provider = url.searchParams.get('provider') ?? undefined;
@@ -186,6 +190,7 @@ export async function handleTransactionRoutes(
     }
     const auth = await resolveAuth(request, config, ['transactions:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const licenseId = licIdMatch[1];
     try {

--- a/apps/api/src/routes/publicV2/verification-sessions.ts
+++ b/apps/api/src/routes/publicV2/verification-sessions.ts
@@ -19,7 +19,6 @@ export async function handleVerificationSessionsRoutes(
 ): Promise<Response> {
   const reqId = generateRequestId();
   const url = new URL(request.url);
-  const convex = getConvexClientFromUrl(config.convexUrl);
 
   if (subPath === '/verification-sessions') {
     if (request.method !== 'GET') {
@@ -27,6 +26,7 @@ export async function handleVerificationSessionsRoutes(
     }
     const auth = await resolveAuth(request, config, ['verification:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const { limit, cursor } = parsePagination(url);
     const subjectId = url.searchParams.get('subject_id') ?? undefined;
@@ -58,6 +58,7 @@ export async function handleVerificationSessionsRoutes(
     }
     const auth = await resolveAuth(request, config, ['verification:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const sessionId = idMatch[1];
     try {

--- a/apps/api/src/routes/publicV2/verification.ts
+++ b/apps/api/src/routes/publicV2/verification.ts
@@ -11,7 +11,6 @@ export async function handleVerificationRoutes(
   config: PublicV2Config
 ): Promise<Response> {
   const reqId = generateRequestId();
-  const convex = getConvexClientFromUrl(config.convexUrl);
 
   // GET /verification/status, returns the caller's own entitlements
   if (subPath === '/verification/status') {
@@ -20,15 +19,16 @@ export async function handleVerificationRoutes(
     }
     const auth = await resolveAuth(request, config, ['verification:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     try {
-      const subject = await convex.query(api.subjects.resolveSubjectForPublicApi, {
+      const subjectResult = await convex.query(api.subjects.resolveSubjectForPublicApi, {
         apiSecret: config.convexApiSecret,
         authUserId: auth.authUserId,
         selector: { authUserId: auth.authUserId },
       });
 
-      if (!subject) {
+      if (!subjectResult.found) {
         return jsonResponse(
           {
             object: 'verification_status',
@@ -40,6 +40,8 @@ export async function handleVerificationRoutes(
           reqId
         );
       }
+
+      const subject = subjectResult.subject;
 
       const entResult = await convex.query(api.entitlements.getEntitlementsBySubject, {
         apiSecret: config.convexApiSecret,
@@ -72,6 +74,7 @@ export async function handleVerificationRoutes(
     }
     const auth = await resolveAuth(request, config, ['verification:read'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     let body: Record<string, unknown>;
     try {
@@ -88,13 +91,13 @@ export async function handleVerificationRoutes(
     }
 
     try {
-      const subject = await convex.query(api.subjects.resolveSubjectForPublicApi, {
+      const subjectResult = await convex.query(api.subjects.resolveSubjectForPublicApi, {
         apiSecret: config.convexApiSecret,
         authUserId: auth.authUserId,
         selector: body.subject as Record<string, unknown>,
       });
 
-      if (!subject) {
+      if (!subjectResult.found) {
         return jsonResponse(
           {
             object: 'verification_check',
@@ -109,6 +112,8 @@ export async function handleVerificationRoutes(
           reqId
         );
       }
+
+      const subject = subjectResult.subject;
 
       const subjectId = (subject as Record<string, unknown>)._id as string;
       const entResult = await convex.query(api.entitlements.getEntitlementsBySubject, {

--- a/apps/api/src/routes/publicV2/webhooks.test.ts
+++ b/apps/api/src/routes/publicV2/webhooks.test.ts
@@ -17,6 +17,8 @@ const apiMock = {
   },
   creatorEvents: {
     emitEvent: 'creatorEvents.emitEvent',
+    listByAuthUser: 'creatorEvents.listByAuthUser',
+    getById: 'creatorEvents.getById',
   },
 } as const;
 
@@ -26,6 +28,7 @@ let mutationImpl: (fn: unknown, args: unknown) => Promise<unknown>;
 const queryMock = mock((fn: unknown, args: unknown) => queryImpl(fn, args));
 const mutationMock = mock((fn: unknown, args: unknown) => mutationImpl(fn, args));
 const loggerErrorMock = mock(() => undefined);
+const convexFactoryCalls: unknown[][] = [];
 
 mock.module('../../../../../convex/_generated/api', () => ({
   api: apiMock,
@@ -34,7 +37,10 @@ mock.module('../../../../../convex/_generated/api', () => ({
 }));
 
 mock.module('../../lib/convex', () => ({
-  getConvexClientFromUrl: () => ({ query: queryMock, mutation: mutationMock }),
+  getConvexClientFromUrl: (...args: unknown[]) => {
+    convexFactoryCalls.push(args);
+    return { query: queryMock, mutation: mutationMock };
+  },
 }));
 
 mock.module('../../lib/logger', () => ({
@@ -47,7 +53,16 @@ mock.module('../../lib/encrypt', () => ({
   encrypt: async (plaintext: string) => `encrypted_${plaintext}`,
 }));
 
+mock.module('./auth', () => ({
+  resolveAuth: async () => ({
+    authUserId: 'user_abc',
+    actorBinding: { payload: 'test-payload', signature: 'test-signature' },
+    scopes: ['events:read'],
+  }),
+}));
+
 const { handleWebhooksRoutes } = await import('./webhooks');
+const { handleEventsRoutes } = await import('./events');
 
 const mockResolveAuth = async (): Promise<AuthResult> => ({
   authUserId: 'user_abc',
@@ -105,6 +120,7 @@ beforeEach(() => {
   queryMock.mockClear();
   mutationMock.mockClear();
   loggerErrorMock.mockClear();
+  convexFactoryCalls.length = 0;
 
   queryImpl = async (fn) => {
     if (fn === apiMock.webhookSubscriptions.list) return [];
@@ -365,6 +381,75 @@ describe('handleWebhooksRoutes', () => {
           (call) => call[0] === apiMock.webhookSubscriptions.deleteSubscription
         )
       ).toBe(true);
+    });
+  });
+
+  describe('GET /webhooks/:id/deliveries', () => {
+    it('returns keyed deliveries with the Convex nextCursor', async () => {
+      queryImpl = async (fn) => {
+        if (fn === apiMock.webhookDeliveries.listBySubscription) {
+          return {
+            deliveries: [{ _id: 'delivery_001', status: 'delivered' }],
+            hasMore: true,
+            nextCursor: 'delivery_001',
+          };
+        }
+        throw new Error(`Unhandled query: ${String(fn)}`);
+      };
+
+      const res = await routes(
+        makeRequest('GET', '/webhooks/wh_001/deliveries?limit=1'),
+        '/webhooks/wh_001/deliveries'
+      );
+
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toMatchObject({
+        data: [{ _id: 'delivery_001', status: 'delivered' }],
+        hasMore: true,
+        nextCursor: 'delivery_001',
+      });
+      expect(convexFactoryCalls).toEqual([
+        [
+          config.convexUrl,
+          {
+            payload: 'test-payload',
+            signature: 'test-signature',
+          },
+        ],
+      ]);
+    });
+  });
+
+  describe('GET /events', () => {
+    it('uses supported list args and preserves keyed event pagination', async () => {
+      queryImpl = async (_fn, args) => {
+        if ('resourceType' in (args as Record<string, unknown>)) {
+          throw new Error('ArgumentValidationError: Object contains extra field `resourceType`');
+        }
+        return { events: [{ _id: 'event_123' }], hasMore: true, nextCursor: 'event_123' };
+      };
+
+      const response = await handleEventsRoutes(
+        makeRequest('GET', '/events?type=purchase&resource_id=product_123'),
+        '/events',
+        config
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        data: [{ _id: 'event_123' }],
+        hasMore: true,
+        nextCursor: 'event_123',
+      });
+      expect(convexFactoryCalls).toEqual([
+        [
+          config.convexUrl,
+          {
+            payload: 'test-payload',
+            signature: 'test-signature',
+          },
+        ],
+      ]);
     });
   });
 

--- a/apps/api/src/routes/publicV2/webhooks.ts
+++ b/apps/api/src/routes/publicV2/webhooks.ts
@@ -170,7 +170,6 @@ export async function handleWebhooksRoutes(
   const resolveAuth = services.resolveAuth ?? _resolveAuthBase;
   const reqId = generateRequestId();
   const url = new URL(request.url);
-  const convex = getConvexClientFromUrl(config.convexUrl);
 
   // GET /webhook-event-types
   if (subPath === '/webhook-event-types') {
@@ -204,6 +203,7 @@ export async function handleWebhooksRoutes(
     if (request.method === 'GET') {
       const auth = await resolveAuth(request, config, ['webhooks:manage'], reqId);
       if (auth instanceof Response) return auth;
+      const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
       const enabledParam = url.searchParams.get('enabled');
       const enabled = enabledParam === 'true' ? true : enabledParam === 'false' ? false : undefined;
@@ -226,6 +226,7 @@ export async function handleWebhooksRoutes(
     if (request.method === 'POST') {
       const auth = await resolveAuth(request, config, ['webhooks:manage'], reqId);
       if (auth instanceof Response) return auth;
+      const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
       let body: Record<string, unknown>;
       try {
@@ -314,6 +315,7 @@ export async function handleWebhooksRoutes(
     }
     const auth = await resolveAuth(request, config, ['webhooks:manage'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const subscriptionId = rotateMatch[1];
     const newSigningSecret = generateSigningSecret();
@@ -357,6 +359,7 @@ export async function handleWebhooksRoutes(
     }
     const auth = await resolveAuth(request, config, ['webhooks:manage'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     const subscriptionId = deliveriesMatch[1];
     const { limit, cursor } = parsePagination(url);
@@ -387,6 +390,7 @@ export async function handleWebhooksRoutes(
     }
     const auth = await resolveAuth(request, config, ['webhooks:manage'], reqId);
     if (auth instanceof Response) return auth;
+    const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
     try {
       await convex.mutation(api.creatorEvents.emitPingEvent, {
@@ -408,6 +412,7 @@ export async function handleWebhooksRoutes(
     if (request.method === 'GET') {
       const auth = await resolveAuth(request, config, ['webhooks:manage'], reqId);
       if (auth instanceof Response) return auth;
+      const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
       try {
         const result = await convex.query(api.webhookSubscriptions.getById, {
@@ -433,6 +438,7 @@ export async function handleWebhooksRoutes(
     if (request.method === 'PATCH') {
       const auth = await resolveAuth(request, config, ['webhooks:manage'], reqId);
       if (auth instanceof Response) return auth;
+      const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
       let body: Record<string, unknown>;
       try {
@@ -468,6 +474,7 @@ export async function handleWebhooksRoutes(
     if (request.method === 'DELETE') {
       const auth = await resolveAuth(request, config, ['webhooks:manage'], reqId);
       if (auth instanceof Response) return auth;
+      const convex = getConvexClientFromUrl(config.convexUrl, auth.actorBinding);
 
       try {
         await convex.mutation(api.webhookSubscriptions.deleteSubscription, {

--- a/convex/manualLicenses.realtest.ts
+++ b/convex/manualLicenses.realtest.ts
@@ -37,4 +37,67 @@ describe('manual license bounds', () => {
       })
     ).rejects.toThrow('Maximum of 100 licenses per bulk request');
   });
+
+  it('returns a filtered cursor page without exposing license hashes', async () => {
+    const t = makeTestConvex();
+    const authUserId = 'auth-manual-pagination';
+    const now = Date.now();
+    const actor = await createApiActorBinding(
+      {
+        version: 1,
+        kind: 'auth_user',
+        authUserId,
+        source: 'session',
+        scopes: [],
+        issuedAt: now,
+        expiresAt: now + 60_000,
+      },
+      process.env.INTERNAL_SERVICE_AUTH_SECRET as string
+    );
+
+    const ids = await t.run(async (ctx) =>
+      Promise.all(
+        ['license-a', 'license-b', 'license-c'].map(async (licenseKeyHash, index) =>
+          await ctx.db.insert('manual_licenses', {
+            authUserId,
+            licenseKeyHash,
+            productId: 'product-pagination',
+            currentUses: 0,
+            status: 'active',
+            createdAt: now + index,
+            updatedAt: now + index,
+          })
+        )
+      )
+    );
+
+    const firstPage = await t.query(api.manualLicenses.listByTenant, {
+      apiSecret: 'test-secret',
+      actor,
+      authUserId,
+      productId: 'product-pagination',
+      limit: 2,
+    });
+
+    expect(firstPage).toMatchObject({ hasMore: true });
+    expect(firstPage.data).toHaveLength(2);
+    expect(firstPage.data.every((license) => !('licenseKeyHash' in license))).toBe(true);
+    const firstCursor = firstPage.nextCursor;
+    if (!firstCursor) {
+      throw new Error('Expected the first manual-license page to include a cursor');
+    }
+
+    const secondPage = await t.query(api.manualLicenses.listByTenant, {
+      apiSecret: 'test-secret',
+      actor,
+      authUserId,
+      productId: 'product-pagination',
+      cursor: firstCursor,
+      limit: 2,
+    });
+
+    expect(secondPage).toMatchObject({ hasMore: false, nextCursor: null });
+    expect(secondPage.data).toHaveLength(1);
+    expect(secondPage.data[0]?._id).toBe(ids[2]);
+  });
 });

--- a/convex/manualLicenses.ts
+++ b/convex/manualLicenses.ts
@@ -165,27 +165,45 @@ export const listByTenant = query({
     cursor: v.optional(v.string()),
     limit: v.optional(v.number()),
   },
-  handler: async (ctx, { apiSecret, actor, authUserId, productId, status }) => {
+  handler: async (ctx, { apiSecret, actor, authUserId, productId, status, cursor, limit }) => {
     requireApiSecret(apiSecret);
     await requireDelegatedAuthUserActor(actor, authUserId);
-    const query = ctx.db
-      .query('manual_licenses')
-      .withIndex('by_auth_user', (q) => q.eq('authUserId', authUserId));
+    const pageSize = Math.max(1, Math.min(limit ?? 50, 100));
+    const pagination = { cursor: cursor ?? null, numItems: pageSize };
+    const page =
+      productId && status
+        ? await ctx.db
+            .query('manual_licenses')
+            .withIndex('by_auth_user_product_status', (q) =>
+              q.eq('authUserId', authUserId).eq('productId', productId).eq('status', status)
+            )
+            .paginate(pagination)
+        : productId
+          ? await ctx.db
+              .query('manual_licenses')
+              .withIndex('by_auth_user_product', (q) =>
+                q.eq('authUserId', authUserId).eq('productId', productId)
+              )
+              .paginate(pagination)
+          : status
+            ? await ctx.db
+                .query('manual_licenses')
+                .withIndex('by_auth_user_status', (q) =>
+                  q.eq('authUserId', authUserId).eq('status', status)
+                )
+                .paginate(pagination)
+            : await ctx.db
+                .query('manual_licenses')
+                .withIndex('by_auth_user', (q) => q.eq('authUserId', authUserId))
+                .paginate(pagination);
 
-    const licenses = await query.collect();
-
-    let filtered = licenses;
-
-    if (productId) {
-      filtered = filtered.filter((l) => l.productId === productId);
-    }
-
-    if (status) {
-      filtered = filtered.filter((l) => l.status === status);
-    }
-
-    // Never return hashes
-    return filtered.map(({ licenseKeyHash: _, ...rest }) => rest);
+    // Never return hashes.
+    const data = page.page.map(({ licenseKeyHash: _, ...rest }) => rest);
+    return {
+      data,
+      hasMore: !page.isDone,
+      nextCursor: page.isDone ? null : page.continueCursor,
+    };
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2144,6 +2144,7 @@ const manual_licenses = defineTable({
 })
   .index('by_auth_user', ['authUserId'])
   .index('by_auth_user_product', ['authUserId', 'productId'])
+  .index('by_auth_user_product_status', ['authUserId', 'productId', 'status'])
   .index('by_license_key_hash', ['licenseKeyHash'])
   .index('by_auth_user_status', ['authUserId', 'status'])
   .index('by_expires', ['expiresAt']);


### PR DESCRIPTION
## Summary
- propagate each protected publicV2 caller actor binding into its Convex client
- correctly unwrap public subject resolution results and restore not-found behavior
- normalize keyed `events` and `deliveries` pages with `nextCursor`, remove the unsupported event filter, and implement indexed manual-license pagination

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run test:convex`
- `bun run test:api:integration`
- `bun run test:external-integrations`
- `bun run test:ci`

`bun audit` remains blocked by the existing moderate advisory for the pinned `@better-auth/oauth-provider` range; this PR makes no dependency or lockfile changes.