### PR TITLE
Remove network flakiness from the convex auth endpoint test

### DIFF
--- a/apps/web/test/unit/convex-auth-endpoints.test.ts
+++ b/apps/web/test/unit/convex-auth-endpoints.test.ts
@@ -16,7 +16,7 @@ const offlineConvexFetch = vi.fn(async (input: RequestInfo | URL) => {
     return Response.json({ status: 'success', value: null });
   }
 
-  throw new Error(`Unexpected outbound request in Convex auth unit test: ${url.href}`);
+  throw new Error(`Unexpected outbound request in Convex auth unit test: ${url.origin}`);
 });
 
 async function createTestAuth() {
@@ -44,6 +44,16 @@ afterEach(() => {
 });
 
 describe('Convex Better Auth endpoints', () => {
+  it('redacts sensitive URL components when rejecting unexpected outbound requests', async () => {
+    await expect(
+      offlineConvexFetch(
+        'https://test-user:test-password@unexpected.example/private?token=test-token#account'
+      )
+    ).rejects.toMatchObject({
+      message: 'Unexpected outbound request in Convex auth unit test: https://unexpected.example',
+    });
+  });
+
   it('does not emit the deprecated oidc-provider warning on session requests', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {

--- a/apps/web/test/unit/convex-auth-endpoints.test.ts
+++ b/apps/web/test/unit/convex-auth-endpoints.test.ts
@@ -1,6 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAuth } from '../../../../convex/auth';
 
 const ORIGINAL_ENV = { ...process.env };
+const TEST_CONVEX_SITE_HOST = 'example.convex.site';
+const TEST_CONVEX_DEPLOYMENT_HOST = 'example.convex.cloud';
+
+const offlineConvexFetch = vi.fn(async (input: RequestInfo | URL) => {
+  const url = new URL(input instanceof Request ? input.url : input);
+
+  if (url.hostname === TEST_CONVEX_SITE_HOST) {
+    return Response.json(null);
+  }
+
+  if (url.hostname === TEST_CONVEX_DEPLOYMENT_HOST) {
+    return Response.json({ status: 'success', value: null });
+  }
+
+  throw new Error(`Unexpected outbound request in Convex auth unit test: ${url.href}`);
+});
 
 async function createTestAuth() {
   process.env.BETTER_AUTH_SECRET = 'test-secret-123456789012345678901234';
@@ -11,18 +28,19 @@ async function createTestAuth() {
   delete process.env.DISCORD_CLIENT_ID;
   delete process.env.DISCORD_CLIENT_SECRET;
 
-  vi.resetModules();
-  const { createAuth } = await import('../../../../convex/auth');
   return createAuth({} as never);
 }
 
 beforeEach(() => {
   process.env = { ...ORIGINAL_ENV };
+  offlineConvexFetch.mockClear();
+  vi.spyOn(globalThis, 'fetch').mockImplementation(offlineConvexFetch);
+  vi.spyOn(window, 'fetch').mockImplementation(offlineConvexFetch);
 });
 
 afterEach(() => {
   process.env = { ...ORIGINAL_ENV };
-  vi.resetModules();
+  vi.restoreAllMocks();
 });
 
 describe('Convex Better Auth endpoints', () => {


### PR DESCRIPTION
## Summary

- intercept Convex test fetches on both `globalThis` and Happy DOM
- return deterministic responses only for the expected `example.convex.site` and `example.convex.cloud` hosts
- fail closed on any unexpected outbound host
- hoist the auth module import so its approximately 3.1s construction/import cost is outside each 15s test timeout

## Root cause

The test made a real outbound request to a bogus `example.convex.*` host while approximately 3.1s of auth module construction/import work ran inside a test with a 15s timeout. Under parallel suite load, network variance plus repeated setup could exhaust that timeout.

## Verification

Before, the auth construction/import path consumed approximately 3.1s inside the per-test timeout and the real network request had unbounded variance.

After:

- five isolated runs passed 3/3 tests in 4.07s, 4.01s, 3.95s, 4.06s, and 4.04s overall
- isolated test-body time was 38ms to 45ms
- two complete `@yucp/web` suites passed 636/636 tests in 50.11s and 31.27s
- `@yucp/web` typecheck exited 0
- Biome reported the touched file clean
- assertion count remains unchanged at 6, with no skip, only, or todo markers

A preliminary full-suite attempt hit an SSR safety import timeout in an untouched test. That exact contract passed in isolation in 7.85s, followed by the two consecutive fully green suite runs above.

Stacked on #81.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved authentication endpoint test reliability using deterministic offline responses for specific Convex hostnames.
  * Added assertions to fail tests when requests are made to unexpected outbound hosts.
  * Simplified authentication test helper usage and updated test setup/cleanup to restore environment variables and mocks consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->