### PR TITLE
Refactor API Backstage and provider display support

### DIFF
--- a/apps/api/src/lib/cdngineBackstage.ts
+++ b/apps/api/src/lib/cdngineBackstage.ts
@@ -1,5 +1,5 @@
 /**
- * Purpose: Handles Backstage package byte transfer through CDNgine without using Convex storage.
+ * Purpose: Provides shared Backstage route support and CDNgine package byte transfer.
  * Governing docs:
  * - README.md
  * - agents.md
@@ -80,6 +80,7 @@ export type CdngineBackstageUploadSession = {
 const DEFAULT_PUBLICATION_POLL_INTERVAL_MS = 500;
 const DEFAULT_PUBLICATION_TIMEOUT_MS = 120_000;
 const CDNGINE_RESPONSE_MAX_BYTES = 16 * 1024;
+export const BACKSTAGE_REPO_TOKEN_HEADER = 'X-YUCP-Repo-Token';
 
 const PENDING_PUBLICATION_STATES = new Set([
   'awaiting-upload',
@@ -97,6 +98,38 @@ function getFiniteNumberOrDefault(value: number | undefined, fallback: number): 
 function getPositiveNumberOrDefault(value: number | undefined, fallback: number): number {
   const resolved = getFiniteNumberOrDefault(value, fallback);
   return resolved > 0 ? resolved : fallback;
+}
+
+export function jsonResponse(body: object, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function getAllowedOrigins(config: {
+  apiBaseUrl: string;
+  frontendBaseUrl: string;
+}): Set<string> {
+  return new Set([new URL(config.apiBaseUrl).origin, new URL(config.frontendBaseUrl).origin]);
+}
+
+export function buildBackstageAddRepoUrl(repositoryUrl: string, repoToken: string): string {
+  const addRepoUrl = new URL('vcc://vpm/addRepo');
+  addRepoUrl.searchParams.set('url', repositoryUrl);
+  addRepoUrl.searchParams.append('headers[]', `${BACKSTAGE_REPO_TOKEN_HEADER}:${repoToken}`);
+  return addRepoUrl.toString();
+}
+
+export function hasCdngineErrorMessage(error: unknown): boolean {
+  return error instanceof Error && error.message.includes('CDNgine');
 }
 
 export function requireCdngineBackstageConfig(
@@ -138,7 +171,7 @@ export function sanitizeCdngineObjectKeySegment(value: string): string {
     .slice(0, 160);
 }
 
-async function fetchWithTimeout(
+export async function fetchWithTimeout(
   url: string,
   init: RequestInit,
   timeoutMs: number

--- a/apps/api/src/providers/display.test.ts
+++ b/apps/api/src/providers/display.test.ts
@@ -1,13 +1,9 @@
 import { describe, expect, it } from 'bun:test';
-import {
-  getConnectedAccountProviderDisplay,
-  listHostedVerificationProviderDisplays,
-  listUserLinkProviderDisplays,
-} from './display';
+import { providerPlatformService } from './display';
 
 describe('provider display helpers', () => {
   it('preserves connected-account fallback display for verification-only providers', () => {
-    expect(getConnectedAccountProviderDisplay('discord')).toEqual({
+    expect(providerPlatformService.getConnectedAccountProviderDisplay('discord')).toEqual({
       id: 'discord',
       label: 'Discord',
       icon: null,
@@ -17,7 +13,7 @@ describe('provider display helpers', () => {
   });
 
   it('includes verification-only OAuth providers in the user link provider list', () => {
-    const providers = listUserLinkProviderDisplays();
+    const providers = providerPlatformService.listUserLinkProviderDisplays();
     const providerIds = providers.map((provider) => provider.id);
 
     expect(providerIds).toContain('gumroad');
@@ -35,7 +31,7 @@ describe('provider display helpers', () => {
   });
 
   it('includes non-OAuth hosted verification providers in the hosted verification display list', () => {
-    const providers = listHostedVerificationProviderDisplays();
+    const providers = providerPlatformService.listHostedVerificationProviderDisplays();
     const providerIds = providers.map((provider) => provider.id);
 
     expect(providerIds).toContain('gumroad');

--- a/apps/api/src/providers/display.ts
+++ b/apps/api/src/providers/display.ts
@@ -4,28 +4,6 @@ import { getVerificationConfig } from '../verification/verificationConfig';
 import { ALL_PROVIDER_RUNTIMES } from './index';
 import type { ConnectDisplayMeta } from './types';
 
-export interface ProviderDisplaySummary {
-  readonly id: string;
-  readonly label: string;
-  readonly icon: string | null;
-  readonly color: string | null;
-  readonly description: string | null;
-}
-
-export interface DashboardProviderSummary {
-  readonly key: string;
-  readonly setupExperience: 'automatic' | 'guided' | 'manual';
-  readonly setupHint: string;
-  readonly label: string;
-  readonly icon: string;
-  readonly iconBg: string;
-  readonly quickStartBg: string;
-  readonly quickStartBorder: string;
-  readonly serverTileHint: string;
-  readonly connectPath: string;
-  readonly connectParamStyle: ConnectDisplayMeta['dashboardConnectParamStyle'];
-}
-
 const VERIFICATION_ONLY_PROVIDER_DISPLAY: Readonly<Record<string, ProviderLinkFallbackDisplay>> = {
   discord: { icon: 'Discord.png', color: '#5865F2' },
 };
@@ -56,7 +34,7 @@ const runtimeConnectSurfaces = ALL_PROVIDER_RUNTIMES.flatMap((provider) => {
   return runtimeSurface ? [runtimeSurface] : [];
 });
 
-const providerPlatformService = createApplicationServices({
+export const providerPlatformService = createApplicationServices({
   providerPlatform: {
     listRuntimeConnectSurfaces: () => runtimeConnectSurfaces,
     getRuntimeConnectSurface: (providerKey) =>
@@ -65,19 +43,3 @@ const providerPlatformService = createApplicationServices({
     getVerificationOnlyDisplay: (providerKey) => VERIFICATION_ONLY_PROVIDER_DISPLAY[providerKey],
   },
 }).providerPlatform;
-
-export function getConnectedAccountProviderDisplay(providerKey: string): ProviderDisplaySummary {
-  return providerPlatformService.getConnectedAccountProviderDisplay(providerKey);
-}
-
-export function listUserLinkProviderDisplays(): ProviderDisplaySummary[] {
-  return providerPlatformService.listUserLinkProviderDisplays();
-}
-
-export function listHostedVerificationProviderDisplays(): ProviderDisplaySummary[] {
-  return providerPlatformService.listHostedVerificationProviderDisplays();
-}
-
-export function listDashboardProviderDisplays(): DashboardProviderSummary[] {
-  return providerPlatformService.listDashboardProviderDisplays();
-}

--- a/apps/api/src/routes/backstageRepos.ts
+++ b/apps/api/src/routes/backstageRepos.ts
@@ -24,7 +24,16 @@ import { createApiServiceActorBinding, createAuthUserActorBinding } from '../lib
 import { buildBackstageImporterDelivery } from '../lib/backstageImporterDelivery';
 import type { CreatorRepoIdentity } from '../lib/backstageRepoIdentity';
 import { buildBackstageRepositoryUrls, getCreatorRepoIdentity } from '../lib/backstageRepoIdentity';
-import { authorizeCdngineBackstageSource } from '../lib/cdngineBackstage';
+import {
+  authorizeCdngineBackstageSource,
+  BACKSTAGE_REPO_TOKEN_HEADER,
+  buildBackstageAddRepoUrl,
+  fetchWithTimeout,
+  getAllowedOrigins,
+  hasCdngineErrorMessage,
+  isRecord,
+  jsonResponse,
+} from '../lib/cdngineBackstage';
 import { getConvexClientFromUrl } from '../lib/convex';
 import { rejectCrossSiteRequest } from '../lib/csrf';
 import { logger } from '../lib/logger';
@@ -37,7 +46,6 @@ import {
 import { normalizeHostedVerificationRequirements } from '../verification/hostedIntents';
 import { getVerificationConfig } from '../verification/verificationConfig';
 
-const BACKSTAGE_REPO_TOKEN_HEADER = 'X-YUCP-Repo-Token';
 const BACKSTAGE_REPO_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const BACKSTAGE_ALIAS_INSTALL_PLAN_TTL_MS = 5 * 60 * 1000;
 const BACKSTAGE_FORWARDED_UPSTREAM_TIMEOUT_MS = 2_000;
@@ -194,16 +202,6 @@ export type BackstageRepoConfig = {
   };
 };
 
-function jsonResponse(body: object, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: {
-      'Content-Type': 'application/json',
-      'Cache-Control': 'no-store',
-    },
-  });
-}
-
 function errorResponse(message: string, status: number): Response {
   return jsonResponse({ error: message }, status);
 }
@@ -224,10 +222,6 @@ function safeDecodeURIComponent(value: string): string | null {
   } catch {
     return null;
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function isUnauthorizedError(error: unknown): boolean {
@@ -307,13 +301,6 @@ function mergeRepositoryPackages(
   };
 }
 
-function buildBackstageAddRepoUrl(repositoryUrl: string, repoToken: string): string {
-  const addRepoUrl = new URL('vcc://vpm/addRepo');
-  addRepoUrl.searchParams.set('url', repositoryUrl);
-  addRepoUrl.searchParams.append('headers[]', `${BACKSTAGE_REPO_TOKEN_HEADER}:${repoToken}`);
-  return addRepoUrl.toString();
-}
-
 function getConfiguredCdngine(
   config: BackstageRepoConfig
 ): ConfiguredCdngineBackstageDelivery | null {
@@ -325,23 +312,6 @@ function getConfiguredCdngine(
     accessToken: config.cdngine.accessToken,
     apiBaseUrl: config.cdngine.apiBaseUrl.replace(/\/+$/, ''),
   };
-}
-
-async function fetchWithTimeout(
-  url: string,
-  init: RequestInit,
-  timeoutMs: number
-): Promise<Response> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    return await fetch(url, {
-      ...init,
-      signal: controller.signal,
-    });
-  } finally {
-    clearTimeout(timeout);
-  }
 }
 
 type CdngineDeliveryAuthorizationResult =
@@ -399,7 +369,7 @@ async function readResponseTextWithLimit(
 }
 
 function isCdngineBackstageDependencyError(error: unknown): boolean {
-  return error instanceof Error && error.message.includes('CDNgine');
+  return hasCdngineErrorMessage(error);
 }
 
 async function authorizeCdngineBackstageDeliveryUrl(input: {
@@ -553,10 +523,6 @@ function parseCreatorRepoRoute(
     return { creatorRepoRef, routeType: 'package' };
   }
   return null;
-}
-
-function getAllowedOrigins(config: BackstageRepoConfig): Set<string> {
-  return new Set([new URL(config.apiBaseUrl).origin, new URL(config.frontendBaseUrl).origin]);
 }
 
 function normalizeFrontendReturnUrl(config: BackstageRepoConfig, value: string): string | null {

--- a/apps/api/src/routes/connect.ts
+++ b/apps/api/src/routes/connect.ts
@@ -34,7 +34,7 @@ import { loadRequestScoped, requestScopeKey } from '../lib/requestScope';
 import { buildTimedResponse, RouteTimingCollector } from '../lib/requestTiming';
 import { createSetupSession, resolveSetupSession } from '../lib/setupSession';
 import { getStateStore } from '../lib/stateStore';
-import { listDashboardProviderDisplays } from '../providers/display';
+import { providerPlatformService } from '../providers/display';
 import { getProviderHooks, getProviderRuntime, listConnectPlugins } from '../providers/index';
 import type { ConnectConfig, ConnectContext } from '../providers/types';
 import { createConnectApiAccessRoutes } from './connectApiAccess';
@@ -172,7 +172,7 @@ export function createConnectRoutes(auth: Auth, config: ConnectConfig) {
       },
     },
     providerDisplays: {
-      listDashboardProviderDisplays,
+      listDashboardProviderDisplays: () => providerPlatformService.listDashboardProviderDisplays(),
     },
   });
   const guildDirectoryService = new GuildDirectoryService({

--- a/apps/api/src/routes/connectUserVerification.readSurface.test.ts
+++ b/apps/api/src/routes/connectUserVerification.readSurface.test.ts
@@ -83,7 +83,7 @@ mock.module('../lib/observability', () => ({
   ) => callback(),
 }));
 
-mock.module('../providers/display', () => ({
+const providerPlatformServiceMock = {
   getConnectedAccountProviderDisplay: (provider: string) => ({
     label: provider === 'itchio' ? 'itch.io' : provider,
     icon: provider === 'itchio' ? 'Itchio.png' : null,
@@ -171,6 +171,10 @@ mock.module('../providers/display', () => ({
     },
   ],
   listHostedVerificationProviderDisplays: () => [],
+};
+
+mock.module('../providers/display', () => ({
+  providerPlatformService: providerPlatformServiceMock,
 }));
 
 const { createConnectUserVerificationRoutes } = await import('./connectUserVerification');

--- a/apps/api/src/routes/connectUserVerification.ts
+++ b/apps/api/src/routes/connectUserVerification.ts
@@ -8,10 +8,7 @@ import { getConvexClientFromUrl } from '../lib/convex';
 import { rejectCrossSiteRequest } from '../lib/csrf';
 import { logger } from '../lib/logger';
 import { withApiSpan } from '../lib/observability';
-import {
-  getConnectedAccountProviderDisplay,
-  listHostedVerificationProviderDisplays,
-} from '../providers/display';
+import { providerPlatformService } from '../providers/display';
 import type { ConnectConfig } from '../providers/types';
 import {
   buildLinkedEntitlementRequirements,
@@ -218,7 +215,9 @@ export function createConnectUserVerificationRoutes({
           providerUserId: link.providerUserId,
           providerUsername: link.providerUsername ?? null,
           verificationMethod: link.verificationMethod ?? null,
-          providerDisplay: getConnectedAccountProviderDisplay(link.provider),
+          providerDisplay: providerPlatformService.getConnectedAccountProviderDisplay(
+            link.provider
+          ),
           linkedAt: link.linkedAt,
           lastValidatedAt: link.lastValidatedAt ?? null,
           expiresAt: link.expiresAt ?? null,
@@ -261,7 +260,9 @@ export function createConnectUserVerificationRoutes({
           providerUserId: link.providerUserId,
           providerUsername: link.providerUsername ?? null,
           verificationMethod: link.verificationMethod ?? null,
-          providerDisplay: getConnectedAccountProviderDisplay(link.provider),
+          providerDisplay: providerPlatformService.getConnectedAccountProviderDisplay(
+            link.provider
+          ),
           linkedAt: link.linkedAt,
           lastValidatedAt: link.lastValidatedAt ?? null,
           expiresAt: link.expiresAt ?? null,
@@ -313,7 +314,9 @@ export function createConnectUserVerificationRoutes({
   }
 
   function getUserProviders(_request: Request): Response {
-    return Response.json({ providers: listHostedVerificationProviderDisplays() });
+    return Response.json({
+      providers: providerPlatformService.listHostedVerificationProviderDisplays(),
+    });
   }
 
   async function postUserVerifyStart(request: Request): Promise<Response> {

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -32,10 +32,16 @@ import { buildBackstageImporterDelivery } from '../lib/backstageImporterDelivery
 import { buildBackstageRepositoryUrls, getCreatorRepoIdentity } from '../lib/backstageRepoIdentity';
 import {
   authorizeCdngineBackstageSource,
+  buildBackstageAddRepoUrl,
   CdngineApiRequestError,
   type CdngineBackstageConfig,
   completeBackstageUploadSessionInCdngine,
   createBackstageUploadSessionInCdngine,
+  fetchWithTimeout,
+  getAllowedOrigins,
+  hasCdngineErrorMessage,
+  isRecord,
+  jsonResponse,
   requireCdngineBackstageConfig,
   sanitizeCdngineObjectKeySegment,
   sha256ArrayBuffer,
@@ -50,7 +56,6 @@ import { readBoundedArrayBuffer, readContentLength } from '../lib/readBoundedArr
 import { MAX_BACKSTAGE_PACKAGE_BYTES } from '../lib/requestBodyLimits';
 
 const PACKAGE_ID_RE = /^[a-z0-9\-_./:]{1,128}$/;
-const BACKSTAGE_REPO_TOKEN_HEADER = 'X-YUCP-Repo-Token';
 const BACKSTAGE_UPLOAD_COMPLETION_TOKEN_HEADER = 'X-YUCP-Upload-Completion-Token';
 const BACKSTAGE_REPO_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const DEFAULT_BACKSTAGE_LIVE_SYNC_TIMEOUT_MS = 1_500;
@@ -223,21 +228,11 @@ class BackstagePackageMediaLimitError extends Error {
   }
 }
 
-function jsonResponse(body: object, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: {
-      'Content-Type': 'application/json',
-      'Cache-Control': 'no-store',
-    },
-  });
-}
-
 function isCdngineBackstageDependencyError(error: unknown): boolean {
   return (
     error instanceof CdngineApiRequestError ||
     isFetchAbortOrTimeoutError(error) ||
-    (error instanceof Error && error.message.includes('CDNgine'))
+    hasCdngineErrorMessage(error)
   );
 }
 
@@ -411,20 +406,6 @@ async function withBackstageLiveSyncTimeout<T>(
   }
 }
 
-async function fetchWithTimeout(
-  url: string,
-  init: RequestInit,
-  timeoutMs: number
-): Promise<Response> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    return await fetch(url, { ...init, signal: controller.signal });
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
 function decodeOptionalHeaderValue(value: string | null): string | null {
   if (!value) {
     return null;
@@ -457,23 +438,12 @@ function normalizePackageMediaContentType(contentType: string | null): string | 
   return normalized;
 }
 
-function getAllowedOrigins(config: PackagesConfig): Set<string> {
-  return new Set([new URL(config.apiBaseUrl).origin, new URL(config.frontendBaseUrl).origin]);
-}
-
 function assertPackageId(packageId: string): string {
   const normalized = decodeURIComponent(packageId).trim();
   if (!PACKAGE_ID_RE.test(normalized)) {
     throw new Error('Invalid packageId format');
   }
   return normalized;
-}
-
-function buildBackstageAddRepoUrl(repositoryUrl: string, repoToken: string): string {
-  const addRepoUrl = new URL('vcc://vpm/addRepo');
-  addRepoUrl.searchParams.set('url', repositoryUrl);
-  addRepoUrl.searchParams.append('headers[]', `${BACKSTAGE_REPO_TOKEN_HEADER}:${repoToken}`);
-  return addRepoUrl.toString();
 }
 
 function buildBackstageProductRecordKey(provider: string, providerProductRef: string): string {
@@ -610,10 +580,6 @@ function normalizeRichTextToPlainText(value?: string | null): string | undefined
     .trim();
 
   return plainText || undefined;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function normalizeBackstageMetadataInput(input: {

--- a/apps/api/src/routes/providerPlatform.ts
+++ b/apps/api/src/routes/providerPlatform.ts
@@ -16,7 +16,7 @@ import {
   PayloadTooLargeError,
   readWebhookTextBody,
 } from '../lib/webhookBody';
-import { listDashboardProviderDisplays } from '../providers/display';
+import { providerPlatformService } from '../providers/display';
 import { PURPOSES as LEMONSQUEEZY } from '../providers/lemonsqueezy/index';
 
 const PROVIDER_PLATFORM_CREDENTIAL_PURPOSE = 'provider-platform-credential' as const;
@@ -1244,7 +1244,7 @@ export function createProviderPlatformRoutes(auth: Auth, config: ProviderPlatfor
       const requestId = newRequestId();
 
       if (request.method === 'GET' && url.pathname === '/api/providers') {
-        const providers = listDashboardProviderDisplays();
+        const providers = providerPlatformService.listDashboardProviderDisplays();
         return new Response(JSON.stringify(providers), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary

- centralize shared Backstage route and CDNgine support helpers
- preserve route-specific CDNgine dependency error policy
- expose the composed provider platform service directly and remove forwarding methods and duplicate result interfaces
- update API callers and behavioral tests to use the direct service surface

## Testing

- `bun test apps/api/src/routes/packages.backstage.test.ts apps/api/src/routes/backstageRepos.test.ts apps/api/src/lib/cdngineBackstage.test.ts apps/api/src/providers/display.test.ts`
- `bun test apps/api/src/routes/connectUserVerification.readSurface.test.ts`
- `bun run --filter '@yucp/api' test:ci`
- `bun run test:boundary-mocks`
- `bun run typecheck`
- `bun run lint`
- `bun run test:external-integrations`