### PR TITLE
fix(verification): enforce issuer on grant JWT verification

### DIFF
--- a/convex/verificationIntents.realtest.ts
+++ b/convex/verificationIntents.realtest.ts
@@ -1,5 +1,6 @@
+import * as ed from '@noble/ed25519';
 import { PROVIDER_REGISTRY } from '@yucp/providers/providerMetadata';
-import { sha256Hex } from '@yucp/shared/crypto';
+import { base64ToBytes, base64UrlEncode, sha256Hex } from '@yucp/shared/crypto';
 import { setPinnedYucpRootsForTests } from '@yucp/shared/yucpTrust';
 import { symmetricEncrypt } from 'better-auth/crypto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -158,6 +159,31 @@ function decodeJwtPayload(jwt: string): Record<string, unknown> {
   const payload = parts[1].replace(/-/g, '+').replace(/_/g, '/');
   const padded = payload.padEnd(Math.ceil(payload.length / 4) * 4, '=');
   return JSON.parse(Buffer.from(padded, 'base64').toString('utf-8')) as Record<string, unknown>;
+}
+
+async function resignJwtWithIssuer(jwt: string, issuer: string): Promise<string> {
+  const parts = jwt.split('.');
+  if (parts.length !== 3) {
+    throw new Error('JWT must contain exactly three parts');
+  }
+
+  const privateKeyBase64 = process.env.YUCP_ROOT_PRIVATE_KEY;
+  if (!privateKeyBase64) {
+    throw new Error('YUCP_ROOT_PRIVATE_KEY is required to re-sign the grant JWT');
+  }
+
+  const payloadB64 = base64UrlEncode(
+    JSON.stringify({
+      ...decodeJwtPayload(jwt),
+      iss: issuer,
+    })
+  );
+  const signingInput = `${parts[0]}.${payloadB64}`;
+  const signature = await ed.signAsync(
+    new TextEncoder().encode(signingInput),
+    base64ToBytes(privateKeyBase64)
+  );
+  return `${signingInput}.${base64UrlEncode(signature)}`;
 }
 
 async function configurePinnedTestRoot(): Promise<void> {
@@ -1886,5 +1912,72 @@ describe('verification intents redemption issuer', () => {
     const payload = decodeJwtPayload(redemptionToken);
     expect(payload.iss).toBe(`${publicIssuerBaseUrl}/api/auth`);
     expect(payload.iss).not.toBe('https://rare-squid-409.convex.site/api/auth');
+  });
+
+  it('rejects a correctly signed verification grant with an unexpected issuer', async () => {
+    const t = makeTestConvex();
+    const authUserId = 'auth-redemption-wrong-grant-issuer';
+    const codeVerifier = 'code-verifier-wrong-grant-issuer';
+    const codeChallenge = await computeCodeChallenge(codeVerifier);
+
+    await seedSubject(t, {
+      authUserId,
+      primaryDiscordUserId: 'discord-redemption-wrong-grant-issuer',
+    });
+
+    const { intentId } = await t.mutation(api.verificationIntents.createVerificationIntent, {
+      apiSecret: API_SECRET,
+      authUserId,
+      packageId: 'pkg-redemption-wrong-grant-issuer',
+      packageName: 'Wrong Grant Issuer Test Package',
+      machineFingerprint: 'machine-redemption-wrong-grant-issuer',
+      codeChallenge,
+      returnUrl: 'http://127.0.0.1:51515/callback',
+      requirements: [
+        {
+          methodKey: 'vrchat-link',
+          providerKey: 'vrchat',
+          kind: 'buyer_provider_link',
+          title: 'Linked VRChat buyer account',
+        },
+      ],
+    });
+
+    await t.mutation(internal.verificationIntents.markIntentVerified, {
+      intentId,
+      methodKey: 'vrchat-link',
+    });
+
+    const intent = await t.action(api.verificationIntents.getVerificationIntent, {
+      apiSecret: API_SECRET,
+      authUserId,
+      intentId,
+    });
+    const grantToken = intent?.grantToken;
+    expect(grantToken).toBeTruthy();
+    if (!grantToken) {
+      throw new Error('Expected verification intent grant token');
+    }
+
+    const wrongIssuerGrantToken = await resignJwtWithIssuer(
+      grantToken,
+      'https://unexpected-issuer.example/api/auth'
+    );
+    expect(decodeJwtPayload(wrongIssuerGrantToken).iss).toBe(
+      'https://unexpected-issuer.example/api/auth'
+    );
+
+    const redemption = await t.action(api.verificationIntents.redeemVerificationIntent, {
+      apiSecret: API_SECRET,
+      authUserId,
+      intentId,
+      codeVerifier,
+      machineFingerprint: 'machine-redemption-wrong-grant-issuer',
+      grantToken: wrongIssuerGrantToken,
+      issuerBaseUrl: 'https://public-api.test.example',
+    });
+
+    expect(redemption.success).toBe(false);
+    expect(redemption.error).toBe('Verification grant is invalid or expired');
   });
 });

