### PR TITLE
Proactive whole-system test campaign

### DIFF
--- a/apps/api/src/lib/publicApiKeys.test.ts
+++ b/apps/api/src/lib/publicApiKeys.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import {
   generatePublicApiKeyValue,
   getPublicApiKeyPrefix,
+  isPublicApiKeyCandidate,
   PUBLIC_API_KEY_PREFIX,
 } from './publicApiKeys';
 
@@ -15,5 +16,17 @@ describe('publicApiKeys', () => {
   it('returns a short display prefix', () => {
     const key = `${PUBLIC_API_KEY_PREFIX}0123456789abcdef`;
     expect(getPublicApiKeyPrefix(key)).toBe(`${PUBLIC_API_KEY_PREFIX}01234567`);
+  });
+
+  it('accepts legacy and Better Auth opaque key suffixes for authoritative verification', () => {
+    expect(isPublicApiKeyCandidate(`${PUBLIC_API_KEY_PREFIX}${'a'.repeat(48)}`)).toBe(true);
+    expect(isPublicApiKeyCandidate(`${PUBLIC_API_KEY_PREFIX}${'Ab'.repeat(32)}`)).toBe(true);
+  });
+
+  it('rejects unbounded or malformed transport values', () => {
+    expect(isPublicApiKeyCandidate(`wrong_${'a'.repeat(64)}`)).toBe(false);
+    expect(isPublicApiKeyCandidate(`${PUBLIC_API_KEY_PREFIX}too-short`)).toBe(false);
+    expect(isPublicApiKeyCandidate(`${PUBLIC_API_KEY_PREFIX}${'a'.repeat(32)}!`)).toBe(false);
+    expect(isPublicApiKeyCandidate(`${PUBLIC_API_KEY_PREFIX}${'a'.repeat(257)}`)).toBe(false);
   });
 });

--- a/apps/api/src/lib/publicApiKeys.ts
+++ b/apps/api/src/lib/publicApiKeys.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from 'node:crypto';
 
 export const PUBLIC_API_KEY_PREFIX = 'ypsk_';
+const PUBLIC_API_KEY_SUFFIX_PATTERN = /^[A-Za-z0-9_-]{32,256}$/;
 
 export function generatePublicApiKeyValue(prefix = PUBLIC_API_KEY_PREFIX): string {
   return `${prefix}${randomBytes(24).toString('hex')}`;
@@ -8,4 +9,16 @@ export function generatePublicApiKeyValue(prefix = PUBLIC_API_KEY_PREFIX): strin
 
 export function getPublicApiKeyPrefix(apiKey: string): string {
   return apiKey.slice(0, Math.min(apiKey.length, PUBLIC_API_KEY_PREFIX.length + 8));
+}
+
+/**
+ * Performs only a bounded transport-shape check before the managed key store
+ * performs authoritative verification. The suffix is intentionally opaque so
+ * both legacy hex keys and the configured Better Auth generator remain valid.
+ */
+export function isPublicApiKeyCandidate(apiKey: string): boolean {
+  return (
+    apiKey.startsWith(PUBLIC_API_KEY_PREFIX) &&
+    PUBLIC_API_KEY_SUFFIX_PATTERN.test(apiKey.slice(PUBLIC_API_KEY_PREFIX.length))
+  );
 }

--- a/apps/api/src/routes/connect.guildChannels.test.ts
+++ b/apps/api/src/routes/connect.guildChannels.test.ts
@@ -34,11 +34,11 @@ const apiMock = {
     revokeOwnedCertificate: 'certificateBilling.revokeOwnedCertificate',
   },
   creatorProfiles: {
-    createCreatorProfile: 'creatorProfiles.createCreatorProfile',
     getCreatorByAuthUser: 'creatorProfiles.getCreatorByAuthUser',
     getCreatorProfile: 'creatorProfiles.getCreatorProfile',
   },
   guildLinks: {
+    completeCreatorOnboarding: 'guildLinks.completeCreatorOnboarding',
     getGuildLinkForUninstall: 'guildLinks.getGuildLinkForUninstall',
     upsertGuildLink: 'guildLinks.upsertGuildLink',
     getUserGuilds: 'guildLinks.getUserGuilds',
@@ -377,21 +377,19 @@ describe('GET /api/connect/ensure-tenant', () => {
         };
       }
 
-      if (fn === apiMock.creatorProfiles.getCreatorByAuthUser) {
-        expect(args).toEqual({
-          apiSecret: 'test-convex-secret',
-          authUserId: 'user-dashboard-001',
-        });
-        return {
-          authUserId: 'user-dashboard-001',
-        };
-      }
-
       throw new Error(`Unexpected query fn: ${String(fn)}`);
     };
 
     mutationImpl = async (fn, args) => {
       mutationCalls.push({ fn, args });
+      if (fn === apiMock.guildLinks.completeCreatorOnboarding) {
+        return {
+          completed: true,
+          conflict: false,
+          authUserId: 'user-dashboard-001',
+          isFirstTime: false,
+        };
+      }
       return null;
     };
 
@@ -428,16 +426,69 @@ describe('GET /api/connect/ensure-tenant', () => {
       authUserId: 'user-dashboard-001',
     });
     expect(mutationCalls).toContainEqual({
-      fn: apiMock.guildLinks.upsertGuildLink,
+      fn: apiMock.guildLinks.completeCreatorOnboarding,
       args: {
         apiSecret: 'test-convex-secret',
         authUserId: 'user-dashboard-001',
+        discordUserId: 'discord-user-001',
         discordGuildId: 'guild-dashboard-001',
-        installedByAuthUserId: 'user-dashboard-001',
-        botPresent: true,
-        status: 'active',
       },
     });
+  });
+});
+
+describe('POST /api/connect/complete', () => {
+  it('rejects a guild owned by another account before creating a profile', async () => {
+    const mutationCalls: Array<{ fn: unknown; args: unknown }> = [];
+    testStore.set('connect:foreign-owner-token', {
+      value: JSON.stringify({
+        discordUserId: 'discord-new-creator',
+        guildId: 'guild-already-owned',
+      }),
+    });
+    queryImpl = async (fn) => {
+      throw new Error(`Onboarding read crossed the atomic ownership guard: ${String(fn)}`);
+    };
+    mutationImpl = async (fn, args) => {
+      mutationCalls.push({ fn, args });
+      if (fn === apiMock.guildLinks.completeCreatorOnboarding) {
+        return { completed: false, conflict: true };
+      }
+      return null;
+    };
+    const fakeAuth = {
+      ...auth,
+      getSession: async () => ({ user: { id: 'new-creator' } }),
+      getDiscordUserId: async () => 'discord-new-creator',
+    } as unknown as Auth;
+    const isolatedRoutes = createConnectRoutes(fakeAuth, testConfig);
+
+    const response = await isolatedRoutes.completeSetup(
+      new Request('http://localhost:3001/api/connect/complete', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          cookie: 'yucp_connect_token=foreign-owner-token',
+        },
+        body: JSON.stringify({ guildId: 'guild-already-owned' }),
+      })
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: 'This server is already linked to another account.',
+    });
+    expect(mutationCalls).toEqual([
+      {
+        fn: apiMock.guildLinks.completeCreatorOnboarding,
+        args: {
+          apiSecret: 'test-convex-secret',
+          authUserId: 'new-creator',
+          discordUserId: 'discord-new-creator',
+          discordGuildId: 'guild-already-owned',
+        },
+      },
+    ]);
   });
 });
 

