### PR TITLE
refactor(api): deduplicate VRChat pending state

### DIFF
--- a/apps/api/src/lib/encryptedPendingState.ts
+++ b/apps/api/src/lib/encryptedPendingState.ts
@@ -1,0 +1,111 @@
+import { buildCookie, clearCookie, getCookieValue } from './browserSessions';
+import { decrypt, encrypt } from './encrypt';
+import type { StateStore } from './stateStore';
+
+const PENDING_STATE_TTL_MS = 5 * 60 * 1000;
+
+export type TimestampedPendingState<TPayload extends object> = TPayload & {
+  createdAt: number;
+  expiresAt: number;
+};
+
+export interface EncryptedPendingStateConfig<
+  TPayload extends object,
+  TValidationArgs extends unknown[],
+> {
+  cookieName: string;
+  cookiePath: string;
+  storagePrefix: string;
+  purpose: string;
+  payloadValidator: (value: unknown, ...args: TValidationArgs) => TPayload | null;
+}
+
+function getPendingSecret(): string {
+  const secret = process.env.VRCHAT_PENDING_STATE_SECRET;
+  if (secret) return secret;
+  if (process.env.NODE_ENV !== 'production' && process.env.BETTER_AUTH_SECRET) {
+    return process.env.BETTER_AUTH_SECRET;
+  }
+  throw new Error('VRCHAT_PENDING_STATE_SECRET is required');
+}
+
+export function createEncryptedPendingState<
+  TPayload extends object,
+  TValidationArgs extends unknown[] = [],
+>(config: EncryptedPendingStateConfig<TPayload, TValidationArgs>) {
+  type State = TimestampedPendingState<TPayload>;
+
+  function appendClearedCookie(headers: Headers, request: Request): void {
+    headers.append(
+      'Set-Cookie',
+      clearCookie(config.cookieName, request, { path: config.cookiePath })
+    );
+  }
+
+  async function create(store: StateStore, request: Request, payload: TPayload): Promise<string> {
+    const now = Date.now();
+    const state: State = {
+      ...payload,
+      createdAt: now,
+      expiresAt: now + PENDING_STATE_TTL_MS,
+    };
+    const id = crypto.randomUUID();
+    const encrypted = await encrypt(JSON.stringify(state), getPendingSecret(), config.purpose);
+    await store.set(`${config.storagePrefix}${id}`, encrypted, PENDING_STATE_TTL_MS);
+    return buildCookie(config.cookieName, id, request, {
+      path: config.cookiePath,
+      maxAgeSeconds: Math.floor(PENDING_STATE_TTL_MS / 1000),
+    });
+  }
+
+  async function read(
+    store: StateStore,
+    request: Request,
+    ...validationArgs: TValidationArgs
+  ): Promise<{ id: string; state: State } | null> {
+    const pendingId = getCookieValue(request, config.cookieName);
+    if (!pendingId) return null;
+
+    const encrypted = await store.get(`${config.storagePrefix}${pendingId}`);
+    if (!encrypted) return null;
+
+    try {
+      const decrypted = await decrypt(encrypted, getPendingSecret(), config.purpose);
+      const value = JSON.parse(decrypted) as unknown;
+      const payload = config.payloadValidator(value, ...validationArgs);
+      const state = value as Partial<State>;
+      const { createdAt, expiresAt } = state;
+      if (
+        !payload ||
+        typeof createdAt !== 'number' ||
+        typeof expiresAt !== 'number' ||
+        expiresAt < Date.now()
+      ) {
+        return null;
+      }
+
+      return {
+        id: pendingId,
+        state: {
+          ...payload,
+          createdAt,
+          expiresAt,
+        },
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async function clear(store: StateStore, request: Request, headers?: Headers): Promise<void> {
+    const pendingId = getCookieValue(request, config.cookieName);
+    if (pendingId) {
+      await store.delete(`${config.storagePrefix}${pendingId}`);
+    }
+    if (headers) {
+      appendClearedCookie(headers, request);
+    }
+  }
+
+  return { appendClearedCookie, create, read, clear };
+}

--- a/apps/api/src/providers/vrchat/pending.ts
+++ b/apps/api/src/providers/vrchat/pending.ts
@@ -1,125 +1,51 @@
-/**
- * VRChat Connect, 2FA pending state for the creator connect flow.
- *
- * Identical pattern to apps/api/src/verification/vrchatPending.ts but with
- * separate cookie name and path so it never interferes with the buyer flow.
- *
- * Cookie: yucp_vrchat_connect_pending
- * Path:   /api/connect/vrchat
- * Store prefix: vrchat_connect_pending:
- * HKDF purpose: 'vrchat-connect-pending-state'
- */
-
 import type { TwoFactorAuthType } from '@yucp/providers';
-import { buildCookie, clearCookie, getCookieValue } from '../../lib/browserSessions';
-import { decrypt, encrypt } from '../../lib/encrypt';
-import type { StateStore } from '../../lib/stateStore';
+import {
+  createEncryptedPendingState,
+  type TimestampedPendingState,
+} from '../../lib/encryptedPendingState';
 
-const PENDING_COOKIE_NAME = 'yucp_vrchat_connect_pending';
-const PENDING_COOKIE_PATH = '/api/connect/vrchat';
-const PENDING_STATE_PREFIX = 'vrchat_connect_pending:';
-const PENDING_STATE_TTL_MS = 5 * 60 * 1000;
-const HKDF_PURPOSE = 'vrchat-connect-pending-state' as const;
-
-export interface VrchatConnectPendingState {
+interface VrchatConnectPendingPayload {
   authUserId: string;
   pendingState: string;
   types: TwoFactorAuthType[];
-  createdAt: number;
-  expiresAt: number;
 }
 
-function getPendingSecret(): string {
-  const secret = process.env.VRCHAT_PENDING_STATE_SECRET;
-  if (secret) return secret;
-  if (process.env.NODE_ENV !== 'production' && process.env.BETTER_AUTH_SECRET) {
-    return process.env.BETTER_AUTH_SECRET;
-  }
-  throw new Error('VRCHAT_PENDING_STATE_SECRET is required');
-}
+export type VrchatConnectPendingState = TimestampedPendingState<VrchatConnectPendingPayload>;
 
-export function appendClearedConnectPendingCookie(headers: Headers, request: Request): void {
-  headers.append(
-    'Set-Cookie',
-    clearCookie(PENDING_COOKIE_NAME, request, { path: PENDING_COOKIE_PATH })
-  );
-}
+function validateConnectPayload(value: unknown): VrchatConnectPendingPayload | null {
+  if (!value || typeof value !== 'object') return null;
+  const state = value as Partial<VrchatConnectPendingPayload>;
+  const validTypes = Array.isArray(state.types)
+    ? state.types.filter(
+        (type): type is TwoFactorAuthType =>
+          type === 'totp' || type === 'emailOtp' || type === 'otp'
+      )
+    : [];
 
-export async function createConnectPendingState(
-  store: StateStore,
-  request: Request,
-  payload: Omit<VrchatConnectPendingState, 'createdAt' | 'expiresAt'>
-): Promise<string> {
-  const now = Date.now();
-  const state: VrchatConnectPendingState = {
-    ...payload,
-    createdAt: now,
-    expiresAt: now + PENDING_STATE_TTL_MS,
-  };
-  const id = crypto.randomUUID();
-  const encrypted = await encrypt(JSON.stringify(state), getPendingSecret(), HKDF_PURPOSE);
-  await store.set(`${PENDING_STATE_PREFIX}${id}`, encrypted, PENDING_STATE_TTL_MS);
-  return buildCookie(PENDING_COOKIE_NAME, id, request, {
-    path: PENDING_COOKIE_PATH,
-    maxAgeSeconds: Math.floor(PENDING_STATE_TTL_MS / 1000),
-  });
-}
-
-export async function readConnectPendingState(
-  store: StateStore,
-  request: Request
-): Promise<{ id: string; state: VrchatConnectPendingState } | null> {
-  const pendingId = getCookieValue(request, PENDING_COOKIE_NAME);
-  if (!pendingId) return null;
-
-  const encrypted = await store.get(`${PENDING_STATE_PREFIX}${pendingId}`);
-  if (!encrypted) return null;
-
-  try {
-    const decrypted = await decrypt(encrypted, getPendingSecret(), HKDF_PURPOSE);
-    const state = JSON.parse(decrypted) as Partial<VrchatConnectPendingState>;
-    const validTypes = Array.isArray(state.types)
-      ? state.types.filter(
-          (t): t is TwoFactorAuthType => t === 'totp' || t === 'emailOtp' || t === 'otp'
-        )
-      : [];
-
-    if (
-      typeof state.authUserId !== 'string' ||
-      typeof state.pendingState !== 'string' ||
-      typeof state.createdAt !== 'number' ||
-      typeof state.expiresAt !== 'number' ||
-      state.expiresAt < Date.now() ||
-      validTypes.length === 0
-    ) {
-      return null;
-    }
-
-    return {
-      id: pendingId,
-      state: {
-        authUserId: state.authUserId,
-        pendingState: state.pendingState,
-        types: validTypes,
-        createdAt: state.createdAt,
-        expiresAt: state.expiresAt,
-      },
-    };
-  } catch {
+  if (
+    typeof state.authUserId !== 'string' ||
+    typeof state.pendingState !== 'string' ||
+    validTypes.length === 0
+  ) {
     return null;
   }
+
+  return {
+    authUserId: state.authUserId,
+    pendingState: state.pendingState,
+    types: validTypes,
+  };
 }
 
-export async function clearConnectPendingState(
-  store: StateStore,
-  request: Request,
-  headers?: Headers
-): Promise<void> {
-  const pendingId = getCookieValue(request, PENDING_COOKIE_NAME);
-  if (pendingId) {
-    await store.delete(`${PENDING_STATE_PREFIX}${pendingId}`);
-  }
-  if (headers) {
-    appendClearedConnectPendingCookie(headers, request);
-  }
-}
+export const {
+  appendClearedCookie: appendClearedConnectPendingCookie,
+  create: createConnectPendingState,
+  read: readConnectPendingState,
+  clear: clearConnectPendingState,
+} = createEncryptedPendingState<VrchatConnectPendingPayload>({
+  cookieName: 'yucp_vrchat_connect_pending',
+  cookiePath: '/api/connect/vrchat',
+  storagePrefix: 'vrchat_connect_pending:',
+  purpose: 'vrchat-connect-pending-state',
+  payloadValidator: validateConnectPayload,
+});

--- a/apps/api/src/verification/vrchatPending.ts
+++ b/apps/api/src/verification/vrchatPending.ts
@@ -1,125 +1,55 @@
 import type { TwoFactorAuthType } from '@yucp/providers';
-import { buildCookie, clearCookie, getCookieValue } from '../lib/browserSessions';
-import { decrypt, encrypt } from '../lib/encrypt';
-import type { StateStore } from '../lib/stateStore';
+import {
+  createEncryptedPendingState,
+  type TimestampedPendingState,
+} from '../lib/encryptedPendingState';
 
-const PENDING_COOKIE_NAME = 'yucp_vrchat_pending';
-const PENDING_COOKIE_PATH = '/api/verification/vrchat-verify';
-const PENDING_STATE_PREFIX = 'vrchat_pending:';
-const PENDING_STATE_TTL_MS = 5 * 60 * 1000;
-
-export interface VrchatPendingState {
+interface VrchatPendingPayload {
   verificationToken: string;
   pendingState: string;
   types: TwoFactorAuthType[];
-  createdAt: number;
-  expiresAt: number;
 }
 
-function getPendingSecret(): string {
-  const secret = process.env.VRCHAT_PENDING_STATE_SECRET;
-  if (secret) {
-    return secret;
-  }
-  if (process.env.NODE_ENV !== 'production' && process.env.BETTER_AUTH_SECRET) {
-    return process.env.BETTER_AUTH_SECRET;
-  }
-  throw new Error('VRCHAT_PENDING_STATE_SECRET is required');
-}
+export type VrchatPendingState = TimestampedPendingState<VrchatPendingPayload>;
 
-export function appendClearedPendingCookie(headers: Headers, request: Request): void {
-  headers.append(
-    'Set-Cookie',
-    clearCookie(PENDING_COOKIE_NAME, request, { path: PENDING_COOKIE_PATH })
-  );
-}
-
-export async function createPendingVrchatState(
-  store: StateStore,
-  request: Request,
-  payload: Omit<VrchatPendingState, 'createdAt' | 'expiresAt'>
-): Promise<string> {
-  const now = Date.now();
-  const state: VrchatPendingState = {
-    ...payload,
-    createdAt: now,
-    expiresAt: now + PENDING_STATE_TTL_MS,
-  };
-  const id = crypto.randomUUID();
-  const encrypted = await encrypt(
-    JSON.stringify(state),
-    getPendingSecret(),
-    'vrchat-pending-state'
-  );
-  await store.set(`${PENDING_STATE_PREFIX}${id}`, encrypted, PENDING_STATE_TTL_MS);
-  return buildCookie(PENDING_COOKIE_NAME, id, request, {
-    path: PENDING_COOKIE_PATH,
-    maxAgeSeconds: Math.floor(PENDING_STATE_TTL_MS / 1000),
-  });
-}
-
-export async function readPendingVrchatState(
-  store: StateStore,
-  request: Request,
+function validateVerificationPayload(
+  value: unknown,
   verificationToken: string
-): Promise<{ id: string; state: VrchatPendingState } | null> {
-  const pendingId = getCookieValue(request, PENDING_COOKIE_NAME);
-  if (!pendingId) {
+): VrchatPendingPayload | null {
+  if (!value || typeof value !== 'object') return null;
+  const state = value as Partial<VrchatPendingPayload>;
+  const validTypes = Array.isArray(state.types)
+    ? state.types.filter(
+        (type): type is TwoFactorAuthType =>
+          type === 'totp' || type === 'emailOtp' || type === 'otp'
+      )
+    : [];
+
+  if (
+    typeof state.verificationToken !== 'string' ||
+    state.verificationToken !== verificationToken ||
+    typeof state.pendingState !== 'string' ||
+    validTypes.length === 0
+  ) {
     return null;
   }
 
-  const encrypted = await store.get(`${PENDING_STATE_PREFIX}${pendingId}`);
-  if (!encrypted) {
-    return null;
-  }
-
-  try {
-    const decrypted = await decrypt(encrypted, getPendingSecret(), 'vrchat-pending-state');
-    const state = JSON.parse(decrypted) as Partial<VrchatPendingState>;
-    const validTypes = Array.isArray(state.types)
-      ? state.types.filter(
-          (type): type is TwoFactorAuthType =>
-            type === 'totp' || type === 'emailOtp' || type === 'otp'
-        )
-      : [];
-
-    if (
-      typeof state.pendingState !== 'string' ||
-      typeof state.verificationToken !== 'string' ||
-      state.verificationToken !== verificationToken ||
-      typeof state.createdAt !== 'number' ||
-      typeof state.expiresAt !== 'number' ||
-      state.expiresAt < Date.now() ||
-      validTypes.length === 0
-    ) {
-      return null;
-    }
-
-    return {
-      id: pendingId,
-      state: {
-        verificationToken: state.verificationToken,
-        pendingState: state.pendingState,
-        types: validTypes,
-        createdAt: state.createdAt,
-        expiresAt: state.expiresAt,
-      },
-    };
-  } catch {
-    return null;
-  }
+  return {
+    verificationToken: state.verificationToken,
+    pendingState: state.pendingState,
+    types: validTypes,
+  };
 }
 
-export async function clearPendingVrchatState(
-  store: StateStore,
-  request: Request,
-  headers?: Headers
-): Promise<void> {
-  const pendingId = getCookieValue(request, PENDING_COOKIE_NAME);
-  if (pendingId) {
-    await store.delete(`${PENDING_STATE_PREFIX}${pendingId}`);
-  }
-  if (headers) {
-    appendClearedPendingCookie(headers, request);
-  }
-}
+export const {
+  appendClearedCookie: appendClearedPendingCookie,
+  create: createPendingVrchatState,
+  read: readPendingVrchatState,
+  clear: clearPendingVrchatState,
+} = createEncryptedPendingState<VrchatPendingPayload, [verificationToken: string]>({
+  cookieName: 'yucp_vrchat_pending',
+  cookiePath: '/api/verification/vrchat-verify',
+  storagePrefix: 'vrchat_pending:',
+  purpose: 'vrchat-pending-state',
+  payloadValidator: validateVerificationPayload,
+});


### PR DESCRIPTION
## Summary

- extract one reusable encrypted pending-state primitive for cookie, storage, encryption, TTL, and lifecycle handling
- keep VRChat connect and verification as thin typed configurations with their existing payload validation
- preserve caller APIs and all existing cookie, storage, purpose, and expiry behavior

## Validation

- `bun test apps/api/src/providers/vrchat/pending.test.ts apps/api/src/verification/vrchatPending.test.ts`
- `bun run --filter '@yucp/api' test:ci`
- `bun run test:boundary-mocks`
- `bun run typecheck`
- `bun run lint`
- `bun run test:external-integrations`