--- a/convex/verificationIntents.ts
+++ b/convex/verificationIntents.ts
@@ -40,6 +40,11 @@ const GRANT_EXPIRY_MS = 5 * 60 * 1000;
 const GRANT_AUDIENCE = 'yucp-verification-intent';
 const LICENSE_AUDIENCE = 'yucp-license-gate';
 
+function getVerificationGrantIssuer(): string {
+  const siteUrl = process.env.CONVEX_SITE_URL?.replace(/\/$/, '') ?? '';
+  return `${siteUrl}/api/auth`;
+}
+
 async function getPinnedSigningKey(configuredKeyId?: string | null): Promise<{
   keyId: string;
   privateKeyBase64: string;
@@ -333,7 +338,8 @@ async function signVerificationGrantJwt(
 }
 
 async function verifyVerificationGrantJwtAgainstPinnedRoots(
-  token: string
+  token: string,
+  expectedIssuer: string
 ): Promise<VerificationGrantClaims | null> {
   try {
     const parts = token.split('.');
@@ -362,6 +368,7 @@ async function verifyVerificationGrantJwtAgainstPinnedRoots(
     const payload = JSON.parse(
       new TextDecoder().decode(base64UrlDecodeToBytes(parts[1]))
     ) as VerificationGrantClaims;
+    if (payload.iss !== expectedIssuer) return null;
     if (payload.aud !== GRANT_AUDIENCE) return null;
     if (payload.exp <= Math.floor(Date.now() / 1000)) return null;
     return payload;
@@ -867,12 +874,11 @@ export const getVerificationIntent = action({
       !intent.verificationGrantUsedAt
     ) {
       const signingKey = await getPinnedSigningKey(process.env.YUCP_ROOT_KEY_ID ?? null);
-      const siteUrl = process.env.CONVEX_SITE_URL?.replace(/\/$/, '') ?? '';
       const nowSeconds = Math.floor(now / 1000);
       const expSeconds = Math.floor(intent.verificationGrantExpiresAt / 1000);
       grantToken = await signVerificationGrantJwt(
         {
-          iss: `${siteUrl}/api/auth`,
+          iss: getVerificationGrantIssuer(),
           aud: GRANT_AUDIENCE,
           sub: intent.authUserId,
           jti: intent.verificationGrantJti,
@@ -1458,7 +1464,10 @@ export const redeemVerificationIntent = action({
     }
 
     await getPinnedSigningKey(process.env.YUCP_ROOT_KEY_ID ?? null);
-    const grantClaims = await verifyVerificationGrantJwtAgainstPinnedRoots(args.grantToken);
+    const grantClaims = await verifyVerificationGrantJwtAgainstPinnedRoots(
+      args.grantToken,
+      getVerificationGrantIssuer()
+    );
     if (!grantClaims) {
       return { success: false, error: 'Verification grant is invalid or expired' };
     }


### PR DESCRIPTION
## Summary

- Reject verification grant JWTs when `iss` does not match the configured Convex auth issuer.
- Use the same issuer composition for grant minting and redemption verification.
- Add a realtest that re-signs an otherwise valid grant with the pinned Ed25519 root key and an unexpected issuer.

## Security context

The verification grant verifier already enforced the pinned-root signature, audience, expiry, and intent-bound claims, but it omitted an explicit issuer check. Enforcing `iss` is defense-in-depth, matches the verifier pattern in `convex/lib/yucpCrypto.ts:442`, and follows [RFC 8725](https://www.rfc-editor.org/rfc/rfc8725) guidance for explicit JWT issuer validation.

This omission was not independently exploitable because a grant still required a valid signature from a pinned root and matching redemption claims. The change closes verifier drift and ensures grants are accepted only from the intended issuer.

## Testing

- Added the wrong-issuer test first and confirmed it failed because redemption returned `success: true`.
- Confirmed the focused test passes after the fix.
- Confirmed all 19 `verificationIntents.realtest.ts` tests pass.
- `bun run typecheck`
- `bun run lint`
- `bun run test:external-integrations`
- `bun run test:ci`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened verification-grant validation by requiring tokens to come from the expected issuer.
  * Improved security when creating and redeeming verification intents.
  * Added coverage for rejecting correctly signed tokens with an unexpected issuer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->