--- a/apps/api/src/routes/connect.ts
+++ b/apps/api/src/routes/connect.ts
@@ -363,45 +363,38 @@ export function createConnectRoutes(auth: Auth, config: ConnectConfig) {
         response: Response;
       }
   > {
-    const convex = getConvexClient();
-    const apiSecret = getConvexApiSecret();
-    const existingProfile = await convex.query(api.creatorProfiles.getCreatorByAuthUser, {
-      apiSecret,
-      authUserId: args.authUserId,
-    });
-
-    if (!existingProfile && !args.discordUserId) {
+    if (!args.discordUserId) {
       return {
         ok: false,
         response: buildMissingDiscordIdentityResponse(),
       };
     }
+    const convex = getConvexClient();
+    const apiSecret = getConvexApiSecret();
 
     try {
-      if (!existingProfile) {
-        await convex.mutation(api.creatorProfiles.createCreatorProfile, {
-          apiSecret,
-          name: `Creator ${args.discordUserId.slice(0, 8)}`,
-          ownerDiscordUserId: args.discordUserId,
-          authUserId: args.authUserId,
-          policy: {},
-        });
-      }
-
-      await convex.mutation(api.guildLinks.upsertGuildLink, {
+      const guildMeta = await fetchGuildMeta(args.guildId);
+      const completed = await convex.mutation(api.guildLinks.completeCreatorOnboarding, {
         apiSecret,
         authUserId: args.authUserId,
+        discordUserId: args.discordUserId,
         discordGuildId: args.guildId,
-        ...(await fetchGuildMeta(args.guildId)),
-        installedByAuthUserId: args.authUserId,
-        botPresent: true,
-        status: 'active',
+        ...guildMeta,
       });
+      if (!completed.completed && completed.conflict) {
+        return {
+          ok: false,
+          response: Response.json(
+            { error: 'This server is already linked to another account.' },
+            { status: 403 }
+          ),
+        };
+      }
 
       return {
         ok: true,
-        authUserId: args.authUserId,
-        isFirstTime: !existingProfile,
+        authUserId: completed.authUserId,
+        isFirstTime: completed.isFirstTime,
       };
     } catch (err) {
       logger.error(args.failureLogMessage, {
@@ -808,7 +801,7 @@ export function createConnectRoutes(auth: Auth, config: ConnectConfig) {
    * Returns { authUserId }, creating tenant + guild link if missing.
    */
   async function ensureTenant(request: Request): Promise<Response> {
-    // This GET endpoint performs state mutations (createCreatorProfile, upsertGuildLink).
+    // This GET endpoint atomically creates the creator profile and guild link when missing.
     // Reject cross-site requests to prevent CSRF exploitation.
     const allowedOrigins = new Set([
       new URL(config.apiBaseUrl).origin,

--- a/apps/api/src/routes/creatorUploads.test.ts
+++ b/apps/api/src/routes/creatorUploads.test.ts
@@ -100,10 +100,38 @@ describe('creator upload authorization', () => {
     );
 
     expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Package namespace owned by another creator',
+    });
     expect(convexQueryMock).toHaveBeenCalledWith(apiMock.packageRegistry.lookupRegistration, {
       apiSecret: config.convexApiSecret,
       actor: 'creator-actor-binding',
       packageId: 'com.yucp.avatar',
+    });
+  });
+
+  it('authorizes the first upload before the creator has registered the package', async () => {
+    convexQueryMock.mockImplementation(async (reference: unknown) => {
+      if (reference === apiMock.packageRegistry.lookupRegistration) {
+        return null;
+      }
+      if (reference === apiMock.certificateBilling.getAccountOverview) {
+        return activeVpmBilling;
+      }
+      throw new Error(`Unexpected query ${String(reference)}`);
+    });
+
+    const response = await createRoutes('creator-123').authorizeUpload(
+      authorizeRequest({ packageId: 'com.yucp.first-upload', version: '1.0.0' })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      tusEndpoint: 'https://ingest.example.test/files',
+      headers: {
+        'x-yucp-upload-package-id': 'com.yucp.first-upload',
+        'x-yucp-upload-version': '1.0.0',
+      },
     });
   });
 
@@ -131,7 +159,7 @@ describe('creator upload authorization', () => {
     expect(await response.json()).toEqual({ error: 'Creator uploads are not configured' });
   });
 
-  it('returns 403 when the owned package is archived', async () => {
+  it('returns 409 when the owned package is archived', async () => {
     convexQueryMock.mockResolvedValue({
       packageId: 'com.yucp.avatar',
       yucpUserId: 'creator-123',
@@ -142,7 +170,8 @@ describe('creator upload authorization', () => {
       authorizeRequest({ packageId: 'com.yucp.avatar', version: '1.0.0' })
     );
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: 'Package is archived' });
   });
 
   it('returns 403 when the package owner lacks the VPM repository capability', async () => {

--- a/apps/api/src/routes/creatorUploads.ts
+++ b/apps/api/src/routes/creatorUploads.ts
@@ -83,12 +83,14 @@ export function createCreatorUploadRoutes({ auth, config }: CreateCreatorUploadR
       actor,
       packageId,
     })) as { status: 'active' | 'archived'; yucpUserId: string } | null;
-    if (
-      !registration ||
-      registration.yucpUserId !== session.user.id ||
-      registration.status !== 'active'
-    ) {
-      return Response.json({ error: 'Active package ownership required' }, { status: 403 });
+    if (registration && registration.yucpUserId !== session.user.id) {
+      return Response.json(
+        { error: 'Package namespace owned by another creator' },
+        { status: 403 }
+      );
+    }
+    if (registration?.status === 'archived') {
+      return Response.json({ error: 'Package is archived' }, { status: 409 });
     }
     const billing = (await convex.query(api.certificateBilling.getAccountOverview, {
       apiSecret: config.convexApiSecret,

--- a/apps/api/src/routes/public.timing.test.ts
+++ b/apps/api/src/routes/public.timing.test.ts
@@ -17,7 +17,7 @@ mock.module('../../../../convex/_generated/api', () => ({
 const { createPublicRoutes } = await import('./public');
 
 describe('createPublicRoutes timing', () => {
-  const VALID_API_KEY = `ypsk_${'a'.repeat(48)}`;
+  const VALID_API_KEY = `ypsk_${'Ab'.repeat(32)}`;
   const config = {
     convexUrl: 'https://test.convex.cloud',
     convexApiSecret: 'test-secret',

--- a/apps/api/src/routes/public.ts
+++ b/apps/api/src/routes/public.ts
@@ -3,7 +3,7 @@ import type { Id } from '../../../../convex/_generated/dataModel';
 import { getConvexClientFromUrl } from '../lib/convex';
 import { logger } from '../lib/logger';
 import { verifyBetterAuthAccessToken } from '../lib/oauthAccessToken';
-import { PUBLIC_API_KEY_PREFIX } from '../lib/publicApiKeys';
+import { isPublicApiKeyCandidate, PUBLIC_API_KEY_PREFIX } from '../lib/publicApiKeys';
 import { buildTimedResponse, RouteTimingCollector } from '../lib/requestTiming';
 import { createPublicApiSupportError } from '../lib/verificationSupport';
 
@@ -11,7 +11,6 @@ const VERIFICATION_SCOPE = 'verification:read';
 const SUBJECTS_SCOPE = 'subjects:read';
 const MAX_PRODUCT_IDS_PER_CHECK = 50;
 const PUBLIC_API_KEY_PERMISSION_NAMESPACE = 'publicApi';
-const PUBLIC_API_KEY_PATTERN = /^ypsk_[0-9a-f]{48}$/;
 
 export interface PublicRouteConfig {
   convexUrl: string;
@@ -152,10 +151,6 @@ function extractApiKey(request: Request): string | null {
   const bearer = extractBearerToken(request);
   if (bearer?.startsWith(PUBLIC_API_KEY_PREFIX)) return bearer;
   return null;
-}
-
-function isPublicApiKeyCandidate(apiKey: string): boolean {
-  return PUBLIC_API_KEY_PATTERN.test(apiKey);
 }
 
 export function parseSubjectSelector(value: unknown): SubjectSelector | null {

--- a/apps/api/src/routes/publicV2/auth.test.ts
+++ b/apps/api/src/routes/publicV2/auth.test.ts
@@ -30,6 +30,7 @@ const { RouteTimingCollector } = await import('../../lib/requestTiming');
 // --- Shared fixtures ---
 
 const VALID_API_KEY = `ypsk_${'a'.repeat(48)}`;
+const BETTER_AUTH_ISSUED_API_KEY = `ypsk_${'Ab'.repeat(32)}`;
 
 const config = {
   apiBaseUrl: 'https://api.test',
@@ -110,6 +111,19 @@ describe('resolveAuth', () => {
   });
 
   describe('x-api-key header, Convex verification', () => {
+    it('passes the opaque key format emitted by Better Auth to managed-key verification', async () => {
+      mutationImpl = async () => validKeyResult(['subjects:read']);
+
+      const result = await resolveAuth(
+        makeRequest({ 'x-api-key': BETTER_AUTH_ISSUED_API_KEY }),
+        config,
+        ['subjects:read']
+      );
+
+      expect(result instanceof Response).toBe(false);
+      expect(mutationMock.mock.calls).toHaveLength(1);
+    });
+
     it('returns 401 when Convex returns null (key not found or expired)', async () => {
       mutationImpl = async () => null;
       const result = await resolveAuth(makeRequest({ 'x-api-key': VALID_API_KEY }), config, []);

--- a/apps/api/src/routes/publicV2/auth.ts
+++ b/apps/api/src/routes/publicV2/auth.ts
@@ -1,18 +1,14 @@
-import {
-  type ApiActorBinding,
-  PUBLIC_API_KEY_PERMISSION_NAMESPACE,
-  PUBLIC_API_KEY_PREFIX,
-} from '@yucp/shared';
+import { type ApiActorBinding, PUBLIC_API_KEY_PERMISSION_NAMESPACE } from '@yucp/shared';
 import { api } from '../../../../../convex/_generated/api';
 import { createAuthUserActorBinding } from '../../lib/apiActor';
 import { getConvexClientFromUrl } from '../../lib/convex';
 import { logger } from '../../lib/logger';
 import { verifyBetterAuthAccessToken } from '../../lib/oauthAccessToken';
+import { isPublicApiKeyCandidate } from '../../lib/publicApiKeys';
 import { buildTimedResponse, type RouteTimingCollector } from '../../lib/requestTiming';
 import { errorResponse, generateRequestId } from './helpers';
 import type { PublicV2Config } from './types';
 
-const PUBLIC_API_KEY_PATTERN = /^ypsk_[0-9a-f]{48}$/;
 export interface AuthResult {
   authUserId: string;
   actorBinding: ApiActorBinding;
@@ -58,11 +54,11 @@ export async function resolveAuth(
   let apiKey: string | null = null;
   let bearerToken: string | null = null;
 
-  if (apiKeyHeader && PUBLIC_API_KEY_PATTERN.test(apiKeyHeader)) {
+  if (apiKeyHeader && isPublicApiKeyCandidate(apiKeyHeader)) {
     apiKey = apiKeyHeader;
   } else if (authHeader?.startsWith('Bearer ')) {
     const tokenValue = authHeader.slice(7);
-    if (tokenValue.startsWith(PUBLIC_API_KEY_PREFIX) && PUBLIC_API_KEY_PATTERN.test(tokenValue)) {
+    if (isPublicApiKeyCandidate(tokenValue)) {
       apiKey = tokenValue;
     } else if (tokenValue.length > 0) {
       bearerToken = tokenValue;

--- a/apps/api/test/e2e/buyer-delivery-flow.e2e.test.ts
+++ b/apps/api/test/e2e/buyer-delivery-flow.e2e.test.ts
@@ -4,9 +4,9 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join, relative, resolve } from 'node:path';
+import { normalizeEmail, sha256Hex } from '@yucp/shared/crypto';
 import { unzipSync, zipSync } from 'fflate';
-import { api } from '../../../../convex/_generated/api';
-import type { Id } from '../../../../convex/_generated/dataModel';
+import { api, internal } from '../../../../convex/_generated/api';
 import {
   Catalog,
   type CatalogDatabase,
@@ -40,6 +40,7 @@ import { createS3Bucket, getS3Object } from '../../../../ops/storage-core/s3Cont
 import { waitForMinioReady } from '../../../../ops/testing/minioReadiness';
 import { waitForPostgres } from '../../../../ops/testing/postgresReadiness';
 import { createAuth } from '../../src/auth';
+import { createApiServiceActorBinding } from '../../src/lib/apiActor';
 import { createConnectUserProductAccessRoutes } from '../../src/routes/connectUserProductAccess';
 import { createVpmRoutes } from '../../src/routes/vpm';
 import {
@@ -59,7 +60,11 @@ const POSTGRES_IMAGE =
 const TEST_CONTAINER_LABEL = 'com.yucp.test=buyer-delivery-flow';
 const API_BASE_URL = 'http://127.0.0.1:3001';
 const PACKAGE_ID = 'club.yucp.buyer-flow';
-const PACKAGE_VERSION = '1.0.0';
+const FIRST_PACKAGE_VERSION = '1.0.0';
+const SECOND_PACKAGE_VERSION = '2.0.0';
+const OTHER_PACKAGE_ID = 'club.yucp.other-creator';
+const OTHER_PACKAGE_VERSION = '1.0.0';
+const PRODUCT_SLUG = 'buyer-flow-package';
 
 type FetchCounts = {
   chunkGets: number;
@@ -105,6 +110,10 @@ function deterministicBytes(seed: string, byteLength: number): Buffer {
 
 function sha256Bytes(bytes: Uint8Array): string {
   return createHash('sha256').update(bytes).digest('hex');
+}
+
+function uniqueName(prefix: string): string {
+  return `${prefix}-${Date.now().toString(36)}-${randomUUID()}`;
 }
 
 function assertScratchPath(path: string): void {
@@ -339,14 +348,23 @@ async function startDeliveryWorker(vars: Record<string, string>): Promise<Delive
   };
 }
 
-async function createCanonicalZipFixture(scratchPath: string): Promise<string> {
-  const sourcePath = join(scratchPath, 'source-package.zip');
-  const originalPackagePath = join(scratchPath, 'buyer-package.zip');
+async function createCanonicalZipFixture(
+  scratchPath: string,
+  input: {
+    fixtureName: string;
+    packageId: string;
+    payloadBytes: number;
+    seed: string;
+    version: string;
+  }
+): Promise<string> {
+  const sourcePath = join(scratchPath, `${input.fixtureName}-source.zip`);
+  const originalPackagePath = join(scratchPath, `${input.fixtureName}.zip`);
   const packageJson = Buffer.from(
     `${JSON.stringify(
       {
-        name: PACKAGE_ID,
-        version: PACKAGE_VERSION,
+        name: input.packageId,
+        version: input.version,
         displayName: 'Buyer Delivery Flow',
         description: 'Byte-exact full-chain delivery fixture',
       },
@@ -354,7 +372,7 @@ async function createCanonicalZipFixture(scratchPath: string): Promise<string> {
       2
     )}\n`
   );
-  const payload = deterministicBytes('buyer-delivery-flow-multi-chunk-payload', 2 * 1024 * 1024);
+  const payload = deterministicBytes(input.seed, input.payloadBytes);
   await writeFile(
     sourcePath,
     zipSync({
@@ -369,11 +387,34 @@ async function createCanonicalZipFixture(scratchPath: string): Promise<string> {
   return originalPackagePath;
 }
 
+async function publishReadyOutboxEvent(sql: CatalogDatabase, versionId: string): Promise<void> {
+  const readyEvents = await sql<ReadyOutboxRow[]>`
+    SELECT id, aggregate_id, event_type, payload, created_at
+    FROM catalog_outbox
+    WHERE aggregate_id = ${versionId} AND event_type = 'catalog.version.ready'
+  `;
+  const readyEvent = readyEvents[0];
+  if (!readyEvent) {
+    throw new Error(`READY promotion did not emit its catalog outbox event: ${versionId}`);
+  }
+  await createConvexCatalogPublish({
+    convexApiSecret: API_SECRET,
+    convexUrl: BACKEND_URL,
+    internalServiceAuthSecret: INTERNAL_SERVICE_AUTH_SECRET,
+  })({
+    id: readyEvent.id,
+    aggregateId: readyEvent.aggregate_id,
+    eventType: readyEvent.event_type,
+    payload: readyEvent.payload,
+    createdAt: readyEvent.created_at,
+  });
+}
+
 function mutateSignature(signature: string): string {
   return `${signature[0] === '0' ? '1' : '0'}${signature.slice(1)}`;
 }
 
-test('delivers the entitled buyer full byte-exact multi-chunk package through the VPM index', async () => {
+test('publishes first and repeat creator releases, materializes a purchase, and delivers by id and alias', async () => {
   await runCommand('docker', ['version', '--format', '{{.Server.Version}}']);
   await verifyDesyncCli();
   await removeLabeledContainers();
@@ -520,10 +561,35 @@ test('delivers the entitled buyer full byte-exact multi-chunk package through th
     ]);
 
     scratchPath = await mkdtemp(join(tmpdir(), 'yucp-buyer-delivery-flow-'));
-    const originalPackagePath = await createCanonicalZipFixture(scratchPath);
-    const originalBytes = new Uint8Array(await readFile(originalPackagePath));
-    const originalSha256 = sha256Bytes(originalBytes);
-    expect(originalBytes.byteLength).toBeGreaterThan(DESYNC_CHUNK_AVG_KIB * 1024);
+    const firstPackagePath = await createCanonicalZipFixture(scratchPath, {
+      fixtureName: 'buyer-package-v1',
+      packageId: PACKAGE_ID,
+      payloadBytes: 2 * 1024 * 1024,
+      seed: 'buyer-delivery-flow-first-release',
+      version: FIRST_PACKAGE_VERSION,
+    });
+    const secondPackagePath = await createCanonicalZipFixture(scratchPath, {
+      fixtureName: 'buyer-package-v2',
+      packageId: PACKAGE_ID,
+      payloadBytes: 2 * 1024 * 1024,
+      seed: 'buyer-delivery-flow-second-release',
+      version: SECOND_PACKAGE_VERSION,
+    });
+    const otherCreatorPackagePath = await createCanonicalZipFixture(scratchPath, {
+      fixtureName: 'other-creator-package-v1',
+      packageId: OTHER_PACKAGE_ID,
+      payloadBytes: 256 * 1024,
+      seed: 'buyer-delivery-flow-other-creator-release',
+      version: OTHER_PACKAGE_VERSION,
+    });
+    const firstPackageBytes = new Uint8Array(await readFile(firstPackagePath));
+    const secondPackageBytes = new Uint8Array(await readFile(secondPackagePath));
+    const otherCreatorPackageBytes = new Uint8Array(await readFile(otherCreatorPackagePath));
+    const firstPackageSha256 = sha256Bytes(firstPackageBytes);
+    const secondPackageSha256 = sha256Bytes(secondPackageBytes);
+    expect(firstPackageBytes.byteLength).toBeGreaterThan(DESYNC_CHUNK_AVG_KIB * 1024);
+    expect(secondPackageBytes.byteLength).toBeGreaterThan(DESYNC_CHUNK_AVG_KIB * 1024);
+    expect(secondPackageSha256).not.toBe(firstPackageSha256);
 
     const harness = getRealApiHarness();
     const creator = await createBetterAuthUser({ name: 'Buyer Flow Creator' });
@@ -531,99 +597,303 @@ test('delivers the entitled buyer full byte-exact multi-chunk package through th
       authUserId: creator.authUserId,
       name: 'Buyer Flow Creator',
     });
+    const otherCreator = await createBetterAuthUser({ name: 'Second Package Creator' });
+    await seedCreatorProfile({
+      authUserId: otherCreator.authUserId,
+      name: 'Second Package Creator',
+    });
+    const unauthorizedCreator = await createBetterAuthUser({ name: 'Namespace Challenger' });
     const buyer = await createBetterAuthUser({ name: 'Entitled Buyer' });
     const unentitledBuyer = await createBetterAuthUser({ name: 'Unentitled Buyer' });
     const buyerSubjectId = await seedSubject(buyer.authUserId);
     await seedSubject(unentitledBuyer.authUserId);
-    const catalogProductId = await seedProductCatalog({
-      authUserId: creator.authUserId,
-      productId: PACKAGE_ID,
-      provider: 'manual',
-      providerProductRef: PACKAGE_ID,
-      displayName: 'Buyer Delivery Flow',
+    expect(await harness.convex.collect('package_registry')).toHaveLength(0);
+    expect(await harness.convex.collect('package_versions_ref')).toHaveLength(0);
+
+    const firstRegistration = await harness.convex.mutation(
+      internal.packageRegistry.registerPackage,
+      {
+        packageId: PACKAGE_ID,
+        packageName: 'Buyer Delivery Flow',
+        publisherId: uniqueName('publisher-first'),
+        yucpUserId: creator.authUserId,
+      }
+    );
+    expect(firstRegistration).toEqual({ registered: true, conflict: false, archived: false });
+    const repeatedRegistration = await harness.convex.mutation(
+      internal.packageRegistry.registerPackage,
+      {
+        packageId: PACKAGE_ID,
+        packageName: 'Buyer Delivery Flow Updated',
+        publisherId: uniqueName('publisher-repeat'),
+        yucpUserId: creator.authUserId,
+      }
+    );
+    expect(repeatedRegistration).toEqual({ registered: true, conflict: false, archived: false });
+    const otherCreatorRegistration = await harness.convex.mutation(
+      internal.packageRegistry.registerPackage,
+      {
+        packageId: OTHER_PACKAGE_ID,
+        packageName: 'Other Creator Package',
+        publisherId: uniqueName('publisher-other'),
+        yucpUserId: otherCreator.authUserId,
+      }
+    );
+    expect(otherCreatorRegistration).toEqual({
+      registered: true,
+      conflict: false,
+      archived: false,
+    });
+    const unauthorizedRegistration = await harness.convex.mutation(
+      internal.packageRegistry.registerPackage,
+      {
+        packageId: PACKAGE_ID,
+        packageName: 'Namespace Challenger Package',
+        publisherId: uniqueName('publisher-unauthorized'),
+        yucpUserId: unauthorizedCreator.authUserId,
+      }
+    );
+    expect(unauthorizedRegistration).toEqual({
+      registered: false,
+      conflict: true,
+      archived: false,
     });
 
-    const uploading = await beginVersion({
+    const legacyPackageId = 'com.yucp.legacy-package';
+    const now = Date.now();
+    await harness.convex.insert('package_registry', {
+      packageId: legacyPackageId,
+      packageName: 'Legacy Package',
+      publisherId: uniqueName('publisher-legacy'),
+      yucpUserId: creator.authUserId,
+      registeredAt: now,
+      updatedAt: now,
+    });
+    const legacyRegistration = await harness.convex.query(api.packageRegistry.lookupRegistration, {
+      apiSecret: API_SECRET,
+      actor: await createApiServiceActorBinding({
+        service: 'api-server',
+        scopes: ['verification-intents:service'],
+      }),
+      packageId: legacyPackageId,
+    });
+    expect(legacyRegistration).toEqual({
+      packageId: legacyPackageId,
+      yucpUserId: creator.authUserId,
+      status: 'active',
+    });
+    const migratedLegacyRegistration = await harness.convex.mutation(
+      internal.packageRegistry.registerPackage,
+      {
+        packageId: legacyPackageId,
+        packageName: 'Legacy Package Updated',
+        publisherId: uniqueName('publisher-legacy-repeat'),
+        yucpUserId: creator.authUserId,
+      }
+    );
+    expect(migratedLegacyRegistration).toEqual({
+      registered: true,
+      conflict: false,
+      archived: false,
+    });
+
+    const providerProductRef = uniqueName('buyer-flow-store-product');
+    const catalogProductId = await seedProductCatalog({
+      authUserId: creator.authUserId,
+      canonicalSlug: PRODUCT_SLUG,
+      productId: PACKAGE_ID,
+      provider: 'gumroad',
+      providerProductRef,
+      displayName: 'Buyer Delivery Flow',
+    });
+    const otherCatalogProductId = await seedProductCatalog({
+      authUserId: otherCreator.authUserId,
+      canonicalSlug: 'other-creator-package',
+      productId: OTHER_PACKAGE_ID,
+      provider: 'gumroad',
+      providerProductRef: uniqueName('other-store-product'),
+      displayName: 'Other Creator Package',
+    });
+
+    const firstUploading = await beginVersion({
       catalog,
       catalogProductId: String(catalogProductId),
       packageId: PACKAGE_ID,
-      version: PACKAGE_VERSION,
+      version: FIRST_PACKAGE_VERSION,
     });
-    const assembled = await assembleVersion({
+    const firstAssembled = await assembleVersion({
       catalog,
-      inputPath: originalPackagePath,
+      inputPath: firstPackagePath,
       store: s3CasStore(casConfig),
-      versionId: uploading.id,
+      versionId: firstUploading.id,
     });
-    expect(assembled.state).toBe('ASSEMBLED');
-    expect(assembled.canonicalSha256).toBe(originalSha256);
-    const ready = await promoteVersion({
+    expect(firstAssembled.state).toBe('ASSEMBLED');
+    expect(firstAssembled.canonicalSha256).toBe(firstPackageSha256);
+    const firstReady = await promoteVersion({
       catalog,
       store: s3CasStore(casConfig),
-      versionId: assembled.id,
+      versionId: firstAssembled.id,
     });
-    expect(ready.state).toBe('READY');
+    expect(firstReady.state).toBe('READY');
+    await publishReadyOutboxEvent(sql, firstReady.id);
+
+    await delay(10);
+    const secondUploading = await beginVersion({
+      catalog,
+      catalogProductId: String(catalogProductId),
+      packageId: PACKAGE_ID,
+      version: SECOND_PACKAGE_VERSION,
+    });
+    const secondAssembled = await assembleVersion({
+      catalog,
+      inputPath: secondPackagePath,
+      store: s3CasStore(casConfig),
+      versionId: secondUploading.id,
+    });
+    expect(secondAssembled.state).toBe('ASSEMBLED');
+    expect(secondAssembled.canonicalSha256).toBe(secondPackageSha256);
+    const secondReady = await promoteVersion({
+      catalog,
+      store: s3CasStore(casConfig),
+      versionId: secondAssembled.id,
+    });
+    expect(secondReady.state).toBe('READY');
+    await publishReadyOutboxEvent(sql, secondReady.id);
+
+    await delay(10);
+    const otherUploading = await beginVersion({
+      catalog,
+      catalogProductId: String(otherCatalogProductId),
+      packageId: OTHER_PACKAGE_ID,
+      version: OTHER_PACKAGE_VERSION,
+    });
+    const otherAssembled = await assembleVersion({
+      catalog,
+      inputPath: otherCreatorPackagePath,
+      store: s3CasStore(casConfig),
+      versionId: otherUploading.id,
+    });
+    expect(otherAssembled.state).toBe('ASSEMBLED');
+    expect(otherAssembled.canonicalSha256).toBe(sha256Bytes(otherCreatorPackageBytes));
+    const otherReady = await promoteVersion({
+      catalog,
+      store: s3CasStore(casConfig),
+      versionId: otherAssembled.id,
+    });
+    expect(otherReady.state).toBe('READY');
+    await publishReadyOutboxEvent(sql, otherReady.id);
 
     const manifestResponse = await getS3Object(
       casConfig,
-      `${casConfig.indexPrefix}${deliveryManifestObjectId(ready.id)}`
+      `${casConfig.indexPrefix}${deliveryManifestObjectId(secondReady.id)}`
     );
     const deliveryManifest = parseDeliveryManifest(
       JSON.parse(await manifestResponse.text()) as unknown
     );
     expect(deliveryManifest.chunks.length).toBeGreaterThan(1);
-    expect(deliveryManifest.totalSize).toBe(originalBytes.byteLength);
+    expect(deliveryManifest.totalSize).toBe(secondPackageBytes.byteLength);
 
-    const readyEvents = await sql<ReadyOutboxRow[]>`
-        SELECT id, aggregate_id, event_type, payload, created_at
-        FROM catalog_outbox
-        WHERE aggregate_id = ${ready.id} AND event_type = 'catalog.version.ready'
-      `;
-    const readyEvent = readyEvents[0];
-    if (!readyEvent) {
-      throw new Error('READY promotion did not emit its catalog outbox event');
-    }
-    await createConvexCatalogPublish({
-      convexApiSecret: API_SECRET,
-      convexUrl: BACKEND_URL,
-      internalServiceAuthSecret: INTERNAL_SERVICE_AUTH_SECRET,
-    })({
-      id: readyEvent.id,
-      aggregateId: readyEvent.aggregate_id,
-      eventType: readyEvent.event_type,
-      payload: readyEvent.payload,
-      createdAt: readyEvent.created_at,
-    });
     const publishedVersions = await harness.convex.collect('package_versions_ref');
-    expect(publishedVersions).toContainEqual(
-      expect.objectContaining({
-        catalogProductId,
-        packageId: PACKAGE_ID,
-        version: PACKAGE_VERSION,
-        versionId: ready.id,
-        state: 'READY',
-        totalSize: originalBytes.byteLength,
-        contentType: 'application/zip',
-      })
+    expect(publishedVersions).toHaveLength(3);
+    expect(publishedVersions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          catalogProductId,
+          packageId: PACKAGE_ID,
+          version: FIRST_PACKAGE_VERSION,
+          versionId: firstReady.id,
+          state: 'SUPERSEDED',
+        }),
+        expect.objectContaining({
+          catalogProductId,
+          packageId: PACKAGE_ID,
+          version: SECOND_PACKAGE_VERSION,
+          versionId: secondReady.id,
+          state: 'READY',
+          totalSize: secondPackageBytes.byteLength,
+          contentType: 'application/zip',
+        }),
+        expect.objectContaining({
+          catalogProductId: otherCatalogProductId,
+          packageId: OTHER_PACKAGE_ID,
+          version: OTHER_PACKAGE_VERSION,
+          versionId: otherReady.id,
+          state: 'READY',
+        }),
+      ])
     );
 
-    const entitlement = await harness.convex.mutation<{
-      entitlementId: Id<'entitlements'>;
-      isNew: boolean;
-      success: boolean;
-    }>(api.entitlements.grantEntitlement, {
-      apiSecret: API_SECRET,
+    const buyerEmailHash = await sha256Hex(normalizeEmail(buyer.email));
+    const providerUserId = uniqueName('gumroad-buyer');
+    const externalAccountId = await harness.convex.insert('external_accounts', {
+      provider: 'gumroad',
+      providerUserId,
+      emailHash: buyerEmailHash,
+      status: 'active',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await harness.convex.insert('buyer_provider_links', {
+      subjectId: buyerSubjectId,
+      provider: 'gumroad',
+      externalAccountId,
+      status: 'active',
+      linkedAt: Date.now(),
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await harness.convex.insert('bindings', {
       authUserId: creator.authUserId,
       subjectId: buyerSubjectId,
-      productId: PACKAGE_ID,
-      catalogProductId,
-      evidence: {
-        provider: 'manual',
-        sourceReference: `buyer-flow:${ready.id}`,
-        purchasedAt: Date.now(),
-      },
+      externalAccountId,
+      bindingType: 'verification',
+      status: 'active',
+      version: 1,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
     });
-    expect(entitlement).toMatchObject({ success: true, isNew: true });
+    const externalOrderId = uniqueName('gumroad-order');
+    await harness.convex.insert('purchase_facts', {
+      authUserId: creator.authUserId,
+      provider: 'gumroad',
+      externalOrderId,
+      buyerEmailHash,
+      providerUserId,
+      providerProductId: providerProductRef,
+      paymentStatus: 'completed',
+      lifecycleStatus: 'active',
+      purchasedAt: Date.now(),
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    const materialized = await harness.convex.mutation(
+      internal.backgroundSync.projectBackfilledPurchasesForProduct,
+      {
+        authUserId: creator.authUserId,
+        productId: PACKAGE_ID,
+        provider: 'gumroad',
+        providerProductRef,
+      }
+    );
+    expect(materialized).toMatchObject({
+      purchaseFactsFound: 1,
+      linkedToSubject: 1,
+      entitlementsGranted: 1,
+      skippedInactive: 0,
+      unresolved: 0,
+    });
+    const entitlements = await harness.convex.collect('entitlements');
+    expect(entitlements).toEqual([
+      expect.objectContaining({
+        authUserId: creator.authUserId,
+        catalogProductId,
+        productId: PACKAGE_ID,
+        sourceProvider: 'gumroad',
+        sourceReference: `gumroad:${externalOrderId}`,
+        status: 'active',
+        subjectId: buyerSubjectId,
+      }),
+    ]);
 
     worker = await startDeliveryWorker({
       CAS_S3_ENDPOINT: minioEndpoint,
@@ -678,23 +948,51 @@ test('delivers the entitled buyer full byte-exact multi-chunk package through th
       origin: API_BASE_URL,
     });
 
-    const unentitledResponse = await connectRoutes.downloadBuyerProductAccess(
-      new Request(`${API_BASE_URL}/api/connect/user/product-access/${catalogProductId}/download`, {
-        headers: requestHeaders(unentitledSession),
-      }),
-      String(catalogProductId)
-    );
-    expect(unentitledResponse.status).toBe(403);
-    await unentitledResponse.arrayBuffer();
+    for (const productReference of [String(catalogProductId), PRODUCT_SLUG, providerProductRef]) {
+      const accessResponse = await connectRoutes.getBuyerProductAccess(
+        new Request(`${API_BASE_URL}/api/connect/user/product-access/${productReference}`, {
+          headers: requestHeaders(buyerSession),
+        }),
+        productReference
+      );
+      expect(accessResponse.status).toBe(200);
+      await expect(accessResponse.json()).resolves.toMatchObject({
+        product: {
+          catalogProductId: String(catalogProductId),
+          canonicalSlug: PRODUCT_SLUG,
+        },
+        accessState: {
+          hasActiveEntitlement: true,
+          requiresVerification: false,
+        },
+      });
 
-    const licenseOkResponse = await connectRoutes.downloadBuyerProductAccess(
-      new Request(`${API_BASE_URL}/api/connect/user/product-access/${catalogProductId}/download`, {
-        headers: requestHeaders(buyerSession),
-      }),
-      String(catalogProductId)
-    );
-    expect(licenseOkResponse.status).toBe(302);
-    expect(licenseOkResponse.headers.get('location')).toContain(`/d/${ready.id}?`);
+      const unentitledResponse = await connectRoutes.downloadBuyerProductAccess(
+        new Request(
+          `${API_BASE_URL}/api/connect/user/product-access/${productReference}/download`,
+          {
+            headers: requestHeaders(unentitledSession),
+          }
+        ),
+        productReference
+      );
+      expect(unentitledResponse.status).toBe(403);
+      await expect(unentitledResponse.json()).resolves.toEqual({
+        error: 'Active entitlement required',
+      });
+
+      const entitledResponse = await connectRoutes.downloadBuyerProductAccess(
+        new Request(
+          `${API_BASE_URL}/api/connect/user/product-access/${productReference}/download`,
+          {
+            headers: requestHeaders(buyerSession),
+          }
+        ),
+        productReference
+      );
+      expect(entitledResponse.status).toBe(302);
+      expect(entitledResponse.headers.get('location')).toContain(`/d/${secondReady.id}?`);
+    }
 
     const repoTokenResponse = await vpmRoutes.mintRepoToken(
       new Request(`${API_BASE_URL}/api/vpm/repo-token`, {
@@ -718,14 +1016,16 @@ test('delivers the entitled buyer full byte-exact multi-chunk package through th
     expect(indexResponse.status).toBe(200);
     const indexText = await indexResponse.text();
     const index = JSON.parse(indexText) as VpmIndex;
-    const packageVersion = index.packages[PACKAGE_ID]?.versions[PACKAGE_VERSION];
+    expect(index.packages[PACKAGE_ID]?.versions[FIRST_PACKAGE_VERSION]).toBeUndefined();
+    expect(index.packages[OTHER_PACKAGE_ID]).toBeUndefined();
+    const packageVersion = index.packages[PACKAGE_ID]?.versions[SECOND_PACKAGE_VERSION];
     expect(packageVersion).toBeDefined();
     if (!packageVersion) {
       throw new Error('VPM index did not list the READY package version');
     }
     const deliveryUrl = new URL(packageVersion.url);
     expect(deliveryUrl.origin).toBe(deliveryBaseUrl);
-    expect(deliveryUrl.pathname).toBe(`/d/${ready.id}`);
+    expect(deliveryUrl.pathname).toBe(`/d/${secondReady.id}`);
     expect(deliveryUrl.searchParams.get('exp')).toBeTruthy();
     expect(deliveryUrl.searchParams.get('sig')).toBeTruthy();
 
@@ -734,21 +1034,21 @@ test('delivers the entitled buyer full byte-exact multi-chunk package through th
     expect(downloadedResponse.status).toBe(200);
     expect(downloadedResponse.headers.get('content-type')).toBe('application/zip');
     expect(downloadedResponse.headers.get('content-length')).toBe(
-      originalBytes.byteLength.toString()
+      secondPackageBytes.byteLength.toString()
     );
     const downloadedBytes = new Uint8Array(await downloadedResponse.arrayBuffer());
     const originChunkFetches = await waitForOriginChunkFetches(counts, chunksBeforeDownload);
     const downloadedSha256 = sha256Bytes(downloadedBytes);
     expect(originChunkFetches).toBeGreaterThan(0);
-    expect(downloadedBytes.byteLength).toBe(originalBytes.byteLength);
-    expect(downloadedSha256).toBe(originalSha256);
-    expect(downloadedBytes).toEqual(originalBytes);
+    expect(downloadedBytes.byteLength).toBe(secondPackageBytes.byteLength);
+    expect(downloadedSha256).toBe(secondPackageSha256);
+    expect(downloadedBytes).toEqual(secondPackageBytes);
     expect(downloadedBytes.byteLength).toBeGreaterThan(Buffer.byteLength(indexText));
     expect(Buffer.from(downloadedBytes.subarray(0, 2)).toString('ascii')).toBe('PK');
     const downloadedZip = unzipSync(downloadedBytes);
     expect(downloadedZip['Runtime/payload.png']?.byteLength).toBe(2 * 1024 * 1024);
     expect(JSON.parse(Buffer.from(downloadedZip['package.json'] ?? []).toString('utf8'))).toEqual(
-      expect.objectContaining({ name: PACKAGE_ID, version: PACKAGE_VERSION })
+      expect.objectContaining({ name: PACKAGE_ID, version: SECOND_PACKAGE_VERSION })
     );
 
     const tamperedUrl = new URL(deliveryUrl);
@@ -761,7 +1061,7 @@ test('delivers the entitled buyer full byte-exact multi-chunk package through th
     const expiredSignature = await signDeliveryUrl({
       expiresAt: Date.now() - 60_000,
       key: deliveryHmacKey,
-      versionId: ready.id,
+      versionId: secondReady.id,
     });
     const expiredUrl = new URL(deliveryUrl);
     expiredUrl.searchParams.set('exp', expiredSignature.exp);
@@ -772,12 +1072,16 @@ test('delivers the entitled buyer full byte-exact multi-chunk package through th
     await expiredResponse.arrayBuffer();
 
     console.log('BUYER_DELIVERY_FLOW_E2E_RESULT');
-    console.log(`original-sha256=${originalSha256}`);
+    console.log(`first-release-sha256=${firstPackageSha256}`);
+    console.log(`second-release-sha256=${secondPackageSha256}`);
     console.log(`downloaded-sha256=${downloadedSha256}`);
-    console.log(`original-length=${originalBytes.byteLength}`);
+    console.log(`second-release-length=${secondPackageBytes.byteLength}`);
     console.log(`downloaded-length=${downloadedBytes.byteLength}`);
     console.log(`manifest-chunks=${deliveryManifest.chunks.length} multi-chunk=yes`);
-    console.log('unentitled=403');
+    console.log('canonical-id=302 slug=302 provider-ref=302 unentitled=403');
+    console.log('first-release=SUPERSEDED second-release=READY other-creator=READY');
+    console.log('namespace-conflict=denied purchase-materialization=active');
+    console.log('legacy-package=migrated-active');
     console.log('tampered-sig=403 expired-sig=403');
     console.log(`origin-chunk-fetches=${originChunkFetches}`);
   } finally {

--- a/apps/api/test/e2e/buyer-delivery-flow.e2e.test.ts
+++ b/apps/api/test/e2e/buyer-delivery-flow.e2e.test.ts
@@ -882,6 +882,22 @@ test('publishes first and repeat creator releases, materializes a purchase, and 
       skippedInactive: 0,
       unresolved: 0,
     });
+    const repeatedMaterialization = await harness.convex.mutation(
+      internal.backgroundSync.projectBackfilledPurchasesForProduct,
+      {
+        authUserId: creator.authUserId,
+        productId: PACKAGE_ID,
+        provider: 'gumroad',
+        providerProductRef,
+      }
+    );
+    expect(repeatedMaterialization).toMatchObject({
+      purchaseFactsFound: 1,
+      linkedToSubject: 0,
+      entitlementsGranted: 0,
+      skippedInactive: 0,
+      unresolved: 0,
+    });
     const entitlements = await harness.convex.collect('entitlements');
     expect(entitlements).toEqual([
       expect.objectContaining({
@@ -1080,7 +1096,7 @@ test('publishes first and repeat creator releases, materializes a purchase, and 
     console.log(`manifest-chunks=${deliveryManifest.chunks.length} multi-chunk=yes`);
     console.log('canonical-id=302 slug=302 provider-ref=302 unentitled=403');
     console.log('first-release=SUPERSEDED second-release=READY other-creator=READY');
-    console.log('namespace-conflict=denied purchase-materialization=active');
+    console.log('namespace-conflict=denied purchase-materialization=active-repeat-idempotent');
     console.log('legacy-package=migrated-active');
     console.log('tampered-sig=403 expired-sig=403');
     console.log(`origin-chunk-fetches=${originChunkFetches}`);

--- a/apps/api/test/e2e/creator-upload-authorize.e2e.test.ts
+++ b/apps/api/test/e2e/creator-upload-authorize.e2e.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, test } from 'bun:test';
+import { api, internal } from '../../../../convex/_generated/api';
+import { buildCreatorProfileWorkspaceKey } from '../../../../convex/lib/certificateBillingConfig';
+import { API_SECRET } from '../../../../ops/convex-real/config';
+import { verifyUploadCapability } from '../../../../ops/storage-core/uploadSigning';
+import {
+  createBetterAuthSession,
+  createBetterAuthUser,
+  E2E_INGEST_TUS_URL,
+  E2E_UPLOAD_HMAC_KEY,
+  getRealApiHarness,
+  installRealApiHarness,
+  seedCreatorProfile,
+} from './support/realApiHarness';
+
+installRealApiHarness();
+
+const VPM_REPO_PRODUCT_ID = 'prod_e2e_vpm_repo';
+const VPM_REPO_BENEFIT_ID = 'benefit_e2e_vpm_repo';
+
+async function createCreatorWithUploadCapability(name: string) {
+  const harness = getRealApiHarness();
+  const creator = await createBetterAuthUser({ name });
+  const creatorProfileId = await seedCreatorProfile({
+    authUserId: creator.authUserId,
+    name,
+  });
+  const workspaceKey = buildCreatorProfileWorkspaceKey(creatorProfileId);
+  const now = Date.now();
+
+  await harness.convex.insert('creator_billing_catalog_products', {
+    productId: VPM_REPO_PRODUCT_ID,
+    slug: 'e2e-vpm-repo',
+    displayName: 'E2E VPM Repository',
+    description: 'Real-backend upload authorization fixture',
+    status: 'active',
+    sortOrder: 1,
+    recurringInterval: 'month',
+    recurringPriceIds: ['price_e2e_vpm_repo_monthly'],
+    meteredPrices: [],
+    benefitIds: [VPM_REPO_BENEFIT_ID],
+    highlights: ['VPM repository uploads'],
+    metadata: { yucp_domain: 'certificate_billing' },
+    syncedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  });
+  await harness.convex.insert('creator_billing_catalog_benefits', {
+    benefitId: VPM_REPO_BENEFIT_ID,
+    type: 'feature_flag',
+    description: 'VPM repository capability',
+    metadata: { vpm_repo: true },
+    featureFlags: { vpm_repo: true },
+    capabilityKeys: ['vpm_repo'],
+    capabilityKey: 'vpm_repo',
+    deviceCap: 1,
+    auditRetentionDays: 30,
+    supportTier: 'standard',
+    tierRank: 1,
+    syncedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  });
+  await harness.convex.insert('creator_billing_entitlements', {
+    workspaceKey,
+    authUserId: creator.authUserId,
+    creatorProfileId,
+    planKey: 'e2e-vpm-repo',
+    productId: VPM_REPO_PRODUCT_ID,
+    status: 'active',
+    allowEnrollment: true,
+    allowSigning: true,
+    deviceCap: 1,
+    auditRetentionDays: 30,
+    supportTier: 'standard',
+    currentPeriodEnd: now + 86_400_000,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  const overview = await harness.convex.query<{
+    billing: { capabilities: Array<{ capabilityKey: string; status: string }> };
+  }>(api.certificateBilling.getAccountOverview, {
+    apiSecret: API_SECRET,
+    authUserId: creator.authUserId,
+  });
+  expect(overview.billing.capabilities).toContainEqual({
+    capabilityKey: 'vpm_repo',
+    status: 'active',
+  });
+
+  return {
+    ...creator,
+    sessionToken: await createBetterAuthSession(creator.authUserId),
+  };
+}
+
+async function authorizeUpload(input: {
+  packageId: string;
+  sessionToken: string;
+  version: string;
+}): Promise<Response> {
+  return await getRealApiHarness().app.fetch('/api/creator/uploads/authorize', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      cookie: `yucp.session_token=${input.sessionToken}`,
+      origin: 'http://127.0.0.1:3001',
+    },
+    body: JSON.stringify({ packageId: input.packageId, version: input.version }),
+  });
+}
+
+async function expectValidUploadAuthorization(
+  response: Response,
+  input: { packageId: string; version: string }
+): Promise<void> {
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as {
+    exp: string;
+    headers: Record<string, string>;
+    sig: string;
+    tusEndpoint: string;
+    versionId: string;
+  };
+  expect(body.versionId).toMatch(/^[0-9a-f-]{36}$/);
+  expect(body.tusEndpoint).toBe(`${E2E_INGEST_TUS_URL}/files`);
+  expect(body.headers).toEqual({
+    'x-yucp-upload-exp': body.exp,
+    'x-yucp-upload-package-id': input.packageId,
+    'x-yucp-upload-sig': body.sig,
+    'x-yucp-upload-version': input.version,
+    'x-yucp-upload-version-id': body.versionId,
+  });
+  expect(
+    await verifyUploadCapability(
+      {
+        exp: body.exp,
+        packageId: input.packageId,
+        sig: body.sig,
+        version: input.version,
+        versionId: body.versionId,
+      },
+      E2E_UPLOAD_HMAC_KEY
+    )
+  ).toBe(true);
+}
+
+describe('real creator upload authorization route', () => {
+  test('authorizes the first upload from an empty package registration state', async () => {
+    const harness = getRealApiHarness();
+    const creator = await createCreatorWithUploadCapability('First Upload Creator');
+    const packageId = 'com.yucp.e2e-first-upload';
+
+    expect(await harness.convex.collect('package_registry')).toHaveLength(0);
+
+    const response = await authorizeUpload({
+      packageId,
+      sessionToken: creator.sessionToken,
+      version: '1.0.0',
+    });
+
+    await expectValidUploadAuthorization(response, { packageId, version: '1.0.0' });
+    expect(await harness.convex.collect('package_registry')).toHaveLength(0);
+  });
+
+  test('rejects an upload when another creator owns the package namespace', async () => {
+    const harness = getRealApiHarness();
+    const creator = await createCreatorWithUploadCapability('Conflicting Upload Creator');
+    const owner = await createBetterAuthUser({ name: 'Existing Package Owner' });
+    const packageId = 'com.yucp.e2e-cross-owner';
+
+    await harness.convex.mutation(internal.packageRegistry.registerPackage, {
+      packageId,
+      packageName: 'Cross-owner package',
+      publisherId: 'publisher-existing-owner',
+      yucpUserId: owner.authUserId,
+    });
+
+    const response = await authorizeUpload({
+      packageId,
+      sessionToken: creator.sessionToken,
+      version: '1.0.0',
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Package namespace owned by another creator',
+    });
+  });
+
+  test('authorizes another upload when the creator owns the active registration', async () => {
+    const harness = getRealApiHarness();
+    const creator = await createCreatorWithUploadCapability('Repeat Upload Creator');
+    const packageId = 'com.yucp.e2e-repeat-upload';
+
+    await harness.convex.mutation(internal.packageRegistry.registerPackage, {
+      packageId,
+      packageName: 'Repeat upload package',
+      publisherId: 'publisher-repeat-owner',
+      yucpUserId: creator.authUserId,
+    });
+
+    const response = await authorizeUpload({
+      packageId,
+      sessionToken: creator.sessionToken,
+      version: '1.1.0',
+    });
+
+    await expectValidUploadAuthorization(response, { packageId, version: '1.1.0' });
+  });
+});

--- a/apps/api/test/e2e/support/realApiHarness.ts
+++ b/apps/api/test/e2e/support/realApiHarness.ts
@@ -13,6 +13,8 @@ import { type BuiltApiApp, buildApp } from '../../support/buildApp';
 
 export const E2E_ENCRYPTION_SECRET = `e2e-${crypto.randomUUID()}`;
 export const E2E_BETTER_AUTH_SECRET = 'test-better-auth-secret-32-chars!!';
+export const E2E_UPLOAD_HMAC_KEY = 'test-upload-hmac-secret-32-chars!!';
+export const E2E_INGEST_TUS_URL = 'https://ingest.e2e.invalid';
 
 type HarnessState = {
   app: BuiltApiApp;
@@ -220,6 +222,8 @@ export function installRealApiHarness(): void {
       betterAuthSecret: E2E_BETTER_AUTH_SECRET,
       internalServiceAuthSecret: INTERNAL_SERVICE_AUTH_SECRET,
       internalRpcSharedSecret: `e2e-rpc-${crypto.randomUUID()}`,
+      uploadHmacKey: E2E_UPLOAD_HMAC_KEY,
+      ingestTusUrl: E2E_INGEST_TUS_URL,
     });
     const server = Bun.serve({
       hostname: '0.0.0.0',

--- a/apps/api/test/e2e/support/realApiHarness.ts
+++ b/apps/api/test/e2e/support/realApiHarness.ts
@@ -406,6 +406,7 @@ export async function seedCreatorProfile(input: {
 
 export async function seedProductCatalog(input: {
   authUserId: string;
+  canonicalSlug?: string;
   productId: string;
   provider: string;
   providerProductRef: string;
@@ -414,6 +415,7 @@ export async function seedProductCatalog(input: {
   const now = Date.now();
   return await requireState().convex.insert('product_catalog', {
     authUserId: input.authUserId,
+    canonicalSlug: input.canonicalSlug,
     productId: input.productId,
     provider: input.provider,
     providerProductRef: input.providerProductRef,

--- a/apps/api/test/e2e/user-journeys.test.ts
+++ b/apps/api/test/e2e/user-journeys.test.ts
@@ -14,8 +14,10 @@ import { encrypt } from '../../src/lib/encrypt';
 import { getProviderRuntime, resolveWebhookPlugin } from '../../src/providers';
 import {
   apiJson,
+  apiKeyHeaders,
   createBetterAuthSession,
   createBetterAuthUser,
+  createPublicApiKey,
   E2E_ENCRYPTION_SECRET,
   getRealApiHarness,
   hashLicenseKey,
@@ -925,7 +927,331 @@ async function expectNoEntitlements(): Promise<void> {
   expect(await getRealApiHarness().convex.collect('entitlements')).toHaveLength(0);
 }
 
+function sessionHeaders(sessionToken: string, extra: HeadersInit = {}): Headers {
+  const headers = new Headers(extra);
+  const existingCookie = headers.get('cookie');
+  headers.set(
+    'cookie',
+    `yucp.session_token=${sessionToken}${existingCookie ? `; ${existingCookie}` : ''}`
+  );
+  headers.set('origin', 'http://127.0.0.1:3001');
+  return headers;
+}
+
+function cookiePair(response: Response): string {
+  const setCookie = response.headers.get('set-cookie');
+  if (!setCookie) {
+    throw new Error('Expected response to set a browser cookie');
+  }
+  return setCookie.split(';', 1)[0] ?? setCookie;
+}
+
+async function listPublicApiSurface(path: string, apiKey: string): Promise<unknown[]> {
+  const response = await getRealApiHarness().app.fetch(path, {
+    headers: apiKeyHeaders(apiKey),
+  });
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as {
+    data?: unknown[];
+    hasMore?: boolean;
+    nextCursor?: string | null;
+    object?: string;
+  };
+  expect(body.object).toBe('list');
+  expect(body.hasMore).toBe(false);
+  expect(body.nextCursor).toBeNull();
+  return body.data ?? [];
+}
+
 describe('real API user journeys against self-hosted Convex', () => {
+  test('creator onboarding starts empty, repeats safely, and rejects a different owner without partial state', async () => {
+    const harness = getRealApiHarness();
+    const creator = await createBetterAuthUser({ name: 'Empty State Creator' });
+    const otherCreator = await createBetterAuthUser({ name: 'Unauthorized Creator' });
+    const creatorSession = await createBetterAuthSession(creator.authUserId);
+    const otherSession = await createBetterAuthSession(otherCreator.authUserId);
+    const guildId = uniqueRef('guild_first_connect');
+    const discordUserId = uniqueRef('discord_first_connect');
+
+    expect(await harness.convex.collect('creator_profiles')).toHaveLength(0);
+    expect(await harness.convex.collect('guild_links')).toHaveLength(0);
+
+    const emptyShellResponse = await harness.app.fetch(
+      '/api/connect/dashboard/shell?includeHomeData=true',
+      { headers: sessionHeaders(creatorSession) }
+    );
+    expect(emptyShellResponse.status).toBe(200);
+    const emptyShell = (await emptyShellResponse.json()) as {
+      guilds?: unknown[];
+      home?: { userAccounts?: unknown[]; connectionStatusByProvider?: Record<string, boolean> };
+      viewer?: { authUserId?: string };
+    };
+    expect(emptyShell.viewer?.authUserId).toBe(creator.authUserId);
+    expect(emptyShell.guilds).toEqual([]);
+    expect(emptyShell.home?.userAccounts).toEqual([]);
+    expect(emptyShell.home?.connectionStatusByProvider).toEqual({});
+
+    async function createConnectBrowserCookie(input: {
+      discordUserId: string;
+      guildId: string;
+    }): Promise<string> {
+      const createTokenResponse = await harness.app.fetch('/api/connect/create-token', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ ...input, apiSecret: API_SECRET }),
+      });
+      expect(createTokenResponse.status).toBe(200);
+      const { token } = (await createTokenResponse.json()) as { token: string };
+      const bootstrapResponse = await harness.app.fetch('/api/connect/bootstrap', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ connectToken: token }),
+      });
+      expect(bootstrapResponse.status).toBe(200);
+      return cookiePair(bootstrapResponse);
+    }
+
+    async function completeConnect(input: {
+      browserCookie: string;
+      sessionToken: string;
+    }): Promise<Response> {
+      return await harness.app.fetch('/api/connect/complete', {
+        method: 'POST',
+        headers: sessionHeaders(input.sessionToken, {
+          'content-type': 'application/json',
+          cookie: input.browserCookie,
+        }),
+        body: JSON.stringify({ guildId }),
+      });
+    }
+
+    const firstResponse = await completeConnect({
+      browserCookie: await createConnectBrowserCookie({ discordUserId, guildId }),
+      sessionToken: creatorSession,
+    });
+    expect(firstResponse.status).toBe(200);
+    await expect(firstResponse.json()).resolves.toMatchObject({
+      success: true,
+      authUserId: creator.authUserId,
+      isFirstTime: true,
+    });
+
+    const repeatResponse = await completeConnect({
+      browserCookie: await createConnectBrowserCookie({ discordUserId, guildId }),
+      sessionToken: creatorSession,
+    });
+    expect(repeatResponse.status).toBe(200);
+    await expect(repeatResponse.json()).resolves.toMatchObject({
+      success: true,
+      authUserId: creator.authUserId,
+      isFirstTime: false,
+    });
+
+    const unauthorizedResponse = await completeConnect({
+      browserCookie: await createConnectBrowserCookie({
+        discordUserId: uniqueRef('discord_wrong_owner'),
+        guildId,
+      }),
+      sessionToken: otherSession,
+    });
+    expect(unauthorizedResponse.status).toBe(403);
+    await expect(unauthorizedResponse.json()).resolves.toEqual({
+      error: 'This server is already linked to another account.',
+    });
+
+    const profiles = await harness.convex.collect('creator_profiles');
+    expect(profiles).toHaveLength(1);
+    expect(profiles[0]).toMatchObject({
+      authUserId: creator.authUserId,
+      ownerDiscordUserId: discordUserId,
+      status: 'active',
+    });
+    const guildLinks = await harness.convex.collect('guild_links');
+    expect(guildLinks).toHaveLength(1);
+    expect(guildLinks[0]).toMatchObject({
+      authUserId: creator.authUserId,
+      discordGuildId: guildId,
+      status: 'active',
+    });
+  });
+
+  test('dashboard and account reads grow from empty to many and reconcile legacy identity records', async () => {
+    const harness = getRealApiHarness();
+    const creator = await createBetterAuthUser({ name: 'Read Surface Creator' });
+    const otherCreator = await createBetterAuthUser({ name: 'Read Surface Other Creator' });
+    await seedCreatorProfile({
+      authUserId: creator.authUserId,
+      name: 'Read Surface Creator',
+    });
+    await seedCreatorProfile({
+      authUserId: otherCreator.authUserId,
+      name: 'Read Surface Other Creator',
+    });
+    const session = await createBetterAuthSession(creator.authUserId);
+    const publicApiKey = await createPublicApiKey(creator.authUserId, PUBLIC_API_SCOPES);
+
+    const emptyConnectionsResponse = await harness.app.fetch('/api/connect/user/connections', {
+      headers: sessionHeaders(session),
+    });
+    expect(emptyConnectionsResponse.status).toBe(200);
+    await expect(emptyConnectionsResponse.json()).resolves.toEqual({ connections: [] });
+
+    const emptyAccountsResponse = await harness.app.fetch('/api/connect/user/accounts', {
+      headers: sessionHeaders(session),
+    });
+    expect(emptyAccountsResponse.status).toBe(200);
+    await expect(emptyAccountsResponse.json()).resolves.toEqual({ connections: [] });
+    expect(await listPublicApiSurface('/api/public/v2/products', publicApiKey)).toEqual([]);
+    expect(await listPublicApiSurface('/api/public/v2/subjects', publicApiKey)).toEqual([]);
+    expect(await listPublicApiSurface('/api/public/v2/entitlements', publicApiKey)).toEqual([]);
+
+    const subject = await seedSubject(creator.authUserId, {
+      discordUserId: uniqueRef('discord_read_surface'),
+    });
+    const firstProductId = uniqueRef('read_product_one');
+    const firstCatalogProductId = await seedProductCatalog({
+      authUserId: creator.authUserId,
+      productId: firstProductId,
+      provider: 'gumroad',
+      providerProductRef: uniqueRef('gumroad_read_one'),
+      displayName: 'Read Product One',
+    });
+    await harness.convex.mutation(api.entitlements.grantEntitlement, {
+      apiSecret: API_SECRET,
+      authUserId: creator.authUserId,
+      subjectId: subject,
+      productId: firstProductId,
+      catalogProductId: firstCatalogProductId,
+      evidence: {
+        provider: 'gumroad',
+        sourceReference: uniqueRef('read_entitlement_one'),
+        purchasedAt: Date.now(),
+      },
+    });
+    await seedProviderConnection({
+      authUserId: creator.authUserId,
+      provider: 'gumroad',
+      authMode: 'oauth',
+      webhookConfigured: true,
+    });
+
+    expect(await listPublicApiSurface('/api/public/v2/products', publicApiKey)).toHaveLength(1);
+    expect(await listPublicApiSurface('/api/public/v2/subjects', publicApiKey)).toHaveLength(1);
+    expect(await listPublicApiSurface('/api/public/v2/entitlements', publicApiKey)).toHaveLength(1);
+    const singleConnectionsResponse = await harness.app.fetch('/api/connect/user/connections', {
+      headers: sessionHeaders(session),
+    });
+    expect(singleConnectionsResponse.status).toBe(200);
+    const singleConnections = (await singleConnectionsResponse.json()) as {
+      connections: Array<{ provider: string }>;
+    };
+    expect(singleConnections.connections.map((connection) => connection.provider)).toEqual([
+      'gumroad',
+    ]);
+
+    const now = Date.now();
+    const legacyExternalAccountId = await harness.convex.insert('external_accounts', {
+      provider: 'itchio',
+      providerUserId: uniqueRef('legacy_itch_user'),
+      providerUsername: 'Legacy Itch Buyer',
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+    });
+    await harness.convex.insert('bindings', {
+      authUserId: creator.authUserId,
+      tenantId: 'legacy-tenant-id',
+      subjectId: subject,
+      externalAccountId: legacyExternalAccountId,
+      bindingType: 'verification',
+      status: 'active',
+      version: 1,
+      createdAt: now,
+      updatedAt: now,
+    });
+    expect(await harness.convex.collect('buyer_provider_links')).toHaveLength(0);
+
+    const refreshedAccountsResponse = await harness.app.fetch(
+      '/api/connect/user/accounts/refresh',
+      {
+        method: 'POST',
+        headers: sessionHeaders(session),
+      }
+    );
+    expect(refreshedAccountsResponse.status).toBe(200);
+    const refreshedAccounts = (await refreshedAccountsResponse.json()) as {
+      connections: Array<{ provider: string; providerUsername: string | null; status: string }>;
+    };
+    expect(refreshedAccounts.connections).toEqual([
+      expect.objectContaining({
+        provider: 'itchio',
+        providerUsername: 'Legacy Itch Buyer',
+        status: 'active',
+      }),
+    ]);
+    expect(await harness.convex.collect('buyer_provider_links')).toHaveLength(1);
+
+    const secondSubject = await seedSubject(creator.authUserId, {
+      discordUserId: uniqueRef('discord_read_surface_two'),
+    });
+    const secondProductId = uniqueRef('read_product_two');
+    const secondCatalogProductId = await seedProductCatalog({
+      authUserId: creator.authUserId,
+      productId: secondProductId,
+      provider: 'payhip',
+      providerProductRef: uniqueRef('payhip_read_two'),
+      displayName: 'Read Product Two',
+    });
+    await harness.convex.mutation(api.entitlements.grantEntitlement, {
+      apiSecret: API_SECRET,
+      authUserId: creator.authUserId,
+      subjectId: secondSubject,
+      productId: secondProductId,
+      catalogProductId: secondCatalogProductId,
+      evidence: {
+        provider: 'payhip',
+        sourceReference: uniqueRef('read_entitlement_two'),
+        purchasedAt: Date.now(),
+      },
+    });
+    await seedProviderConnection({
+      authUserId: creator.authUserId,
+      provider: 'payhip',
+      authMode: 'api_key',
+      webhookConfigured: false,
+    });
+    await seedProductCatalog({
+      authUserId: otherCreator.authUserId,
+      productId: uniqueRef('wrong_owner_product'),
+      provider: 'jinxxy',
+      providerProductRef: uniqueRef('wrong_owner_ref'),
+      displayName: 'Wrong Owner Product',
+    });
+    await seedSubject(otherCreator.authUserId, {
+      discordUserId: uniqueRef('discord_wrong_owner_read'),
+    });
+
+    const products = await listPublicApiSurface('/api/public/v2/products', publicApiKey);
+    const subjects = await listPublicApiSurface('/api/public/v2/subjects', publicApiKey);
+    const entitlements = await listPublicApiSurface('/api/public/v2/entitlements', publicApiKey);
+    expect(products).toHaveLength(2);
+    expect(subjects).toHaveLength(2);
+    expect(entitlements).toHaveLength(2);
+    expect(JSON.stringify(products)).not.toContain('Wrong Owner Product');
+
+    const manyConnectionsResponse = await harness.app.fetch('/api/connect/user/connections', {
+      headers: sessionHeaders(session),
+    });
+    expect(manyConnectionsResponse.status).toBe(200);
+    const manyConnections = (await manyConnectionsResponse.json()) as {
+      connections: Array<{ provider: string }>;
+    };
+    expect(manyConnections.connections.map((connection) => connection.provider).sort()).toEqual([
+      'gumroad',
+      'payhip',
+    ]);
+  });
+
   test('manual products stay reachable through hosted intent creation and session-backed redemption', async () => {
     const harness = getRealApiHarness();
     const creator = await createBetterAuthUser({ name: 'Hosted Manual Redemption Creator' });
@@ -1177,6 +1503,11 @@ describe('real API user journeys against self-hosted Convex', () => {
         expect([200, 202]).toContain(response.status);
         const processing = await processPendingWebhookEvents();
         expect(processing).toMatchObject({ failed: 0, processed: 1 });
+
+        const repeatedResponse = await postWebhookGrant(journey);
+        expect([200, 202]).toContain(repeatedResponse.status);
+        const repeatedProcessing = await processPendingWebhookEvents();
+        expect(repeatedProcessing).toMatchObject({ failed: 0, processed: 0 });
 
         await waitForActiveProviderEntitlement({
           catalogProductId: journey.catalogProductId,

--- a/apps/api/test/support/buildApp.ts
+++ b/apps/api/test/support/buildApp.ts
@@ -18,6 +18,8 @@ const MANAGED_ENV_KEYS = [
   'INTERNAL_SERVICE_TOKEN',
   'DELIVERY_HMAC_KEY',
   'DELIVERY_BASE_URL',
+  'UPLOAD_HMAC_KEY',
+  'INGEST_TUS_URL',
   'VPM_BASE_URL',
   'VRCHAT_PENDING_STATE_SECRET',
   'VRCHAT_PROVIDER_SESSION_SECRET',
@@ -63,6 +65,8 @@ export interface BuildAppConfig {
   internalRpcSharedSecret?: string;
   couplingServiceBaseUrl?: string;
   couplingServiceSharedSecret?: string;
+  uploadHmacKey?: string;
+  ingestTusUrl?: string;
   discordClientId?: string;
   discordClientSecret?: string;
   webhookBaseUrl?: string;
@@ -100,6 +104,8 @@ function buildEnv(config: BuildAppConfig): ManagedEnv {
     INTERNAL_SERVICE_TOKEN: undefined,
     DELIVERY_HMAC_KEY: undefined,
     DELIVERY_BASE_URL: undefined,
+    UPLOAD_HMAC_KEY: config.uploadHmacKey,
+    INGEST_TUS_URL: config.ingestTusUrl,
     VPM_BASE_URL: undefined,
     VRCHAT_PENDING_STATE_SECRET: 'test-vrchat-pending-state-secret',
     VRCHAT_PROVIDER_SESSION_SECRET: 'test-vrchat-provider-session-secret',

--- a/convex/guildLinks.realtest.ts
+++ b/convex/guildLinks.realtest.ts
@@ -55,6 +55,58 @@ describe('guild_links schema compatibility', () => {
     process.env.YUCP_ENABLE_AUTOMATIC_SETUP = previousAutomaticSetupFlag;
   });
 
+  it('atomically creates first onboarding state, repeats, and rejects a foreign guild owner', async () => {
+    const t = makeTestConvex();
+    const previousApiSecret = process.env.CONVEX_API_SECRET;
+    process.env.CONVEX_API_SECRET = API_SECRET;
+    try {
+      const first = await t.mutation(api.guildLinks.completeCreatorOnboarding, {
+        apiSecret: API_SECRET,
+        authUserId: 'auth-onboarding-owner',
+        discordUserId: 'discord-onboarding-owner',
+        discordGuildId: 'guild-onboarding-owned',
+      });
+      expect(first).toEqual({
+        completed: true,
+        conflict: false,
+        authUserId: 'auth-onboarding-owner',
+        isFirstTime: true,
+      });
+
+      const repeated = await t.mutation(api.guildLinks.completeCreatorOnboarding, {
+        apiSecret: API_SECRET,
+        authUserId: 'auth-onboarding-owner',
+        discordUserId: 'discord-onboarding-owner',
+        discordGuildId: 'guild-onboarding-owned',
+      });
+      expect(repeated).toEqual({
+        completed: true,
+        conflict: false,
+        authUserId: 'auth-onboarding-owner',
+        isFirstTime: false,
+      });
+
+      const conflict = await t.mutation(api.guildLinks.completeCreatorOnboarding, {
+        apiSecret: API_SECRET,
+        authUserId: 'auth-onboarding-challenger',
+        discordUserId: 'discord-onboarding-challenger',
+        discordGuildId: 'guild-onboarding-owned',
+      });
+      expect(conflict).toEqual({ completed: false, conflict: true });
+
+      const state = await t.run(async (ctx) => ({
+        guildLinks: await ctx.db.query('guild_links').collect(),
+        profiles: await ctx.db.query('creator_profiles').collect(),
+      }));
+      expect(state.guildLinks).toHaveLength(1);
+      expect(state.guildLinks[0]?.authUserId).toBe('auth-onboarding-owner');
+      expect(state.profiles).toHaveLength(1);
+      expect(state.profiles[0]?.authUserId).toBe('auth-onboarding-owner');
+    } finally {
+      process.env.CONVEX_API_SECRET = previousApiSecret;
+    }
+  });
+
   it('accepts legacy verifyPromptMessage metadata on guild links', async () => {
     const t = makeTestConvex();
     const now = Date.now();

--- a/convex/guildLinks.ts
+++ b/convex/guildLinks.ts
@@ -6,7 +6,8 @@
  */
 
 import { ConvexError, v } from 'convex/values';
-import { mutation, query } from './_generated/server';
+import type { Id } from './_generated/dataModel';
+import { type MutationCtx, mutation, query } from './_generated/server';
 import { requireApiSecret } from './lib/apiAuth';
 
 const GuildLinkStatus = v.union(
@@ -25,6 +26,59 @@ const VerifyPromptMessage = v.object({
   imageUrl: v.optional(v.string()),
   updatedAt: v.number(),
 });
+
+type GuildLinkWrite = {
+  authUserId: string;
+  botPresent: boolean;
+  commandScopeState?: { registered: boolean; registeredAt?: number };
+  discordGuildIcon?: string;
+  discordGuildId: string;
+  discordGuildName?: string;
+  installedByAuthUserId: string;
+  status: 'active' | 'uninstalled' | 'suspended';
+};
+
+async function upsertGuildLinkRecord(
+  ctx: MutationCtx,
+  args: GuildLinkWrite,
+  now: number
+): Promise<Id<'guild_links'>> {
+  const existing = await ctx.db
+    .query('guild_links')
+    .withIndex('by_discord_guild', (q) => q.eq('discordGuildId', args.discordGuildId))
+    .first();
+
+  if (existing) {
+    if (existing.authUserId && existing.authUserId !== args.authUserId) {
+      throw new ConvexError('Unauthorized: guild link owned by different user');
+    }
+    const patch: Record<string, unknown> = {
+      authUserId: args.authUserId,
+      installedByAuthUserId: args.installedByAuthUserId,
+      botPresent: args.botPresent,
+      status: args.status,
+      commandScopeState: args.commandScopeState,
+      updatedAt: now,
+    };
+    if (args.discordGuildName !== undefined) patch.discordGuildName = args.discordGuildName;
+    if (args.discordGuildIcon !== undefined) patch.discordGuildIcon = args.discordGuildIcon;
+    await ctx.db.patch(existing._id, patch);
+    return existing._id;
+  }
+
+  return await ctx.db.insert('guild_links', {
+    authUserId: args.authUserId,
+    discordGuildId: args.discordGuildId,
+    discordGuildName: args.discordGuildName,
+    discordGuildIcon: args.discordGuildIcon,
+    installedByAuthUserId: args.installedByAuthUserId,
+    botPresent: args.botPresent,
+    status: args.status,
+    commandScopeState: args.commandScopeState,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
 
 /**
  * Upsert a guild link. Called by API after bot install callback.
@@ -49,42 +103,82 @@ export const upsertGuildLink = mutation({
   handler: async (ctx, args) => {
     requireApiSecret(args.apiSecret);
     const now = Date.now();
+    return await upsertGuildLinkRecord(ctx, args, now);
+  },
+});
 
-    const existing = await ctx.db
+/**
+ * Atomically creates the first creator profile and links the Discord guild.
+ * A foreign guild owner is reported before either record can be written.
+ */
+export const completeCreatorOnboarding = mutation({
+  args: {
+    apiSecret: v.string(),
+    authUserId: v.string(),
+    discordUserId: v.string(),
+    discordGuildId: v.string(),
+    discordGuildName: v.optional(v.string()),
+    discordGuildIcon: v.optional(v.string()),
+  },
+  returns: v.union(
+    v.object({
+      completed: v.literal(true),
+      conflict: v.literal(false),
+      authUserId: v.string(),
+      isFirstTime: v.boolean(),
+    }),
+    v.object({
+      completed: v.literal(false),
+      conflict: v.literal(true),
+    })
+  ),
+  handler: async (ctx, args) => {
+    requireApiSecret(args.apiSecret);
+    const existingGuildLink = await ctx.db
       .query('guild_links')
       .withIndex('by_discord_guild', (q) => q.eq('discordGuildId', args.discordGuildId))
       .first();
-
-    if (existing) {
-      const patch: Record<string, unknown> = {
-        authUserId: args.authUserId,
-        installedByAuthUserId: args.installedByAuthUserId,
-        botPresent: args.botPresent,
-        status: args.status,
-        commandScopeState: args.commandScopeState,
-        updatedAt: now,
-      };
-      if (existing.authUserId && existing.authUserId !== args.authUserId) {
-        throw new ConvexError('Unauthorized: guild link owned by different user');
-      }
-      if (args.discordGuildName !== undefined) patch.discordGuildName = args.discordGuildName;
-      if (args.discordGuildIcon !== undefined) patch.discordGuildIcon = args.discordGuildIcon;
-      await ctx.db.patch(existing._id, patch);
-      return existing._id;
+    if (existingGuildLink?.authUserId && existingGuildLink.authUserId !== args.authUserId) {
+      return { completed: false as const, conflict: true as const };
     }
 
-    return await ctx.db.insert('guild_links', {
+    const existingProfile = await ctx.db
+      .query('creator_profiles')
+      .withIndex('by_auth_user', (q) => q.eq('authUserId', args.authUserId))
+      .first();
+    const now = Date.now();
+    if (!existingProfile) {
+      await ctx.db.insert('creator_profiles', {
+        authUserId: args.authUserId,
+        name: `Creator ${args.discordUserId.slice(0, 8)}`,
+        ownerDiscordUserId: args.discordUserId,
+        status: 'active',
+        policy: {},
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    await upsertGuildLinkRecord(
+      ctx,
+      {
+        authUserId: args.authUserId,
+        discordGuildId: args.discordGuildId,
+        discordGuildName: args.discordGuildName,
+        discordGuildIcon: args.discordGuildIcon,
+        installedByAuthUserId: args.authUserId,
+        botPresent: true,
+        status: 'active',
+      },
+      now
+    );
+
+    return {
+      completed: true as const,
+      conflict: false as const,
       authUserId: args.authUserId,
-      discordGuildId: args.discordGuildId,
-      discordGuildName: args.discordGuildName,
-      discordGuildIcon: args.discordGuildIcon,
-      installedByAuthUserId: args.installedByAuthUserId,
-      botPresent: args.botPresent,
-      status: args.status,
-      commandScopeState: args.commandScopeState,
-      createdAt: now,
-      updatedAt: now,
-    });
+      isFirstTime: !existingProfile,
+    };
   },
 });
 

--- a/ops/production-regression-loop.ts
+++ b/ops/production-regression-loop.ts
@@ -62,11 +62,14 @@ export const PRODUCTION_REGRESSION_SURFACES: ProductionRegressionSurface[] = [
     id: 'identity',
     label: 'Identity and ownership boundaries',
     invariant:
-      'Buyer and creator identities must stay explicit at every helper, route, and persistence boundary so one actor can never materialize or mutate another actor’s state. Public API-key verification must authenticate only managed public-api records whose stored Better Auth owner matches the metadata auth user, so key metadata can never impersonate another tenant.',
+      'Buyer and creator identities must stay explicit at every helper, route, and persistence boundary so one actor can never materialize or mutate another actor’s state. Creator onboarding must reject a guild already owned by another account before creating a profile or writing any partial setup state. Public API-key verification must accept the opaque key format emitted by the configured issuer and authenticate only managed public-api records whose stored Better Auth owner matches the metadata auth user, so key metadata can never impersonate another tenant.',
     primaryRegressionHomes: [
       'apps/api/src/lib/subjectIdentity.test.ts',
       'apps/api/src/routes/providerPlatform.test.ts',
+      'apps/api/src/routes/connect.guildChannels.test.ts',
+      'apps/api/src/routes/publicV2/auth.test.ts',
       'convex/identitySync.realtest.ts',
+      'convex/guildLinks.realtest.ts',
       'convex/betterAuthApiKeys.realtest.ts',
     ],
     secondaryRegressionHomes: [
@@ -75,6 +78,7 @@ export const PRODUCTION_REGRESSION_SURFACES: ProductionRegressionSurface[] = [
       'convex/licenseVerification.realtest.ts',
     ],
     remediationHomes: [
+      'convex/guildLinks.realtest.ts',
       'ops/subject-ownership-remediation.test.ts',
       'ops/buyer-attribution-remediation.test.ts',
     ],
@@ -153,6 +157,7 @@ export const EXTERNAL_INTEGRATION_GATE_STEPS: ExternalIntegrationGateStep[] = [
       '--config',
       'convex/vitest.config.ts',
       './convex/identitySync.realtest.ts',
+      './convex/guildLinks.realtest.ts',
       './convex/attestation.realtest.ts',
       './convex/betterAuthApiKeys.realtest.ts',
     ],
@@ -203,6 +208,13 @@ export const EXTERNAL_INTEGRATION_GATE_STEPS: ExternalIntegrationGateStep[] = [
     covers: ['verification'],
   },
   {
+    id: 'api-onboarding-ownership',
+    description: 'API onboarding ownership and atomicity regressions',
+    cwdRelativeToRepoRoot: 'apps/api',
+    args: ['test', './src/routes/connect.guildChannels.test.ts'],
+    covers: ['identity', 'account'],
+  },
+  {
     id: 'api-identity-verification-and-backfill',
     description:
       'API identity, verification, route-scoping, and backfill regressions for production incidents',
@@ -213,6 +225,7 @@ export const EXTERNAL_INTEGRATION_GATE_STEPS: ExternalIntegrationGateStep[] = [
       './src/lib/subjectIdentity.test.ts',
       './src/routes/connect.user-verify.manual-license.test.ts',
       './src/routes/providerPlatform.test.ts',
+      './src/routes/public.timing.test.ts',
       './src/routes/connectUserVerification.readSurface.test.ts',
       './src/routes/connect.user-verify.behavior.test.ts',
       './src/routes/backfill.test.ts',


### PR DESCRIPTION
﻿## Whole-system coverage

- Creator upload authorization through the actual `/api/creator/uploads/authorize` HTTP route against self-hosted Convex: an authenticated creator with active `vpm_repo` capability succeeds from an empty package registry, a foreign-owned namespace returns 403, and an owned active namespace succeeds.
- Creator onboarding and identity from a truly empty Convex backend: empty dashboard shell, token bootstrap, first connect, repeat connect, foreign-guild rejection, and no partial profile or link writes.
- Package lifecycle from zero: empty registry and version pointers, first registration, repeat registration, first release, second release, a different creator and package, namespace conflict rejection, and an older package record with no status migrated through repeat registration.
- Version state machine: real PostgreSQL catalog creation, upload, assembly, CAS storage, promotion, READY publication into Convex, first-version supersession, creator isolation, and adjacent illegal/readiness state coverage.
- Buyer purchase and delivery: real purchase fact, buyer identity binding, first and replay-idempotent entitlement materialization, canonical product id lookup, slug lookup, provider reference lookup, no-entitlement denial, VPM index filtering, signed delivery, byte-exact multi-chunk reconstruction, signature tampering, and expiry.
- Provider verification: generic provider registry/runtime coverage, Gumroad/Jinxxy/Lemon Squeezy backfill projection, Gumroad/Jinxxy/Lemon Squeezy/Payhip webhook projection, repeat webhook idempotency, manual hosted redemption, negative paths, and entitlement isolation.
- Dashboard and account reads: empty, single, and many products, subjects, entitlements, provider connections, wrong-owner isolation, and reconciliation of a legacy tenant-shaped identity binding.
- Production regression loop now includes the onboarding atomicity and issued-key-format invariants and runs onboarding in an isolated process to prevent cross-file module-mock leakage.

## Defects found and fixed

1. Foreign-guild onboarding returned 500 and could create a creator profile before ownership rejection. Root cause: profile creation and guild ownership enforcement were separate Convex mutations. Fix: one atomic `completeCreatorOnboarding` mutation checks ownership before creating or updating either record and returns a stable 403 conflict to the API.
2. Better Auth issued 64-character opaque public API key suffixes, but both public API routes admitted only 48-character lowercase hexadecimal suffixes. Root cause: route-local regexes disagreed with the configured key issuer. Fix: a shared bounded opaque-key candidate check accepts current and legacy formats, while managed Convex verification remains authoritative.

3. A creator's first upload returned 403 before the package namespace could be registered by signing. Root cause: the upload authorization route required an existing active registration even though signing is the sole registration writer. Fix: missing registration now proceeds to the unchanged billing capability check, while a foreign owner still returns 403 and an owned archived package returns 409.

## Verification

- `bun test apps/api/src/routes/creatorUploads.test.ts`: 10 passed, 0 failed.
- `bun test --timeout 60000 --max-concurrency 1 apps/api/test/e2e/creator-upload-authorize.e2e.test.ts`: 3 passed, 0 failed, 17 assertions against the real HTTP route and self-hosted Convex.
- `bun run test:e2e:flows`: 14 passed, 5 credential-gated skipped, 0 failed, 186 assertions.
- `bun run test:flow:e2e`: 1 passed, 0 failed, 70 assertions against Convex, PostgreSQL, MinIO, CAS, desync, and the delivery worker.
- `bun run test:catalog:integration`: 12 passed, 0 failed, 67 assertions.
- `bun run test:pipeline:promote:e2e`: 1 passed, 0 failed, 17 assertions.
- `bun run test:storage:e2e`: all invoked suites passed, including CAS local/S3, catalog, ingest, TUS, delivery, importer, promotion, GC, and scheduler.
- `bun run lint`: exit 0.
- `bun run typecheck`: exit 0.
- `bun run test:external-integrations`: exit 0.
- `bun run test:ci`: exit 0.
- `bun run test:all`: exit 0.

## Explicit limitations

- Live Gumroad and Jinxxy credential tests remained skipped because `E2E_GUMROAD_*` and `E2E_JINXXY_*` were not configured. Generic provider contracts, seeded real-backend projection, and webhook flows ran locally.
- No browser-rendered dashboard restructuring was performed. Dashboard/account API read surfaces and existing web consumer regressions were exercised.
- No dependency versions or lockfiles changed. `bun audit` was intentionally not run per task scope.
