### PR TITLE
feat: Phase 4 — desync product integration (upload/download/VPM)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -95,6 +95,7 @@ import type * as oauthDiscovery from "../oauthDiscovery.js";
 import type * as oauthLoopback from "../oauthLoopback.js";
 import type * as outbox_jobs from "../outbox_jobs.js";
 import type * as packageRegistry from "../packageRegistry.js";
+import type * as packageVersions from "../packageVersions.js";
 import type * as plugins_vrchat from "../plugins/vrchat.js";
 import type * as polyfills from "../polyfills.js";
 import type * as productResolution from "../productResolution.js";
@@ -228,6 +229,7 @@ declare const fullApi: ApiFromModules<{
   oauthLoopback: typeof oauthLoopback;
   outbox_jobs: typeof outbox_jobs;
   packageRegistry: typeof packageRegistry;
+  packageVersions: typeof packageVersions;
   "plugins/vrchat": typeof plugins_vrchat;
   polyfills: typeof polyfills;
   productResolution: typeof productResolution;

--- a/convex/packageVersions.realtest.ts
+++ b/convex/packageVersions.realtest.ts
@@ -1,0 +1,162 @@
+import { createApiActorBinding } from '@yucp/shared/apiActor';
+import { describe, expect, it } from 'vitest';
+import { api, internal } from './_generated/api';
+import { makeTestConvex } from './testHelpers';
+
+process.env.CONVEX_API_SECRET = 'test-secret';
+process.env.INTERNAL_SERVICE_AUTH_SECRET = 'test-internal-service-secret';
+
+async function createDownloadServiceActorBinding() {
+  const now = Date.now();
+  return await createApiActorBinding(
+    {
+      version: 1,
+      kind: 'service',
+      service: 'api-server',
+      scopes: ['downloads:service'],
+      issuedAt: now,
+      expiresAt: now + 60_000,
+    },
+    process.env.INTERNAL_SERVICE_AUTH_SECRET as string
+  );
+}
+
+describe('packageVersions', () => {
+  it('inserts a READY package version reference with the stable channel by default', async () => {
+    const t = makeTestConvex();
+    const createdAt = Date.now();
+
+    await t.mutation(internal.packageVersions.upsertReadyVersion, {
+      packageId: 'com.yucp.avatar-tools',
+      version: '1.0.0',
+      versionId: '00000000-0000-4000-8000-000000000001',
+      totalSize: 1_024,
+      contentType: 'application/zip',
+      createdAt,
+    });
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('package_versions_ref').collect());
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      packageId: 'com.yucp.avatar-tools',
+      version: '1.0.0',
+      versionId: '00000000-0000-4000-8000-000000000001',
+      channel: 'stable',
+      state: 'READY',
+      totalSize: 1_024,
+      contentType: 'application/zip',
+      createdAt,
+    });
+  });
+
+  it('supersedes the prior READY reference for the same package and channel', async () => {
+    const t = makeTestConvex();
+
+    await t.mutation(internal.packageVersions.upsertReadyVersion, {
+      packageId: 'com.yucp.avatar-tools',
+      version: '1.0.0',
+      versionId: '00000000-0000-4000-8000-000000000001',
+      channel: 'stable',
+      createdAt: 1_000,
+    });
+    await t.mutation(internal.packageVersions.upsertReadyVersion, {
+      packageId: 'com.yucp.avatar-tools',
+      version: '1.1.0',
+      versionId: '00000000-0000-4000-8000-000000000002',
+      channel: 'stable',
+      createdAt: 2_000,
+    });
+
+    const rows = await t.run(async (ctx) =>
+      await ctx.db
+        .query('package_versions_ref')
+        .withIndex('by_package_channel', (q) =>
+          q.eq('packageId', 'com.yucp.avatar-tools').eq('channel', 'stable')
+        )
+        .collect()
+    );
+
+    expect(rows).toHaveLength(2);
+    expect(rows.find((row) => row.version === '1.0.0')?.state).toBe('SUPERSEDED');
+    expect(rows.find((row) => row.version === '1.1.0')?.state).toBe('READY');
+  });
+
+  it('does not duplicate an at-least-once READY event for the same versionId', async () => {
+    const t = makeTestConvex();
+    const input = {
+      packageId: 'com.yucp.avatar-tools',
+      version: '1.0.0',
+      versionId: '00000000-0000-4000-8000-000000000001',
+      channel: 'beta',
+      createdAt: 1_000,
+    } as const;
+
+    const firstId = await t.mutation(internal.packageVersions.upsertReadyVersion, input);
+    const secondId = await t.mutation(internal.packageVersions.upsertReadyVersion, input);
+    const rows = await t.run(async (ctx) =>
+      await ctx.db
+        .query('package_versions_ref')
+        .withIndex('by_version_id', (q) => q.eq('versionId', input.versionId))
+        .collect()
+    );
+
+    expect(secondId).toBe(firstId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.state).toBe('READY');
+  });
+
+  it('resolves the latest READY reference by product or package and returns null when absent', async () => {
+    const t = makeTestConvex();
+    const catalogProductId = await t.run(async (ctx) => {
+      const now = Date.now();
+      return await ctx.db.insert('product_catalog', {
+        authUserId: 'creator-package-versions',
+        productId: 'avatar-tools-product',
+        provider: 'gumroad',
+        providerProductRef: 'gumroad-avatar-tools',
+        status: 'active',
+        supportsAutoDiscovery: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    await t.mutation(internal.packageVersions.upsertReadyVersion, {
+      packageId: 'com.yucp.avatar-tools',
+      version: '1.0.0',
+      versionId: '00000000-0000-4000-8000-000000000001',
+      catalogProductId,
+      createdAt: 1_000,
+    });
+    await t.mutation(internal.packageVersions.upsertReadyVersion, {
+      packageId: 'com.yucp.avatar-tools',
+      version: '1.1.0',
+      versionId: '00000000-0000-4000-8000-000000000002',
+      catalogProductId,
+      createdAt: 2_000,
+    });
+
+    const actor = await createDownloadServiceActorBinding();
+    const byProduct = await t.query(api.packageVersions.resolveDownloadableVersion, {
+      apiSecret: 'test-secret',
+      actor,
+      catalogProductId,
+    });
+    const byPackage = await t.query(api.packageVersions.resolveDownloadableVersion, {
+      apiSecret: 'test-secret',
+      actor,
+      packageId: 'com.yucp.avatar-tools',
+    });
+    const absent = await t.query(api.packageVersions.resolveDownloadableVersion, {
+      apiSecret: 'test-secret',
+      actor,
+      packageId: 'com.yucp.missing',
+    });
+
+    expect(byProduct?.versionId).toBe('00000000-0000-4000-8000-000000000002');
+    expect(byProduct?.state).toBe('READY');
+    expect(byPackage?.versionId).toBe('00000000-0000-4000-8000-000000000002');
+    expect(absent).toBeNull();
+  });
+});

--- a/convex/packageVersions.ts
+++ b/convex/packageVersions.ts
@@ -1,0 +1,99 @@
+import { v } from 'convex/values';
+import type { Doc, Id } from './_generated/dataModel';
+import { internalMutation, query } from './_generated/server';
+import { ApiActorBindingV, requireServiceActor } from './lib/apiActor';
+import { requireApiSecret } from './lib/apiAuth';
+
+const DEFAULT_CHANNEL = 'stable';
+
+export const upsertReadyVersion = internalMutation({
+  args: {
+    packageId: v.string(),
+    version: v.string(),
+    versionId: v.string(),
+    channel: v.optional(v.string()),
+    catalogProductId: v.optional(v.id('product_catalog')),
+    totalSize: v.optional(v.number()),
+    contentType: v.optional(v.string()),
+    createdAt: v.number(),
+  },
+  handler: async (ctx, args): Promise<Id<'package_versions_ref'>> => {
+    const existing = await ctx.db
+      .query('package_versions_ref')
+      .withIndex('by_version_id', (q) => q.eq('versionId', args.versionId))
+      .first();
+    if (existing) {
+      return existing._id;
+    }
+
+    const channel = args.channel ?? DEFAULT_CHANNEL;
+    const currentReadyVersions = await ctx.db
+      .query('package_versions_ref')
+      .withIndex('by_package_channel', (q) =>
+        q.eq('packageId', args.packageId).eq('channel', channel).eq('state', 'READY')
+      )
+      .collect();
+
+    for (const current of currentReadyVersions) {
+      await ctx.db.patch(current._id, { state: 'SUPERSEDED' });
+    }
+
+    return await ctx.db.insert('package_versions_ref', {
+      packageId: args.packageId,
+      version: args.version,
+      versionId: args.versionId,
+      channel,
+      state: 'READY',
+      catalogProductId: args.catalogProductId,
+      totalSize: args.totalSize,
+      contentType: args.contentType,
+      createdAt: args.createdAt,
+    });
+  },
+});
+
+export const resolveDownloadableVersion = query({
+  args: {
+    apiSecret: v.string(),
+    actor: ApiActorBindingV,
+    catalogProductId: v.optional(v.id('product_catalog')),
+    packageId: v.optional(v.string()),
+    channel: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<Doc<'package_versions_ref'> | null> => {
+    requireApiSecret(args.apiSecret);
+    await requireServiceActor(args.actor, ['downloads:service']);
+
+    const channel = args.channel ?? DEFAULT_CHANNEL;
+    if (args.catalogProductId) {
+      const candidates = await ctx.db
+        .query('package_versions_ref')
+        .withIndex('by_catalog_product', (q) =>
+          q.eq('catalogProductId', args.catalogProductId).eq('state', 'READY')
+        )
+        .collect();
+      return (
+        candidates
+          .filter(
+            (candidate) =>
+              candidate.channel === channel &&
+              (args.packageId === undefined || candidate.packageId === args.packageId)
+          )
+          .sort((left, right) => right.createdAt - left.createdAt)[0] ?? null
+      );
+    }
+
+    const packageId = args.packageId;
+    if (!packageId) {
+      return null;
+    }
+
+    return await ctx.db
+      .query('package_versions_ref')
+      .withIndex('by_package_channel', (q) =>
+        q.eq('packageId', packageId).eq('channel', channel).eq('state', 'READY')
+      )
+      .order('desc')
+      .first();
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2729,6 +2729,25 @@ const package_registry = defineTable({
   .index('by_publisher_id', ['publisherId']);
 
 /**
+ * Thin Convex pointer from a package release to the READY Postgres catalog version.
+ * Delivery manifests remain derived from versionId and are not duplicated here.
+ */
+const package_versions_ref = defineTable({
+  packageId: v.string(),
+  version: v.string(),
+  versionId: v.string(),
+  channel: v.optional(v.string()),
+  state: v.union(v.literal('READY'), v.literal('SUPERSEDED')),
+  catalogProductId: v.optional(v.id('product_catalog')),
+  totalSize: v.optional(v.number()),
+  contentType: v.optional(v.string()),
+  createdAt: v.number(),
+})
+  .index('by_package_channel', ['packageId', 'channel', 'state'])
+  .index('by_version_id', ['versionId'])
+  .index('by_catalog_product', ['catalogProductId', 'state']);
+
+/**
  * Signing Log, Layer 2 defense.
  * Append-only transparency log: content hash + identity, one entry per (hash, packageId) pair.
  * Same hash signed by a different identity triggers a conflict flag.
@@ -3010,6 +3029,7 @@ export default defineSchema({
   yucp_manifests,
   yucp_certificates,
   package_registry,
+  package_versions_ref,
   signing_log,
   cert_issuance_log,
   oauth_loopback_sessions,


### PR DESCRIPTION
## Summary

- Starts Phase 4 product integration with increment 4.3, the Convex data model that points products and packages at READY desync catalog versions.
- Adds the thin `package_versions_ref` pointer table without duplicating delivery manifests or Postgres byte truth.
- Adds idempotent READY upsert and authenticated downloadable-version resolution contracts.
- Adds Convex realtests for insertion, supersession, at-least-once replay, latest resolution, and missing results.
- Regenerates the Convex API module map.

## Stack

This PR is stacked on `feat/desync-chunk-storage`, the branch for #77. Retarget this PR to `main` after #77 merges.

## Planned increments

- [x] 4.3 Convex data model
- [ ] 4.1 Creator upload
- [ ] 4.4 READY to Convex bridge
- [ ] 4.2 Buyer download
- [ ] 4.5 VPM/VCC

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun x vitest run --config convex/vitest.config.ts convex/packageVersions.realtest.ts`
